### PR TITLE
feat: improve markdown WYSIWYG editing

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -53,10 +53,6 @@ test('playground markdown preview has a WYSIWYG editing mode', async ({ page }) 
   await expect.poll(() => getMarkdownContent(page)).toBe('# Hello\n\nsome text');
 
   await page.getByRole('button', { name: 'Preview Markdown' }).click();
-  const preview = page.locator('.markdown-preview:not(.wysiwyg-editing)');
-  await expect(preview.locator('h1')).toHaveText('Hello');
-
-  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
   const editable = page.locator('.wysiwyg-editing');
   await expect(editable).toBeVisible();
   await expect(editable.locator('h1')).toHaveText('Hello');
@@ -67,7 +63,56 @@ test('playground markdown preview has a WYSIWYG editing mode', async ({ page }) 
   await expect.poll(() => getMarkdownContent(page)).toContain('**some text**');
 
   await page.getByRole('button', { name: 'Done editing' }).click();
+  const preview = page.locator('.markdown-preview:not(.wysiwyg-editing)');
   await expect(preview.locator('strong')).toHaveText('some text');
+});
+
+test('WYSIWYG turns an exact three-hyphen line into a horizontal rule', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('before');
+  await expect.poll(() => getMarkdownContent(page)).toBe('before');
+
+  await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+
+  await editable.locator('> p:last-child').click();
+  await page.keyboard.type('not---');
+  await expect(editable.locator('hr')).toHaveCount(0);
+  await page.keyboard.press('Enter');
+  await page.keyboard.type('-');
+  await page.keyboard.press('Shift+Enter');
+  await page.keyboard.type('--');
+  await expect(editable.locator('hr')).toHaveCount(0);
+  await page.keyboard.press('Enter');
+  await page.keyboard.type('---');
+  await expect(editable.locator('hr')).toHaveCount(1);
+  await expect.poll(async () => (await getMarkdownContent(page))?.match(/^---$/gm)?.length ?? 0).toBe(1);
+
+  await page.getByRole('button', { name: 'Horizontal rule' }).click();
+  await expect(editable.locator('hr')).toHaveCount(2);
+  await expect.poll(async () => (await getMarkdownContent(page))?.match(/^---$/gm)?.length ?? 0).toBe(2);
+});
+
+test('horizontal rule toolbar preserves Markdown tables', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('| A | B |\n| - | - |\n| 1 | 2 |');
+  await expect.poll(() => getMarkdownContent(page)).toContain('| 1 | 2 |');
+
+  await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await editable.locator('td').first().click();
+  await page.getByRole('button', { name: 'Horizontal rule' }).click();
+
+  await expect(editable.locator('table')).toHaveCount(1);
+  await expect(editable.locator('hr')).toHaveCount(0);
+  await expect.poll(() => getMarkdownContent(page)).toContain('| 1 | 2 |');
 });
 
 async function writeImageToClipboard(page: Page, width = 800, height = 600) {
@@ -99,6 +144,7 @@ test('pasted images render as thumbnails with lightbox and delete in the preview
   await pasteImageIntoEditor(page);
 
   await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  await page.getByRole('button', { name: 'Done editing' }).click();
   const preview = page.locator('.markdown-preview:not(.wysiwyg-editing)');
   const thumbnail = preview.locator('.md-thumb');
   await expect(thumbnail).toBeVisible();
@@ -142,7 +188,6 @@ test('WYSIWYG keeps an empty line at the end so typing continues after a pasted 
   await expect.poll(() => getMarkdownContent(page)).toBe('hello');
 
   await page.getByRole('button', { name: 'Preview Markdown' }).click();
-  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
   const editable = page.locator('.wysiwyg-editing');
   await expect(editable).toBeVisible();
 
@@ -188,7 +233,6 @@ test('WYSIWYG toolbar wraps the selection in inline code', async ({ page }) => {
   await expect.poll(() => getMarkdownContent(page)).toBe('hello world');
 
   await page.getByRole('button', { name: 'Preview Markdown' }).click();
-  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
   const editable = page.locator('.wysiwyg-editing');
   await expect(editable).toBeVisible();
 
@@ -214,7 +258,6 @@ test('WYSIWYG auto-matches backticks into inline code and undo cancels it', asyn
   await expect.poll(() => getMarkdownContent(page)).toBe('hello');
 
   await page.getByRole('button', { name: 'Preview Markdown' }).click();
-  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
   const editable = page.locator('.wysiwyg-editing');
   await expect(editable).toBeVisible();
 
@@ -256,7 +299,6 @@ test('WYSIWYG code blocks have a working copy button', async ({ page }) => {
   await expect.poll(() => getMarkdownContent(page)).toContain('```js');
 
   await page.getByRole('button', { name: 'Preview Markdown' }).click();
-  await page.getByRole('button', { name: 'Edit markdown (WYSIWYG)' }).click();
   const editable = page.locator('.wysiwyg-editing');
   const copyButton = editable.locator('.md-code-copy .copy-code-button');
   await expect(copyButton).toBeVisible();

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -98,6 +98,11 @@ describe('markdown utils', () => {
         expect(back).toBe(md);
     });
 
+    it('round-trips horizontal rules as three hyphens', () => {
+        expect(renderMarkdownPlain('---')).toContain('<hr>');
+        expect(htmlToMarkdown('<p>before</p><hr><p>after</p>')).toBe('before\n\n---\n\nafter');
+    });
+
     it('trailing empty lines are trimmed so WYSIWYG round-trips stay stable', () => {
         // The WYSIWYG editor keeps an empty line at the end of the document
         // (ensureTrailingEmptyLine); converting it back must not grow the

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -302,7 +302,8 @@ function getTurndownService(): TurndownService {
             headingStyle: 'atx',
             codeBlockStyle: 'fenced',
             bulletListMarker: '-',
-            emDelimiter: '*'
+            emDelimiter: '*',
+            hr: '---'
         });
         turndownService.use(gfm);
         // Inline code created by the WYSIWYG backtick auto-matching (see

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -852,7 +852,7 @@ func main() {
         code = starterCode[language] ?? '';
     }
 
-    function openMarkdownPreview() {
+    async function openMarkdownPreview() {
         const sourceTab = tabs[activeTabId];
         const sourceFileId = sourceTab?.fileId;
         const sourceFileName = sourceTab?.fileName || 'Solution';
@@ -868,6 +868,8 @@ func main() {
         }];
         activeTabId = tabs.length - 1;
         persistTabOrder();
+        await tick();
+        await enterPreviewEditMode();
     }
 
     // Builds the markdown snippet inserted when an image is pasted into a
@@ -903,14 +905,7 @@ func main() {
         return sourceEntry?.content ?? '';
     }
 
-    async function togglePreviewEditMode() {
-        if (previewEditMode) {
-            commitWysiwygEdits();
-            previewEditMode = false;
-            wysiwygSourceFileId = null;
-            showLinkInput = false;
-            return;
-        }
+    async function enterPreviewEditMode() {
         if (!activeTab?.sourceFileId) return;
         wysiwygSourceFileId = activeTab.sourceFileId;
         previewEditMode = true;
@@ -924,10 +919,86 @@ func main() {
         }
     }
 
+    async function togglePreviewEditMode() {
+        if (previewEditMode) {
+            commitWysiwygEdits();
+            previewEditMode = false;
+            wysiwygSourceFileId = null;
+            showLinkInput = false;
+            return;
+        }
+        await enterPreviewEditMode();
+    }
+
     function handleWysiwygInput() {
+        maybeAutoInsertHorizontalRule();
         maybeAutoCloseInlineCode();
         if (wysiwygDebounce) clearTimeout(wysiwygDebounce);
         wysiwygDebounce = setTimeout(commitWysiwygEdits, 300);
+    }
+
+    let applyingHorizontalRule = false;
+    function maybeAutoInsertHorizontalRule() {
+        if (applyingHorizontalRule || !wysiwygEl) return;
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) return;
+        const range = selection.getRangeAt(0);
+        if (!range.collapsed || !wysiwygEl.contains(range.startContainer)) return;
+
+        const parent = range.startContainer.nodeType === Node.ELEMENT_NODE
+            ? range.startContainer as HTMLElement
+            : range.startContainer.parentElement;
+        if (!parent || parent.closest('pre, code')) return;
+
+        let line: HTMLElement | null = parent;
+        while (line && line.parentElement !== wysiwygEl) line = line.parentElement;
+        if (!line || line.parentElement !== wysiwygEl || !/^(P|DIV)$/.test(line.tagName)) return;
+        if (line.childNodes.length !== 1 || line.firstChild?.nodeType !== Node.TEXT_NODE || line.textContent !== '---') return;
+
+        insertWysiwygHorizontalRule(line);
+    }
+
+    function insertWysiwygHorizontalRule(lineToReplace?: HTMLElement) {
+        if (!wysiwygEl) return false;
+        wysiwygEl.focus();
+        const selection = window.getSelection();
+        if (!selection) return false;
+        const selectedRange = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+        if (!lineToReplace && selectedRange && Array.from(wysiwygEl.querySelectorAll('table')).some((table) => selectedRange.intersectsNode(table))) return false;
+        if (lineToReplace) {
+            const lineRange = document.createRange();
+            lineRange.selectNodeContents(lineToReplace);
+            selection.removeAllRanges();
+            selection.addRange(lineRange);
+        } else if (selection.rangeCount === 0 || !wysiwygEl.contains(selection.anchorNode)) {
+            return false;
+        }
+
+        const existingRules = new Set(wysiwygEl.querySelectorAll('hr'));
+        applyingHorizontalRule = true;
+        try {
+            document.execCommand('insertHorizontalRule');
+        } finally {
+            applyingHorizontalRule = false;
+        }
+
+        const insertedRule = Array.from(wysiwygEl.querySelectorAll('hr')).find((rule) => !existingRules.has(rule));
+        if (!insertedRule) return false;
+
+        let next = insertedRule.nextSibling;
+        if (!next || (next instanceof HTMLElement && (next.tagName === 'HR' || next.contentEditable === 'false'))) {
+            const paragraph = document.createElement('p');
+            paragraph.innerHTML = '<br>';
+            insertedRule.after(paragraph);
+            next = paragraph;
+        }
+
+        const nextRange = document.createRange();
+        nextRange.selectNodeContents(next);
+        nextRange.collapse(true);
+        selection.removeAllRanges();
+        selection.addRange(nextRange);
+        return true;
     }
 
     // When the user types a closing backtick, try to match it with a previous
@@ -1190,6 +1261,10 @@ func main() {
             toggleInlineCode();
             return;
         }
+        if (command === 'insertHorizontalRule') {
+            if (insertWysiwygHorizontalRule()) handleWysiwygInput();
+            return;
+        }
         applyWysiwygCommand(command, btn.dataset.value);
     }
 
@@ -1205,6 +1280,10 @@ func main() {
         }
         if (command === 'inlineCode') {
             toggleInlineCode();
+            return;
+        }
+        if (command === 'insertHorizontalRule') {
+            if (insertWysiwygHorizontalRule()) handleWysiwygInput();
             return;
         }
         applyWysiwygCommand(command, btn.dataset.value);
@@ -2270,6 +2349,9 @@ func main() {
                             </button>
                             <button type="button" data-command="inlineCode" title="Inline code" aria-label="Inline code">
                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 11-6 6v3h9l3-3"/><path d="m22 12-4.6 4.6a2 2 0 0 1-2.8 0l-5.2-5.2a2 2 0 0 1 0-2.8L14 4"/></svg>
+                            </button>
+                            <button type="button" data-command="insertHorizontalRule" title="Horizontal rule" aria-label="Horizontal rule">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="4" y1="12" x2="20" y2="12"/></svg>
                             </button>
                             <span class="wysiwyg-separator"></span>
                             <button type="button" data-command="link" title="Insert link" aria-label="Insert link">


### PR DESCRIPTION
## Summary
- Open Markdown previews directly in WYSIWYG mode
- Convert exact three-hyphen lines into horizontal rules
- Add a horizontal-rule toolbar button
- Preserve Markdown round-tripping and table safety

## Tests
- 29 unit tests passed
- 9 Markdown Playwright tests passed
- Repository type check remains blocked by existing unrelated errors