### PR TITLE
Fix explanation in stock trading metadata

### DIFF
--- a/problems/best-time-to-buy-and-sell-stock/metadata.json
+++ b/problems/best-time-to-buy-and-sell-stock/metadata.json
@@ -8,7 +8,7 @@
     {
       "input": "prices = [7,1,5,3,6,4]",
       "output": 5,
-      "explanation": "Buy on day 2 (price = 1) and sell on day 5 (price = 6), profit = 6-1 = 5. Note that buying on day 1 and selling on day 2 is not allowed because you must buy before you sell."
+      "explanation": "Buy on day 2 (price = 1) and sell on day 5 (price = 6), profit = 6-1 = 5. Note that buying on day 2 and selling on day 1 is not allowed because you must buy before you sell."
     },
     {
       "input": "prices = [7,6,4,3,1]",


### PR DESCRIPTION
"Buying on day 1 and selling on day 2" is a correct case. The description has it as invalid.