### PR TITLE
fix: Externalize turndown to fix SSR 500 in game mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
 			"license": "MIT",
 			"dependencies": {
 				"dockerode": "^5.0.1",
-				"tar-stream": "^3.1.7"
+				"tar-stream": "^3.1.7",
+				"turndown": "^7.2.4",
+				"turndown-plugin-gfm": "^1.0.2"
 			},
 			"bin": {
 				"cojudge": "bin/cojudge"
@@ -35,8 +37,6 @@
 				"svelte": "^5.39.5",
 				"svelte-check": "^4.3.2",
 				"svelte-preprocess": "^6.0.3",
-				"turndown": "^7.2.4",
-				"turndown-plugin-gfm": "^1.0.2",
 				"typescript": "^5.9.2",
 				"uuid": "^13.0.0",
 				"vite": "^7.1.7",
@@ -1283,7 +1283,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
 			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
-			"dev": true,
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/@playwright/test": {
@@ -4664,7 +4663,6 @@
 			"version": "7.2.4",
 			"resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
 			"integrity": "sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@mixmark-io/domino": "^2.2.0"
@@ -4678,7 +4676,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/turndown-plugin-gfm/-/turndown-plugin-gfm-1.0.2.tgz",
 			"integrity": "sha512-vwz9tfvF7XN/jE0dGoBei3FXWuvll78ohzCZQuOb+ZjWrs3a0XhQVomJEb2Qh4VHTPNRO4GPZh0V7VRbiWwkRg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/tweetnacl": {

--- a/package.json
+++ b/package.json
@@ -61,8 +61,6 @@
 		"svelte": "^5.39.5",
 		"svelte-check": "^4.3.2",
 		"svelte-preprocess": "^6.0.3",
-		"turndown": "^7.2.4",
-		"turndown-plugin-gfm": "^1.0.2",
 		"typescript": "^5.9.2",
 		"uuid": "^13.0.0",
 		"vite": "^7.1.7",
@@ -70,6 +68,8 @@
 	},
 	"dependencies": {
 		"dockerode": "^5.0.1",
-		"tar-stream": "^3.1.7"
+		"tar-stream": "^3.1.7",
+		"turndown": "^7.2.4",
+		"turndown-plugin-gfm": "^1.0.2"
 	}
 }


### PR DESCRIPTION
## Problem

Game Mode in the released desktop installers returns a 500 error. Game Mode navigates with a full page load (`window.location.href = '/problems/<slug>?gameMode=1'`), which triggers server-side rendering. Any full page load of `/problems/[slug]` or `/playground` failed with 500, also affecting the web deployment on refresh/direct visits.

## Root cause

`turndown`/`turndown-plugin-gfm` were in `devDependencies`, so SvelteKit bundles them into the production SSR bundle. Turndown's ES build contains a bare CJS `require('@mixmark-io/domino')` inside `createHTMLParser()`, executed at module top level when no `DOMParser` exists. In the browser this branch is never hit, but on the server (Node ESM output) it throws:

```
ReferenceError: require is not defined in ES module scope
```

which fails the route chunk import and produces a 500.

Why CI/dev didn't catch it: `vite dev` and vitest externalize node_modules for SSR, so Node loads turndown's real CJS build where `require` works. Only the production bundled SSR build was broken.

## Fix

Move `turndown` and `turndown-plugin-gfm` from `devDependencies` to `dependencies` (same pattern as `dockerode`/`tar-stream`). SvelteKit externalizes `dependencies` from the server bundle, so Node natively imports turndown's CJS build (with `@mixmark-io/domino`) at runtime, and `stage-desktop-backend.mjs`'s `npm ci --omit=dev` ships them in the desktop backend. The client bundle is unchanged.

## Verification

- Production build: `/`, `/problems/3sum?gameMode=1`, `/playground` all return 200 (previously 500)
- Staged desktop backend (`npm ci --omit=dev`): turndown loads and converts HTML correctly
- All markdown unit tests pass (10)