### PR TITLE
fix: Allow external link opening from backend origin in release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,10 @@
 				{
 					"identifier": "default",
 					"windows": ["*"],
-					"permissions": ["allow-new-window", "opener:default"]
+					"permissions": ["allow-new-window", "opener:default"],
+					"remote": {
+						"urls": ["http://cojudge.localhost:5376/*"]
+					}
 				}
 			]
 		}


### PR DESCRIPTION
Follow-up to #25: the `opener:default` capability only applies to local origins, so in the release build (page served from `http://cojudge.localhost:5376` by the bundled backend) the opener plugin's click handler was rejected by the ACL and plain clicks on `target=\"_blank\"` external links did nothing. Cmd+Click worked because it bypasses JS and uses the native `on_new_window` handler.

Adds `remote.urls` to the capability so IPC is allowed from the app's own backend origin. Also fixes the "New Window" dropdown button, whose `new_window` invoke was denied in release for the same reason.