### PR TITLE
fix: Export progress on desktop and support revealing saved file

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,7 +30,7 @@
     let loadModalCard: HTMLElement | null = null;
     let loadCodeInputs: HTMLInputElement[] = [];
     let pendingImport: Record<string, unknown> | null = null;
-    let importNotice: { message: string; error: boolean } | null = null;
+    let importNotice: { message: string; error: boolean; filePath?: string } | null = null;
     let importNoticeTimer: ReturnType<typeof setTimeout> | undefined;
     let showFirebaseSettings = false;
     let showLoadCode = false;
@@ -379,7 +379,7 @@
         }
     }
 
-    function exportLocalStorage() {
+    async function exportLocalStorage() {
         if (!browser) return;
         const data: Record<string, unknown> = {};
         for (let i = 0; i < localStorage.length; i++) {
@@ -387,6 +387,28 @@
             if (!key) continue;
             data[key] = parseMaybe(localStorage.getItem(key));
         }
+
+        if (isDesktopMode) {
+            try {
+                const response = await fetch('/api/export', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify({ data })
+                });
+                const result = await response.json();
+                if (result.success) {
+                    showImportNotice(`Exported to ${result.filePath}`, false, result.filePath);
+                } else {
+                    showImportNotice(result.error || 'Failed to export progress', true);
+                }
+            } catch (error: any) {
+                showImportNotice(error.message || 'Failed to export progress', true);
+            }
+            return;
+        }
+
         const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
@@ -657,13 +679,28 @@
         void goto(`/p/${encodeURIComponent(code)}`);
     }
 
-    function showImportNotice(message: string, error: boolean) {
-        importNotice = { message, error };
+    function showImportNotice(message: string, error: boolean, filePath?: string) {
+        importNotice = { message, error, filePath };
         if (importNoticeTimer) clearTimeout(importNoticeTimer);
         importNoticeTimer = setTimeout(() => {
             importNotice = null;
             importNoticeTimer = undefined;
-        }, 4000);
+        }, filePath ? 6000 : 4000);
+    }
+
+    async function revealFile(filePath: string | undefined) {
+        if (!filePath) return;
+        try {
+            await fetch('/api/reveal-file', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ filePath })
+            });
+        } catch (error) {
+            console.error('Failed to reveal file:', error);
+        }
     }
 
     function trapModalFocus(event: KeyboardEvent, modal: HTMLElement) {
@@ -1004,7 +1041,12 @@
     {/if}
     {#if importNotice}
         <div class:error={importNotice.error} class="import-toast" role={importNotice.error ? 'alert' : 'status'}>
-            {importNotice.message}
+            <span>{importNotice.message}</span>
+            {#if importNotice.filePath}
+                <button class="reveal-btn" onclick={() => revealFile(importNotice?.filePath)}>
+                    Show in Folder
+                </button>
+            {/if}
         </div>
     {/if}
     <nav class="tabs" aria-label="Course">
@@ -1650,6 +1692,26 @@
         border-radius: 0.625rem;
         background: var(--color-surface);
         box-shadow: 0 12px 36px rgba(0, 0, 0, 0.22);
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+    }
+    .import-toast .reveal-btn {
+        background: none;
+        border: none;
+        color: var(--color-highlight);
+        font-weight: 500;
+        cursor: pointer;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.8rem;
+        border-radius: 4px;
+        white-space: nowrap;
+        text-decoration: underline;
+    }
+    .import-toast .reveal-btn:hover {
+        background: rgba(255, 255, 255, 0.08);
+        text-decoration: none;
     }
     .import-toast.error {
         border-left-color: var(--color-hard);

--- a/src/routes/api/export/+server.ts
+++ b/src/routes/api/export/+server.ts
@@ -1,0 +1,34 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+export const POST: RequestHandler = async ({ request }) => {
+    try {
+        const { data } = await request.json();
+        if (!data) {
+            return json({ error: 'Missing data' }, { status: 400 });
+        }
+
+        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const filename = `cojudge-localStorage-backup-${ts}.json`;
+
+        const homeDir = os.homedir();
+        let targetDir = path.join(homeDir, 'Downloads');
+
+        try {
+            await fs.access(targetDir);
+        } catch {
+            targetDir = homeDir;
+        }
+
+        const filePath = path.join(targetDir, filename);
+        await fs.writeFile(filePath, JSON.stringify(data, null, 2), 'utf8');
+
+        return json({ success: true, filePath });
+    } catch (error: any) {
+        console.error('Failed to export progress on desktop:', error);
+        return json({ error: error.message || 'Failed to export progress' }, { status: 500 });
+    }
+};

--- a/src/routes/api/reveal-file/+server.ts
+++ b/src/routes/api/reveal-file/+server.ts
@@ -1,0 +1,29 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { exec } from 'node:child_process';
+import path from 'node:path';
+import os from 'node:os';
+
+export const POST: RequestHandler = async ({ request }) => {
+    try {
+        const { filePath } = await request.json();
+        if (!filePath) {
+            return json({ error: 'Missing filePath' }, { status: 400 });
+        }
+
+        const platform = os.platform();
+        if (platform === 'win32') {
+            exec(`explorer.exe /select,"${filePath}"`);
+        } else if (platform === 'darwin') {
+            exec(`open -R "${filePath}"`);
+        } else {
+            const dirPath = path.dirname(filePath);
+            exec(`xdg-open "${dirPath}"`);
+        }
+
+        return json({ success: true });
+    } catch (error: any) {
+        console.error('Failed to reveal file:', error);
+        return json({ error: error.message || 'Failed to reveal file' }, { status: 500 });
+    }
+};


### PR DESCRIPTION
This PR fixes 'Export progress' on desktop by adding dedicated endpoints in SvelteKit's Node.js backend to save local storage data directly into the user's Downloads/Home folder, and opens Finder/Explorer/Linux file manager to reveal the exported backup file. Clicking 'Export progress' in desktop mode now displays a toast notification with a 'Show in Folder' button.