### PR TITLE
feat: Add WYSIWYG markdown editing with image paste and inline code

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -62,10 +62,209 @@ test('playground markdown preview has a WYSIWYG editing mode', async ({ page }) 
   await expect(editable.locator('h1')).toHaveText('Hello');
 
   // Triple-click selects the paragraph, then bold it via the toolbar
-  await editable.locator('p').click({ clickCount: 3 });
+  await editable.locator('p').first().click({ clickCount: 3 });
   await page.getByRole('button', { name: 'Bold', exact: true }).click();
   await expect.poll(() => getMarkdownContent(page)).toContain('**some text**');
 
   await page.getByRole('button', { name: 'Done editing' }).click();
   await expect(preview.locator('strong')).toHaveText('some text');
+});
+
+async function writeImageToClipboard(page: Page, width = 800, height = 600) {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+  await page.evaluate(async ({ width, height }) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext('2d')!;
+    context.fillStyle = '#6965db';
+    context.fillRect(0, 0, width, height);
+    const image = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((blob) => blob ? resolve(blob) : reject(new Error('PNG creation failed')), 'image/png');
+    });
+    await navigator.clipboard.write([new ClipboardItem({ 'image/png': image })]);
+  }, { width, height });
+}
+
+async function pasteImageIntoEditor(page: Page, width = 800, height = 600) {
+  await writeImageToClipboard(page, width, height);
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.press('ControlOrMeta+v');
+  await expect.poll(() => getMarkdownContent(page)).toMatch(/^!\[image\]\(data:image\/png;base64,/);
+}
+
+test('pasted images render as thumbnails with lightbox and delete in the preview', async ({ page }) => {
+  await openMarkdownPlayground(page);
+  await pasteImageIntoEditor(page);
+
+  await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  const preview = page.locator('.markdown-preview:not(.wysiwyg-editing)');
+  const thumbnail = preview.locator('.md-thumb');
+  await expect(thumbnail).toBeVisible();
+  await expect(thumbnail.locator('.md-thumb-delete')).toBeAttached();
+
+  // The thumbnail is constrained, not the original 800x600 size
+  const thumbBox = await thumbnail.locator('img').boundingBox();
+  expect(thumbBox).not.toBeNull();
+  expect(thumbBox!.width).toBeLessThanOrEqual(240);
+  expect(thumbBox!.height).toBeLessThanOrEqual(160);
+
+  // Clicking the thumbnail opens a full-screen lightbox
+  await thumbnail.locator('img').click();
+  const lightbox = page.locator('.image-lightbox');
+  await expect(lightbox).toBeVisible();
+  const lightboxBox = await lightbox.locator('img').boundingBox();
+  expect(lightboxBox!.height).toBeGreaterThan(thumbBox!.height);
+
+  // Esc closes the lightbox
+  await page.keyboard.press('Escape');
+  await expect(lightbox).not.toBeAttached();
+
+  // Re-open, then close via the cross icon
+  await thumbnail.locator('img').click();
+  await expect(lightbox).toBeVisible();
+  await lightbox.locator('.lightbox-close').click();
+  await expect(lightbox).not.toBeAttached();
+
+  // The trash icon removes the image from the source markdown
+  await thumbnail.locator('.md-thumb-delete').click();
+  await expect.poll(() => getMarkdownContent(page)).not.toContain('![image](');
+  await expect(preview.locator('.md-thumb')).toHaveCount(0);
+});
+
+test('WYSIWYG keeps an empty line at the end so typing continues after a pasted image', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('hello');
+  await expect.poll(() => getMarkdownContent(page)).toBe('hello');
+
+  await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+
+  // The editor always ends with an empty line
+  await expect(editable.locator('> p:last-child')).toHaveText('');
+
+  // Paste an image at the end of the last line
+  await writeImageToClipboard(page);
+  await editable.locator('p').first().click();
+  await page.keyboard.press('End');
+  await page.keyboard.press('ControlOrMeta+v');
+
+  const thumbnail = editable.locator('.md-thumb');
+  await expect(thumbnail).toBeVisible();
+  // An empty line is kept after the thumbnail so the caret is not trapped
+  await expect(editable.locator('> p:last-child')).toHaveText('');
+
+  // Move past the image and keep typing. Images pasted in WYSIWYG mode have no
+  // alt text, so they round-trip as ![](...), not ![image](...).
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.type('more text');
+  await expect.poll(() => getMarkdownContent(page)).toMatch(/!\[\]\(data:image\/png;base64,[^)]*\)\n\nmore text/);
+
+  // Round-tripping through edit mode must not accumulate blank lines: leaving
+  // and re-entering WYSIWYG rebuilds the document from the stored markdown, so
+  // typing on the trailing empty line adds exactly one blank line plus the
+  // typed line, never more
+  const stable = await getMarkdownContent(page);
+  await page.getByRole('button', { name: 'Done editing' }).click();
+  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
+  await editable.locator('p').last().click();
+  await page.keyboard.type('x');
+  await page.getByRole('button', { name: 'Done editing' }).click();
+  await expect.poll(() => getMarkdownContent(page)).toBe(`${stable}\n\nx`);
+});
+
+test('WYSIWYG toolbar wraps the selection in inline code', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('hello world');
+  await expect.poll(() => getMarkdownContent(page)).toBe('hello world');
+
+  await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+
+  // Select all the text, then apply inline code from the toolbar
+  await editable.locator('p').first().click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.getByRole('button', { name: 'Inline code' }).click();
+
+  await expect(editable.locator('code')).toHaveText('hello world');
+  await expect.poll(() => getMarkdownContent(page)).toContain('`hello world`');
+
+  await page.getByRole('button', { name: 'Done editing' }).click();
+  const preview = page.locator('.markdown-preview:not(.wysiwyg-editing)');
+  await expect(preview.locator('code')).toHaveText('hello world');
+});
+
+test('WYSIWYG auto-matches backticks into inline code and undo cancels it', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('hello');
+  await expect.poll(() => getMarkdownContent(page)).toBe('hello');
+
+  await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+
+  // Type `code` at the end of the paragraph: the closing backtick should
+  // match the opening one and form an inline code element
+  await editable.locator('p').first().click();
+  await page.keyboard.press('End');
+  await page.keyboard.type(' `code`');
+
+  const markerSpan = editable.locator('span[style*="var(--color-second-bg)"]');
+  await expect(markerSpan).toHaveText('code');
+  // The marker span is immediately styled like inline code (this rule lives in
+  // app.css; Svelte strips it from component styles because it only matches
+  // runtime-created elements)
+  const markerFont = await markerSpan.evaluate((el) => getComputedStyle(el).fontFamily);
+  expect(markerFont.toLowerCase()).toContain('mono');
+  await expect.poll(() => getMarkdownContent(page)).toContain('`code`');
+
+  // Undo reverts the auto-format, keeping the typed backticks as plain text
+  await page.keyboard.press('ControlOrMeta+z');
+  await expect(markerSpan).toHaveCount(0);
+  await expect(editable.locator('p').first()).toContainText('`code`');
+
+  // The undone state stores the literal backticks (escaped in markdown), so
+  // the preview shows them as plain text, not inline code
+  await page.getByRole('button', { name: 'Done editing' }).click();
+  const preview = page.locator('.markdown-preview:not(.wysiwyg-editing)');
+  await expect(preview.locator('p')).toContainText('`code`');
+  await expect(preview.locator('code')).toHaveCount(0);
+});
+
+test('WYSIWYG code blocks have a working copy button', async ({ page }) => {
+  await openMarkdownPlayground(page);
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('```js\nconst a = 1;\n```');
+  await expect.poll(() => getMarkdownContent(page)).toContain('```js');
+
+  await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  const copyButton = editable.locator('.md-code-copy .copy-code-button');
+  await expect(copyButton).toBeVisible();
+
+  // Copying must not modify the stored markdown
+  await copyButton.click();
+  await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toBe('const a = 1;\n');
+
+  await page.getByRole('button', { name: 'Done editing' }).click();
+  await expect.poll(() => getMarkdownContent(page)).toContain('```js');
 });

