### PR TITLE
fix: Open external links in desktop mode

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
 				{
 					"identifier": "default",
 					"windows": ["*"],
-					"permissions": ["allow-new-window"]
+					"permissions": ["allow-new-window", "opener:default"]
 				}
 			]
 		}


### PR DESCRIPTION
The Tauri opener plugin intercepts clicks on `a[target="_blank"]` links and opens them via the `plugin:opener|open_url` IPC command. The capability ACL only granted `allow-new-window`, so the IPC call was denied and the LeetCode link on problem pages did nothing in the desktop app.

Switches the opener permission to `opener:default`, which includes `allow-default-urls` (scoped to `http://*`, `https://*`, `mailto:*`, `tel:*`). `allow-open-url` alone has no URL scope and rejects every URL.