--- a/e2e/playground-tabs.test.ts
+++ b/e2e/playground-tabs.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from '@playwright/test';
+
+test('closing the active tab keeps the next tab\'s own language', async ({ page }) => {
+  await page.goto('/playground');
+  await page.evaluate(() => {
+    const now = Date.now();
+    const files = [
+      {
+        fileId: 'file-a',
+        fileName: 'FileA',
+        language: 'java',
+        lastLanguage: 'java',
+        content: '// java file A',
+        viewState: null,
+        output: '',
+        logs: '',
+        isActive: false,
+        order: 0,
+        isOpen: true,
+        // Most recently viewed: becomes the active tab on load
+        lastUpdated: now + 1000
+      },
+      {
+        fileId: 'file-b',
+        fileName: 'FileB',
+        language: 'python',
+        lastLanguage: 'python',
+        content: '# python file B',
+        viewState: null,
+        output: '',
+        logs: '',
+        isActive: false,
+        order: 1,
+        isOpen: true,
+        lastUpdated: now
+      }
+    ];
+    localStorage.removeItem('user-settings');
+    localStorage.setItem('files', JSON.stringify({ playground: JSON.stringify(files) }));
+  });
+  await page.reload();
+  await expect(page.locator('.monaco-editor')).toBeVisible();
+
+  // Tab A (java) is active initially
+  await expect(page.locator('.tab.active .tab-title')).toHaveText('FileA');
+  await expect(page.locator('#language-select')).toHaveValue('java');
+
+  // Closing tab A activates tab B, which must keep its own language (python)
+  // instead of inheriting the closed tab's language (java)
+  await page.locator('.tab', { hasText: 'FileA' }).locator('.tab-close').click();
+  await expect(page.locator('.tab.active .tab-title')).toHaveText('FileB');
+  await expect(page.locator('#language-select')).toHaveValue('python');
+  await expect(page.locator('.monaco-editor .view-lines')).toContainText('python file B');
+});

--- a/src/app.css
+++ b/src/app.css
@@ -123,6 +123,64 @@
   display: block;
 }
 
+/* Image thumbnails: pasted images render small; click opens a full-size view */
+.markdown-body .md-thumb {
+  position: relative;
+  display: inline-block;
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.markdown-body .md-thumb img {
+  max-width: 240px;
+  max-height: 160px;
+  width: auto;
+  height: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  cursor: zoom-in;
+}
+
+.markdown-body .md-thumb-delete {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.55);
+  color: #fff;
+  cursor: pointer;
+  opacity: 0.7;
+}
+
+.markdown-body .md-thumb-delete:hover {
+  opacity: 1;
+  background: var(--color-hard);
+}
+
+/*
+ * Inline code created by the WYSIWYG backtick auto-matching. The auto-matched
+ * code is a span whose inline background is the theme variable
+ * --color-second-bg (see INLINE_CODE_STYLE_MARKER in markdown.ts; the span is
+ * inserted with a concrete color because Chrome's execCommand sanitizer drops
+ * var() references, then rewritten). This global rule styles it like code.
+ * Must stay in app.css: the span is created at runtime, so Svelte drops the
+ * rule from component styles as "unused".
+ */
+.wysiwyg-editing span[style*="var(--color-second-bg)"] {
+  font-family: var(--font-mono);
+  font-size: 85%;
+  background-color: var(--color-second-bg);
+  border-radius: 6px;
+  padding: 0.2em 0.4em;
+}
+
 .markdown-body pre {
   background-color: var(--color-code-bg);
   border: 1px solid var(--color-border);

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -60,4 +60,51 @@ describe('markdown utils', () => {
         const html = renderMarkdownPlain(`![image](${dataUrl})`);
         expect(htmlToMarkdown(html)).toContain(`![image](${dataUrl})`);
     });
+
+    it('renders images as thumbnails with a delete button when imageThumbnails is enabled', () => {
+        const dataUrl = 'data:image/png;base64,iVBORw0KGgo=';
+        const html = renderMarkdown(`![image](${dataUrl})`, { imageThumbnails: true }) as string;
+        expect(html).toContain('md-thumb');
+        expect(html).toContain('md-thumb-delete');
+        expect(html).toContain(`src="${dataUrl}"`);
+        expect(html).toContain('aria-label="Delete image"');
+    });
+
+    it('renders plain <img> without thumbnail wrapper by default', () => {
+        const html = renderMarkdown('![image](https://example.com/a.png)') as string;
+        expect(html).not.toContain('md-thumb');
+        expect(html).toContain('<img');
+    });
+
+    it('thumbnail HTML round-trips back to markdown image syntax', () => {
+        const dataUrl = 'data:image/png;base64,iVBORw0KGgo=';
+        const html = renderMarkdown(`![image](${dataUrl})`, { imageThumbnails: true }) as string;
+        expect(htmlToMarkdown(html)).toContain(`![image](${dataUrl})`);
+    });
+
+    it('converts WYSIWYG auto-matched inline code spans back to backticks', () => {
+        const html = '<p>hello <span style="background-color: var(--color-second-bg);">code</span></p>';
+        const md = htmlToMarkdown(html);
+        expect(md).toContain('`code`');
+        // Plain spans with other styles are left as-is (plain text)
+        const plain = htmlToMarkdown('<p>hello <span style="color: red;">world</span></p>');
+        expect(plain).toContain('world');
+    });
+
+    it('WYSIWYG inline code spans round-trip stably', () => {
+        const md = 'hello `code`';
+        const html = renderMarkdownPlain(md);
+        const back = htmlToMarkdown(html);
+        expect(back).toBe(md);
+    });
+
+    it('trailing empty lines are trimmed so WYSIWYG round-trips stay stable', () => {
+        // The WYSIWYG editor keeps an empty line at the end of the document
+        // (ensureTrailingEmptyLine); converting it back must not grow the
+        // markdown with trailing blank lines.
+        expect(htmlToMarkdown('<p>hello</p><p><br></p>')).toBe('hello');
+        expect(htmlToMarkdown('<p>hello</p><p>more</p><p><br></p>')).toBe('hello\n\nmore');
+        // No growth when round-tripping twice
+        expect(htmlToMarkdown(renderMarkdownPlain(htmlToMarkdown('<p>hello</p><p><br></p>')))).toBe('hello');
+    });
 });

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -63,6 +63,27 @@ function applyExpandedState(wrapper: HTMLElement, preEl: Element, expandLabel: E
 if (typeof document !== 'undefined') {
     document.addEventListener('click', (e: MouseEvent) => {
         const target = e.target as HTMLElement;
+
+        const copyBtn = target.closest('.copy-code-button') as HTMLElement | null;
+        if (copyBtn) {
+            e.preventDefault();
+            const wrapper = copyBtn.closest('.code-block-wrapper, .md-code-copy') as HTMLElement | null;
+            const codeEl = wrapper?.querySelector('code');
+            if (!codeEl) return;
+            const code = codeEl.innerText;
+            navigator.clipboard.writeText(code).then(() => {
+                const originalInner = copyBtn.innerHTML;
+                const originalColor = copyBtn.style.color;
+                copyBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"></polyline></svg>';
+                copyBtn.style.color = 'var(--color-easy)';
+                setTimeout(() => {
+                    copyBtn.innerHTML = originalInner;
+                    copyBtn.style.color = originalColor;
+                }, 2000);
+            }).catch(() => {});
+            return;
+        }
+
         const btn = target.closest('.collapse-code-button') as HTMLElement | null;
         if (!btn) return;
         e.preventDefault();
@@ -103,8 +124,120 @@ if (typeof document !== 'undefined') {
     observer.observe(document.body, { childList: true, subtree: true });
 }
 
-export function getMarkdownRenderer() {
+// Class names used for image thumbnails (small preview + delete button).
+export const THUMB_WRAPPER_CLASS = 'md-thumb';
+export const THUMB_DELETE_CLASS = 'md-thumb-delete';
+
+// Marker used for inline code created by the WYSIWYG backtick auto-matching.
+// Chrome sanitizes <code> elements inserted via execCommand into styled spans
+// and drops inline styles that reference CSS variables, so the span is first
+// inserted with a concrete background color and then rewritten to this marker
+// (a theme variable) by the caller right after insertion. htmlToMarkdown
+// converts spans carrying this marker back to inline code markdown, and the
+// WYSIWYG CSS styles them like code using the theme variable, so the marker
+// adapts to every theme.
+export const INLINE_CODE_STYLE_MARKER = 'var(--color-second-bg)';
+
+export function inlineCodeSpanHtml(text: string): string {
+    const escaped = text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    // Concrete color: Chrome's execCommand sanitizer preserves background-color
+    // only when it is a concrete value, not a var() reference.
+    return `<span style="background-color: rgb(255, 254, 253);">${escaped}</span>`;
+}
+
+const TRASH_ICON_SVG = '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3 6h18"/><path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"/><path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"/><line x1="10" x2="10" y1="11" y2="17"/><line x1="14" x2="14" y1="11" y2="17"/></svg>';
+
+function escapeHtmlAttr(value: string): string {
+    return value
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+// Renders an image as a small thumbnail with a delete button, instead of the
+// full-size image. Click handling (lightbox / delete) is done via event
+// delegation by the caller. contenteditable="false" makes the thumbnail an
+// atomic unit inside the WYSIWYG editor.
+export function imageThumbnailHtml(href: string, alt: string, title?: string | null): string {
+    const titleAttr = title ? ` title="${escapeHtmlAttr(title)}"` : '';
+    return `<span class="${THUMB_WRAPPER_CLASS}" contenteditable="false"><img src="${escapeHtmlAttr(href)}" alt="${escapeHtmlAttr(alt)}"${titleAttr}><button type="button" class="${THUMB_DELETE_CLASS}" title="Delete image" aria-label="Delete image">${TRASH_ICON_SVG}</button></span>`;
+}
+
+// Wraps every <img> under root in a thumbnail container with a delete button.
+// Used by the WYSIWYG editor, where images start out as plain <img> elements
+// (initial render and image paste).
+export function wrapImageThumbnails(root: HTMLElement) {
+    const imgs = Array.from(root.querySelectorAll('img'));
+    for (const img of imgs) {
+        if (img.closest(`.${THUMB_WRAPPER_CLASS}`)) continue;
+        const wrapper = document.createElement('span');
+        wrapper.className = THUMB_WRAPPER_CLASS;
+        wrapper.setAttribute('contenteditable', 'false');
+        img.replaceWith(wrapper);
+        wrapper.appendChild(img);
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = THUMB_DELETE_CLASS;
+        btn.title = 'Delete image';
+        btn.setAttribute('aria-label', 'Delete image');
+        btn.innerHTML = TRASH_ICON_SVG;
+        wrapper.appendChild(btn);
+    }
+}
+
+// Class name of the wrapper added around code blocks in the WYSIWYG editor so
+// they get a copy button (see wrapCodeBlocksWithCopy). Stripped again by
+// htmlToMarkdown so only the <pre> round-trips back to markdown.
+export const CODE_COPY_WRAPPER_CLASS = 'md-code-copy';
+
+// Appends an empty line at the end of the WYSIWYG editor when it does not
+// already end with one. A contenteditable="false" thumbnail at the very end of
+// the document would trap the caret, so an empty <p> is always kept after it
+// (and after the last paragraph in general), letting the user move past a
+// pasted image and keep typing. htmlToMarkdown trims the empty line away.
+export function ensureTrailingEmptyLine(root: HTMLElement) {
+    const last = root.lastElementChild as HTMLElement | null;
+    if (last) {
+        const children = Array.from(last.children);
+        const onlyBr = children.length === 0 || (children.length === 1 && children[0].tagName === 'BR');
+        if (last.tagName === 'P' && onlyBr && !last.textContent?.trim()) return;
+    }
+    const p = document.createElement('p');
+    p.innerHTML = '<br>';
+    root.appendChild(p);
+}
+
+// Wraps every <pre> under root with a copy button. The button is
+// contenteditable="false" so it stays out of the editable content; the <pre>
+// itself remains editable.
+export function wrapCodeBlocksWithCopy(root: HTMLElement) {
+    const preElements = Array.from(root.querySelectorAll('pre'));
+    for (const pre of preElements) {
+        if (pre.closest(`.${CODE_COPY_WRAPPER_CLASS}`)) continue;
+        const wrapper = document.createElement('div');
+        wrapper.className = `code-block-wrapper ${CODE_COPY_WRAPPER_CLASS}`;
+        pre.replaceWith(wrapper);
+        wrapper.appendChild(pre);
+        const actions = document.createElement('div');
+        actions.className = 'code-block-actions';
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'copy-code-button';
+        btn.title = 'Copy code';
+        btn.setAttribute('aria-label', 'Copy code');
+        btn.setAttribute('contenteditable', 'false');
+        btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
+        actions.appendChild(btn);
+        wrapper.appendChild(actions);
+    }
+}
+
+export function getMarkdownRenderer(options?: { imageThumbnails?: boolean }) {
     const renderer = new Renderer();
+    if (options?.imageThumbnails) {
+        renderer.image = (token: any) => imageThumbnailHtml(token.href ?? '', token.text ?? '', token.title);
+    }
     renderer.code = (token: any) => {
         const text = token.text;
         const lang = (token.lang || '').split(/\s+/)[0];
@@ -137,18 +270,7 @@ export function getMarkdownRenderer() {
                         <polyline points="18 15 12 9 6 15"></polyline>
                     </svg>
                 </button>
-                <button class="copy-code-button" title="Copy code" onclick="
-                    const code = this.closest('.code-block-wrapper').querySelector('code').innerText; 
-                    navigator.clipboard.writeText(code); 
-                    const button = this;
-                    const originalInner = button.innerHTML;
-                    button.innerHTML = '<svg width=\\'16\\' height=\\'16\\' viewBox=\\'0 0 24 24\\' fill=\\'none\\' stroke=\\'currentColor\\' stroke-width=\\'2\\' stroke-linecap=\\'round\\' stroke-linejoin=\\'round\\'><polyline points=\\'20 6 9 17 4 12\\'></polyline></svg>';
-                    button.style.color = 'var(--color-easy)';
-                    setTimeout(() => { 
-                        button.innerHTML = originalInner;
-                        button.style.color = '';
-                    }, 2000);
-                ">
+                <button class="copy-code-button" title="Copy code" aria-label="Copy code">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                         <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
@@ -161,8 +283,8 @@ export function getMarkdownRenderer() {
     return renderer;
 }
 
-export function renderMarkdown(content: string) {
-    const renderer = getMarkdownRenderer();
+export function renderMarkdown(content: string, options?: { imageThumbnails?: boolean }) {
+    const renderer = getMarkdownRenderer(options);
     return marked.parse(content, { renderer });
 }
 
@@ -183,10 +305,44 @@ function getTurndownService(): TurndownService {
             emDelimiter: '*'
         });
         turndownService.use(gfm);
+        // Inline code created by the WYSIWYG backtick auto-matching (see
+        // inlineCodeSpanHtml) round-trips back to inline code markdown.
+        turndownService.addRule('wysiwygInlineCode', {
+            filter: (node: HTMLElement) =>
+                node.nodeName === 'SPAN' && (node.getAttribute('style') || '').includes(INLINE_CODE_STYLE_MARKER),
+            replacement: (content: string) => {
+                if (!content) return '';
+                content = content.replace(/\r?\n|\r/g, ' ');
+                let delimiter = '`';
+                while (content.includes(delimiter)) delimiter += '`';
+                const extraSpace = /^`|^ .*?[^ ].* $|`$/.test(content) ? ' ' : '';
+                return delimiter + extraSpace + content + extraSpace + delimiter;
+            }
+        });
     }
     return turndownService;
 }
 
 export function htmlToMarkdown(html: string): string {
-    return getTurndownService().turndown(html);
+    // Strip interactive wrappers (thumbnail delete buttons, code-block copy
+    // buttons, contenteditable markers) so only the plain content round-trips
+    // back to markdown.
+    if (typeof DOMParser !== 'undefined' && (html.includes(THUMB_WRAPPER_CLASS) || html.includes(CODE_COPY_WRAPPER_CLASS))) {
+        const doc = new DOMParser().parseFromString(html, 'text/html');
+        doc.querySelectorAll(`.${THUMB_DELETE_CLASS}`).forEach((el) => el.remove());
+        doc.querySelectorAll(`.${THUMB_WRAPPER_CLASS}`).forEach((el) => {
+            const img = el.querySelector('img');
+            if (img) el.replaceWith(img);
+            else el.remove();
+        });
+        doc.querySelectorAll(`.${CODE_COPY_WRAPPER_CLASS}`).forEach((el) => {
+            el.querySelector('.code-block-actions')?.remove();
+            el.replaceWith(...Array.from(el.childNodes));
+        });
+        html = doc.body.innerHTML;
+    }
+    // Trailing whitespace (e.g. the empty line kept by
+    // ensureTrailingEmptyLine) is insignificant in markdown, so drop it to
+    // keep repeated WYSIWYG round-trips stable.
+    return getTurndownService().turndown(html).replace(/\s+$/, '');
 }

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -11,7 +11,7 @@
     import fileStore, { type FileEntry, fileSyncVersion } from '$lib/stores/fileStore.js';
     import userSettingsStorage, { type ThemeChoice, type ActivePanel } from '$lib/stores/userSettingsStorage';
     import { type ProgrammingLanguage } from '$lib/utils/util.js';
-    import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown } from '$lib/utils/markdown';
+    import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, wrapImageThumbnails, wrapCodeBlocksWithCopy, ensureTrailingEmptyLine, inlineCodeSpanHtml, INLINE_CODE_STYLE_MARKER, THUMB_WRAPPER_CLASS, THUMB_DELETE_CLASS } from '$lib/utils/markdown';
     import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
     import QRCode from 'qrcode';
     import { onMount, tick } from 'svelte';
@@ -603,7 +603,10 @@ func main() {
                 if (nextOpenIdx !== -1) {
                     activeTabId = nextOpenIdx;
                     if (tabs[nextOpenIdx].type !== 'preview') {
-                        loadOrInitFile(language);
+                        const targetLanguage = getLanguageForTab(tabs[nextOpenIdx].fileId);
+                        setLastLanguage(tabs[nextOpenIdx].fileId, targetLanguage);
+                        language = targetLanguage;
+                        loadOrInitFile(targetLanguage);
                     }
                 }
             }
@@ -633,7 +636,12 @@ func main() {
             }
             if (nextOpenIdx !== -1) {
                 activeTabId = nextOpenIdx;
-                loadOrInitFile(language);
+                if (tabs[nextOpenIdx].type !== 'preview') {
+                    const targetLanguage = getLanguageForTab(tabs[nextOpenIdx].fileId);
+                    setLastLanguage(tabs[nextOpenIdx].fileId, targetLanguage);
+                    language = targetLanguage;
+                    loadOrInitFile(targetLanguage);
+                }
             }
         }
     }
@@ -868,6 +876,15 @@ func main() {
         return `![image](${dataUrl})`;
     }
 
+    // --- Image lightbox (full-size view opened from thumbnails) ---
+    let lightboxSrc: string | null = null;
+    function openLightbox(src: string) {
+        lightboxSrc = src;
+    }
+    function closeLightbox() {
+        lightboxSrc = null;
+    }
+
     // --- Markdown preview WYSIWYG editing ---
     let previewEditMode = false;
     let wysiwygEl: HTMLDivElement | null = null;
@@ -900,13 +917,201 @@ func main() {
         await tick();
         if (wysiwygEl) {
             wysiwygEl.innerHTML = renderMarkdownPlain(getActivePreviewSourceContent());
+            wrapImageThumbnails(wysiwygEl);
+            wrapCodeBlocksWithCopy(wysiwygEl);
+            ensureTrailingEmptyLine(wysiwygEl);
             wysiwygEl.focus();
         }
     }
 
     function handleWysiwygInput() {
+        maybeAutoCloseInlineCode();
         if (wysiwygDebounce) clearTimeout(wysiwygDebounce);
         wysiwygDebounce = setTimeout(commitWysiwygEdits, 300);
+    }
+
+    // When the user types a closing backtick, try to match it with a previous
+    // backtick in the same text node and form an inline code element. Runs on
+    // the input event, after the backtick has been typed, so a single ctrl+z
+    // (undo) cancels the auto-format and restores exactly what was typed.
+    // Chrome sanitizes <code> tags in execCommand HTML, so a marker span is
+    // inserted instead and converted back to inline code by htmlToMarkdown.
+    let applyingInlineCode = false;
+    function maybeAutoCloseInlineCode() {
+        if (applyingInlineCode || !wysiwygEl) return;
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) return;
+        const range = selection.getRangeAt(0);
+        if (!range.collapsed) return;
+        const node = range.startContainer;
+        if (node.nodeType !== Node.TEXT_NODE || !wysiwygEl.contains(node)) return;
+        const parentEl = node.parentElement;
+        if (!parentEl || parentEl.closest('code') || parentEl.closest('pre')) return;
+        const text = node.textContent ?? '';
+        const offset = range.startOffset;
+        if (offset < 1 || text.charAt(offset - 1) !== '`') return;
+        const openIdx = text.slice(0, offset - 1).lastIndexOf('`');
+        if (openIdx === -1) return;
+        const codeText = text.slice(openIdx + 1, offset - 1);
+        if (!codeText || codeText !== codeText.trim()) return;
+        applyingInlineCode = true;
+        try {
+            const replaceRange = document.createRange();
+            replaceRange.setStart(node, openIdx);
+            replaceRange.setEnd(node, offset);
+            selection.removeAllRanges();
+            selection.addRange(replaceRange);
+            document.execCommand('insertHTML', false, inlineCodeSpanHtml(codeText));
+            // Rewrite the inserted span's background from the concrete color
+            // (which the sanitizer kept) to the theme-variable marker, so the
+            // code adapts to the active theme and round-trips back to backticks.
+            const inserted = wysiwygEl.querySelectorAll('span');
+            const markerSpan = inserted[inserted.length - 1];
+            if (markerSpan instanceof HTMLElement) markerSpan.style.backgroundColor = INLINE_CODE_STYLE_MARKER;
+        } finally {
+            applyingInlineCode = false;
+        }
+    }
+
+    // Toggle inline code on the current selection (or the word at the caret).
+    function toggleInlineCode() {
+        if (!wysiwygEl) return;
+        wysiwygEl.focus();
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) return;
+        // If the caret/selection is inside an inline <code>, unwrap it
+        let node: Node | null = selection.anchorNode;
+        let existing: HTMLElement | null = null;
+        while (node && node !== wysiwygEl) {
+            if (node instanceof HTMLElement && node.tagName === 'CODE' && node.parentElement?.tagName !== 'PRE') {
+                existing = node;
+                break;
+            }
+            node = node.parentNode;
+        }
+        if (existing) {
+            const parent = existing.parentNode;
+            if (parent) {
+                while (existing.firstChild) parent.insertBefore(existing.firstChild, existing);
+                parent.removeChild(existing);
+                parent.normalize();
+            }
+            handleWysiwygInput();
+            return;
+        }
+        let range = selection.getRangeAt(0);
+        if (range.collapsed) {
+            // Expand to the word around the caret
+            const textNode = range.startContainer;
+            if (textNode.nodeType !== Node.TEXT_NODE) return;
+            const text = textNode.textContent ?? '';
+            let start = range.startOffset;
+            let end = range.startOffset;
+            while (start > 0 && !/\s/.test(text.charAt(start - 1))) start--;
+            while (end < text.length && !/\s/.test(text.charAt(end))) end++;
+            if (start === end) return;
+            range.setStart(textNode, start);
+            range.setEnd(textNode, end);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            range = selection.getRangeAt(0);
+        }
+        const frag = range.extractContents();
+        // If the selection spans block-level content (e.g. Ctrl+A over several
+        // paragraphs), wrapping everything in one inline <code> would nest block
+        // elements inside it and corrupt the stored markdown. Wrap each block's
+        // text in its own <code> instead.
+        const blocks = Array.from(frag.children).filter(
+            (el): el is HTMLElement => el instanceof HTMLElement && /^(P|DIV|LI|H[1-6]|PRE)$/.test(el.tagName)
+        );
+        const codeEl = document.createElement('code');
+        if (blocks.length > 0) {
+            for (const block of blocks) {
+                if (block.tagName === 'PRE' || !block.textContent?.trim()) continue;
+                const nestedCode = document.createElement('code');
+                while (block.firstChild) nestedCode.appendChild(block.firstChild);
+                block.appendChild(nestedCode);
+            }
+            range.insertNode(frag);
+            // Reselect the first wrapped block so toggling again unwraps it
+            const firstWrapped = blocks.find((b) => b.tagName !== 'PRE' && b.textContent?.trim());
+            if (firstWrapped?.firstElementChild) {
+                selection.removeAllRanges();
+                const newRange = document.createRange();
+                newRange.selectNodeContents(firstWrapped.firstElementChild);
+                selection.addRange(newRange);
+            }
+        } else {
+            codeEl.appendChild(frag);
+            range.insertNode(codeEl);
+            // Reselect the wrapped content so toggling again unwraps it
+            selection.removeAllRanges();
+            const newRange = document.createRange();
+            newRange.selectNodeContents(codeEl);
+            selection.addRange(newRange);
+        }
+        handleWysiwygInput();
+    }
+
+    // Click handling inside the WYSIWYG area: trash icon deletes the image,
+    // clicking the thumbnail opens the full-size lightbox.
+    function handleWysiwygClick(event: MouseEvent) {
+        const target = event.target as HTMLElement;
+        const deleteBtn = target.closest(`.${THUMB_DELETE_CLASS}`) as HTMLElement | null;
+        if (deleteBtn && wysiwygEl?.contains(deleteBtn)) {
+            event.preventDefault();
+            deleteBtn.closest(`.${THUMB_WRAPPER_CLASS}`)?.remove();
+            ensureTrailingEmptyLine(wysiwygEl);
+            commitWysiwygEdits();
+            return;
+        }
+        const img = target.closest(`.${THUMB_WRAPPER_CLASS} img`) as HTMLImageElement | null;
+        if (img && wysiwygEl?.contains(img)) {
+            event.preventDefault();
+            openLightbox(img.src);
+        }
+    }
+
+    // Click handling in the read-only markdown preview.
+    function handlePreviewClick(event: MouseEvent) {
+        const target = event.target as HTMLElement;
+        const container = event.currentTarget as HTMLElement;
+        const deleteBtn = target.closest(`.${THUMB_DELETE_CLASS}`) as HTMLElement | null;
+        if (deleteBtn && container.contains(deleteBtn)) {
+            event.preventDefault();
+            const img = deleteBtn.closest(`.${THUMB_WRAPPER_CLASS}`)?.querySelector('img');
+            const src = img?.getAttribute('src');
+            if (src) deletePreviewImage(src);
+            return;
+        }
+        const img = target.closest(`.${THUMB_WRAPPER_CLASS} img`) as HTMLImageElement | null;
+        if (img && container.contains(img)) {
+            event.preventDefault();
+            openLightbox(img.src);
+        }
+    }
+
+    // Removes the image with the given src from the preview's source markdown.
+    function deletePreviewImage(src: string) {
+        const sourceFileId = activeTab?.type === 'preview' ? activeTab.sourceFileId : null;
+        if (!sourceFileId) return;
+        const fkey = fileKey();
+        fileStore.update((s) => {
+            const files = JSON.parse(s[fkey] || '[]') as FileEntry[];
+            const sourceEntry = files.find((f) => f.fileId === sourceFileId && f.language === 'markdown');
+            if (!sourceEntry) return s;
+            const escaped = src.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            const pattern = new RegExp(`!\\[[^\\]]*\\]\\(\\s*${escaped}(?:\\s+"[^"]*")?\\s*\\)`, 'g');
+            const next = sourceEntry.content
+                .replace(pattern, '')
+                .replace(/[ \t]+\n/g, '\n')
+                .replace(/\n{3,}/g, '\n\n');
+            if (next !== sourceEntry.content) {
+                sourceEntry.content = next;
+                sourceEntry.lastUpdated = Date.now();
+            }
+            return { ...s, [fkey]: JSON.stringify(files) };
+        });
     }
 
     function commitWysiwygEdits() {
@@ -950,6 +1155,13 @@ func main() {
             const reader = new FileReader();
             reader.onload = () => {
                 document.execCommand('insertImage', false, reader.result as string);
+                if (wysiwygEl) {
+                    wrapImageThumbnails(wysiwygEl);
+                    wrapCodeBlocksWithCopy(wysiwygEl);
+                    // Keep an empty line after the pasted image so the caret
+                    // can move past the contenteditable="false" thumbnail
+                    ensureTrailingEmptyLine(wysiwygEl);
+                }
             };
             reader.readAsDataURL(file);
             break;
@@ -974,6 +1186,10 @@ func main() {
             openLinkInput();
             return;
         }
+        if (command === 'inlineCode') {
+            toggleInlineCode();
+            return;
+        }
         applyWysiwygCommand(command, btn.dataset.value);
     }
 
@@ -985,6 +1201,10 @@ func main() {
         const command = btn.dataset.command!;
         if (command === 'link') {
             openLinkInput();
+            return;
+        }
+        if (command === 'inlineCode') {
+            toggleInlineCode();
             return;
         }
         applyWysiwygCommand(command, btn.dataset.value);
@@ -1501,8 +1721,8 @@ func main() {
         const files = JSON.parse(fileStoreValue[fkey] || '[]') as FileEntry[];
         const sourceEntry = files.find((f: FileEntry) => f.fileId === activeTab.sourceFileId && f.language === 'markdown');
         const src = sourceEntry?.content ?? '';
-        
-        return renderMarkdown(src);
+
+        return renderMarkdown(src, { imageThumbnails: true });
     })();
     $: pageTitle = activeTabName ? `${activeTabName} - Playground - Cojudge` : 'Playground - Cojudge';
     let isMac = false;
@@ -1518,6 +1738,7 @@ func main() {
             if (e.key === 'Escape') {
                 showSettings = false;
                 closeSearch();
+                closeLightbox();
             }
             // Cmd+P or Ctrl+P
             if ((e.ctrlKey || e.metaKey) && !e.shiftKey && e.key.toLowerCase() === 'p') {
@@ -2047,6 +2268,9 @@ func main() {
                             <button type="button" data-command="formatBlock" data-value="pre" title="Code block" aria-label="Code block">
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
                             </button>
+                            <button type="button" data-command="inlineCode" title="Inline code" aria-label="Inline code">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>
+                            </button>
                             <span class="wysiwyg-separator"></span>
                             <button type="button" data-command="link" title="Insert link" aria-label="Insert link">
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg>
@@ -2069,8 +2293,11 @@ func main() {
                                 />
                             {/if}
                         </div>
+                        <!-- svelte-ignore a11y-click-events-have-key-events -->
+                        <!-- svelte-ignore a11y-no-static-element-interactions -->
                         <div
                             class="markdown-preview markdown-body wysiwyg-editing"
+                            style="font-size: {fontSize}px;"
                             contenteditable="true"
                             role="textbox"
                             aria-multiline="true"
@@ -2079,11 +2306,14 @@ func main() {
                             bind:this={wysiwygEl}
                             on:input={handleWysiwygInput}
                             on:paste={handleWysiwygPaste}
+                            on:click={handleWysiwygClick}
                             on:blur={commitWysiwygEdits}
                         ></div>
                     </div>
                 {:else}
-                    <div class="markdown-preview markdown-body">
+                    <!-- svelte-ignore a11y-click-events-have-key-events -->
+                    <!-- svelte-ignore a11y-no-static-element-interactions -->
+                    <div class="markdown-preview markdown-body" on:click={handlePreviewClick}>
                         {@html previewHtml}
                     </div>
                 {/if}
@@ -2150,13 +2380,28 @@ func main() {
     </div>
 
     {#if showShareModal}
-        <ShareModal 
-            url={shareUrl} 
-            qrCodeDataUrl={qrCodeDataUrl} 
+        <ShareModal
+            url={shareUrl}
+            qrCodeDataUrl={qrCodeDataUrl}
             {code}
-            on:close={() => showShareModal = false} 
+            on:close={() => showShareModal = false}
             on:generateNew={handleGenerateNewLink}
         />
+    {/if}
+
+    {#if lightboxSrc}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <!-- svelte-ignore a11y-no-static-element-interactions -->
+        <div class="image-lightbox" role="dialog" aria-modal="true" aria-label="Full-size image" tabindex="-1" on:click={closeLightbox}>
+            <button type="button" class="lightbox-close" title="Close (Esc)" aria-label="Close image viewer" on:click|stopPropagation={closeLightbox}>
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <line x1="18" y1="6" x2="6" y2="18"/>
+                    <line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+            </button>
+            <!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+            <img src={lightboxSrc} alt="Full-size" on:click|stopPropagation={() => {}} />
+        </div>
     {/if}
 
     {#if showSearch}
@@ -2932,6 +3177,48 @@ func main() {
         text-align: center;
         box-shadow: 0 1px 0 var(--color-border);
         color: var(--color-text);
+    }
+
+    /* Image lightbox (full-size view) */
+    .image-lightbox {
+        position: fixed;
+        inset: 0;
+        z-index: 4000;
+        background: rgba(0, 0, 0, 0.85);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 32px;
+        cursor: zoom-out;
+    }
+
+    .image-lightbox img {
+        max-width: 100%;
+        max-height: 100%;
+        object-fit: contain;
+        border-radius: var(--border-radius-md);
+        box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+        cursor: default;
+    }
+
+    .lightbox-close {
+        position: absolute;
+        top: 16px;
+        right: 16px;
+        width: 36px;
+        height: 36px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: none;
+        border-radius: 50%;
+        background: rgba(255, 255, 255, 0.12);
+        color: #fff;
+        cursor: pointer;
+    }
+
+    .lightbox-close:hover {
+        background: rgba(255, 255, 255, 0.25);
     }
 
     /* Search Overlay */


### PR DESCRIPTION
## Summary

Improves the playground's markdown editing with a richer WYSIWYG mode:

- **Image paste**: clipboard images paste as base64 thumbnails with a delete button in the WYSIWYG editor; in the preview they render as constrained thumbnails with a full-screen lightbox (Esc or cross to close) and a trash icon that removes them from the source markdown
- **Trailing empty line**: the WYSIWYG editor always ends with an empty line so the caret is never trapped after a pasted image and typing continues naturally
- **Inline code**: backticks auto-match into inline code that adapts to the active theme (marker uses `var(--color-second-bg)`); the toolbar's Inline code button wraps selections, including multi-paragraph selections (each block gets its own `<code>`)
- **Code blocks**: working copy button in WYSIWYG mode
- **Round-trip stability**: leaving/re-entering WYSIWYG never accumulates blank lines; `htmlToMarkdown` strips interactive wrappers and trims trailing whitespace

## Why the inline-code marker is not a literal variable

Chrome's `execCommand` sanitizer strips inline styles that reference CSS variables and drops classes, so the auto-matched span is inserted with a concrete background color and immediately rewritten to `var(--color-second-bg)` via JS. The visible background always resolves from the theme variable.

## Tests

- 21 e2e tests pass (7 new/changed in `e2e/playground-markdown.test.ts`, plus `e2e/playground-tabs.test.ts`)
- 28 unit tests pass
- `npm run build` and `svelte-check` (19 errors / 5 warnings, pre-existing baseline) unchanged