### PR TITLE
feat: show progress during cloud sync and deletion

### DIFF
--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -84,6 +84,11 @@ export type CloudUser = {
 	photoURL: string | null;
 };
 
+export type CloudProgress = {
+	label: string;
+	value: number | null;
+};
+
 export type CloudSyncState = {
 	authStatus: CloudAuthStatus;
 	syncStatus: CloudOperationStatus;
@@ -93,6 +98,7 @@ export type CloudSyncState = {
 	remoteStatus: CloudRemoteStatus;
 	history: CloudRevision[];
 	error: string | null;
+	progress: CloudProgress | null;
 };
 
 type DeviceUserMeta = {
@@ -154,10 +160,19 @@ const initialState: CloudSyncState = {
 	resolution: null,
 	remoteStatus: 'unknown',
 	history: [],
-	error: null
+	error: null,
+	progress: null
 };
 
 export const cloudSyncState = writable<CloudSyncState>(initialState);
+
+function setCloudProgress(label: string, value: number | null): void {
+	cloudSyncState.update((state) => ({ ...state, progress: { label, value } }));
+}
+
+function clearCloudProgress(): void {
+	cloudSyncState.update((state) => (state.progress ? { ...state, progress: null } : state));
+}
 
 let activeAuth: Auth | null = null;
 let activeDb: Firestore | null = null;
@@ -641,7 +656,8 @@ function markSynced(
 		syncStatus: 'idle',
 		lastSyncedAt: meta.lastSyncedAt,
 		resolution,
-		error: null
+		error: null,
+		progress: null
 	}));
 	return true;
 }
@@ -731,7 +747,7 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 	if (isCloudRestoreInProgress()) return;
 	if (!navigator.onLine) {
 		if (isOperationCurrent(context)) {
-			cloudSyncState.update((state) => ({ ...state, syncStatus: 'offline', error: null }));
+			cloudSyncState.update((state) => ({ ...state, syncStatus: 'offline', error: null, progress: null }));
 		}
 		if (mode !== 'fetch') throw new Error('Connect to the internet before updating cloud progress.');
 		return;
@@ -741,13 +757,15 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 		...state,
 		syncStatus: 'syncing',
 		remoteStatus: 'loading',
-		error: null
+		error: null,
+		progress: { label: 'Preparing progress…', value: 10 }
 	}));
 	try {
 		await coordinateOtherContexts('flush');
 		if (!isOperationCurrent(context)) return;
 		const local = await readLocalSnapshot(context);
 		if (!isOperationCurrent(context)) return;
+		setCloudProgress('Reading cloud state…', 35);
 		const device = readDeviceMeta();
 		const accountId = cloudAccountId(context.projectId, context.uid);
 		const accountNeedsConfirmation = needsCloudAccountConfirmation(device.workspaceId, accountId);
@@ -760,7 +778,8 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 				...state,
 				resolution: 'account',
 				syncStatus: 'idle',
-				error: null
+				error: null,
+				progress: null
 			}));
 			return;
 		}
@@ -790,7 +809,8 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 					...state,
 					syncStatus: 'idle',
 					resolution: null,
-					error: null
+					error: null,
+					progress: null
 				}));
 			}
 			return;
@@ -801,7 +821,8 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 				...state,
 				resolution: 'local-changes',
 				syncStatus: 'idle',
-				error: null
+				error: null,
+				progress: null
 			}));
 			return;
 		}
@@ -811,15 +832,19 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 				...state,
 				resolution: 'conflict',
 				syncStatus: 'idle',
-				error: null
+				error: null,
+				progress: null
 			}));
 			return;
 		}
 		if (direction === 'upload') {
+			setCloudProgress('Uploading progress…', 55);
 			const uploaded = await uploadSnapshot(context.db, context.uid, local, remote);
 			if (!isOperationCurrent(context)) return;
+			setCloudProgress('Finalizing…', 85);
 			const updatedHistory = await readRemoteHistory(context.db, context.uid, uploaded);
 			if (!isOperationCurrent(context)) return;
+			setCloudProgress('Finalizing…', 95);
 			publishHistory(updatedHistory, uploaded.revisionId);
 			await finalizeCloudRevision(context, uploaded.checksum);
 			return;
@@ -828,14 +853,17 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 			throw new Error('No Cojudge Cloud snapshot exists for this account yet.');
 		}
 
+		setCloudProgress('Downloading from cloud…', 55);
 		const downloaded = await downloadSnapshot(context.db, context.uid, remote);
 		if (!isOperationCurrent(context)) return;
+		setCloudProgress('Applying cloud data…', 85);
 		const latest = await readRemoteMeta(context.db, context.uid);
 		if (!isOperationCurrent(context)) return;
 		if (!latest || latest.revisionId !== remote.revisionId) {
 			throw new Error('Cloud progress changed while downloading. Try again.');
 		}
 		await applyDownloadedSnapshot(context, downloaded, local, latest.checksum);
+		clearCloudProgress();
 	} catch (error) {
 		if (!isOperationCurrent(context)) return;
 		const offline = !navigator.onLine;
@@ -843,7 +871,8 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 			...state,
 			syncStatus: offline ? 'offline' : 'error',
 			remoteStatus: offline ? state.remoteStatus : 'error',
-			error: offline ? null : errorMessage(error)
+			error: offline ? null : errorMessage(error),
+			progress: null
 		}));
 		throw error;
 	}
@@ -1003,7 +1032,12 @@ async function runRevisionRestore(
 	context: OperationContext
 ): Promise<void> {
 	if (!browser || !isOperationCurrent(context)) return;
-	cloudSyncState.update((state) => ({ ...state, syncStatus: 'syncing', error: null }));
+	cloudSyncState.update((state) => ({
+		...state,
+		syncStatus: 'syncing',
+		error: null,
+		progress: { label: 'Restoring backup…', value: 35 }
+	}));
 	try {
 		if (!navigator.onLine) throw new Error('Connect to the internet before restoring cloud progress.');
 		if (get(cloudSyncState).resolution === 'account') {
@@ -1033,21 +1067,25 @@ async function runRevisionRestore(
 			selected = currentSlot;
 		}
 
+		setCloudProgress('Downloading backup…', 65);
 		const downloaded = await downloadSnapshot(context.db, context.uid, selected);
 		if (!isOperationCurrent(context)) return;
+		setCloudProgress('Applying backup…', 85);
 		const latest = await readRemoteMeta(context.db, context.uid);
 		if (!latest || latest.revisionId !== remote.revisionId) {
 			throw new Error('Cloud progress changed while restoring. Try again.');
 		}
 		if (!isOperationCurrent(context)) return;
 		await applyDownloadedSnapshot(context, downloaded, local, latest.checksum);
+		clearCloudProgress();
 	} catch (error) {
 		if (!isOperationCurrent(context)) return;
 		cloudSyncState.update((state) => ({
 			...state,
 			syncStatus: navigator.onLine ? 'error' : 'offline',
 			remoteStatus: navigator.onLine ? 'error' : state.remoteStatus,
-			error: navigator.onLine ? errorMessage(error) : null
+			error: navigator.onLine ? errorMessage(error) : null,
+			progress: null
 		}));
 		throw error;
 	}
@@ -1078,7 +1116,12 @@ async function runRevisionDelete(
 	context: OperationContext
 ): Promise<void> {
 	if (!browser || !isOperationCurrent(context)) return;
-	cloudSyncState.update((state) => ({ ...state, syncStatus: 'syncing', error: null }));
+	cloudSyncState.update((state) => ({
+		...state,
+		syncStatus: 'syncing',
+		error: null,
+		progress: { label: 'Deleting backup…', value: null }
+	}));
 	try {
 		if (!navigator.onLine) throw new Error('Connect to the internet before deleting a cloud backup.');
 		if (get(cloudSyncState).resolution === 'account') {
@@ -1125,13 +1168,14 @@ async function runRevisionDelete(
 		const updated = await refreshRemoteState(context.db, context.uid);
 		if (!isOperationCurrent(context)) return;
 		publishHistory(updated.history, updated.remote?.revisionId ?? null);
-		cloudSyncState.update((state) => ({ ...state, syncStatus: 'idle', error: null }));
+		cloudSyncState.update((state) => ({ ...state, syncStatus: 'idle', error: null, progress: null }));
 	} catch (error) {
 		if (!isOperationCurrent(context)) return;
 		cloudSyncState.update((state) => ({
 			...state,
 			syncStatus: navigator.onLine ? 'error' : 'offline',
-			error: navigator.onLine ? errorMessage(error) : null
+			error: navigator.onLine ? errorMessage(error) : null,
+			progress: null
 		}));
 		throw error;
 	}
@@ -1177,7 +1221,8 @@ function handleAuthUser(user: User | null, currentGeneration: number): void {
 			resolution: null,
 			remoteStatus: 'unknown',
 			history: [],
-			error: null
+			error: null,
+			progress: null
 		});
 		return;
 	}
@@ -1196,7 +1241,8 @@ function handleAuthUser(user: User | null, currentGeneration: number): void {
 		resolution: accountNeedsConfirmation ? 'account' : null,
 		remoteStatus: 'unknown',
 		history: [],
-		error: null
+		error: null,
+		progress: null
 	});
 	void checkCloudNow().catch(() => undefined);
 }
@@ -1307,12 +1353,17 @@ async function clearLocalDataAndSignOut(
 		{ mode: 'exclusive', ifAvailable: true },
 		async (lock) => {
 			if (!lock) throw new Error('Another Cojudge window is updating local data. Try again shortly.');
+			setCloudProgress('Checking cloud backup…', null);
 			if (requireCloudMatch) {
 				await coordinateOtherContexts('flush');
 				try {
 					const initialCheck = await inspectCloudSignOut(context);
-					if (initialCheck !== 'matching') return initialCheck;
+					if (initialCheck !== 'matching') {
+						clearCloudProgress();
+						return initialCheck;
+					}
 				} catch {
+					clearCloudProgress();
 					return 'unknown';
 				}
 			}
@@ -1323,6 +1374,7 @@ async function clearLocalDataAndSignOut(
 			let announced = false;
 			try {
 				if (!isOperationCurrent(context)) return 'unknown';
+				setCloudProgress('Deleting local data…', 55);
 				localStorage.setItem(CLOUD_RESTORE_LOCK_KEY, Date.now().toString());
 				if (requireCloudMatch) {
 					try {
@@ -1336,6 +1388,7 @@ async function clearLocalDataAndSignOut(
 				await signOutFirebase();
 
 				mutationStarted = true;
+				setCloudProgress('Finalizing…', 85);
 				applyProgressData({}, { replace: true });
 				clearProgressStorage(localStorage);
 				if (dotFilesSnapshot !== null) {
@@ -1356,6 +1409,7 @@ async function clearLocalDataAndSignOut(
 				}
 				throw error;
 			} finally {
+				clearCloudProgress();
 				if (!announced) {
 					resumeAfterCloudMutation();
 				}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1278,6 +1278,14 @@
                             </span>
                         </div>
                     </div>
+                    {#if $cloudSyncState.progress}
+                        <div class="cloud-progress" role="progressbar" aria-label={$cloudSyncState.progress.label} aria-valuenow={$cloudSyncState.progress.value ?? undefined} aria-valuemin={0} aria-valuemax={100}>
+                            <span class="cloud-progress-label">{$cloudSyncState.progress.label}</span>
+                            <div class="cloud-progress-track">
+                                <div class="cloud-progress-fill" class:indeterminate={$cloudSyncState.progress.value === null} style={$cloudSyncState.progress.value === null ? '' : `width: ${$cloudSyncState.progress.value}%`}></div>
+                            </div>
+                        </div>
+                    {/if}
                     {#if $cloudSyncState.resolution === 'local-changes'}
                         <div class="cloud-file-changes">
                             <div class="cloud-file-changes-heading">
@@ -2103,6 +2111,39 @@
     .cloud-sync-dot.pending {
         background: var(--color-medium);
         box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-medium) 16%, transparent);
+    }
+    .cloud-progress {
+        display: grid;
+        gap: 0.35rem;
+        margin-top: 0.5rem;
+    }
+    .cloud-progress-label {
+        color: var(--color-text-secondary);
+        font-size: 0.72rem;
+    }
+    .cloud-progress-track {
+        height: 0.4rem;
+        overflow: hidden;
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--color-text) 14%, transparent);
+    }
+    .cloud-progress-fill {
+        height: 100%;
+        border-radius: 999px;
+        background: var(--color-highlight);
+        transition: width 0.25s ease;
+    }
+    .cloud-progress-fill.indeterminate {
+        width: 35%;
+        animation: cloud-progress-slide 1.1s ease-in-out infinite;
+    }
+    @keyframes cloud-progress-slide {
+        0% {
+            transform: translateX(-110%);
+        }
+        100% {
+            transform: translateX(310%);
+        }
     }
     .cloud-file-changes {
         display: grid;


### PR DESCRIPTION
Adds a phase-based progress bar to the Cojudge Cloud modal so syncing (preparing/upload/download/apply), revision restore, revision delete, and sign-out local-data deletion visibly reflect progress instead of just a disabled button.

- Adds a `progress` field to `cloudSyncState` (`CloudProgress`: label + determinate value, or indeterminate).
- Advances progress through each stage in `runSync`, `runRevisionRestore`, `runRevisionDelete`, and `clearLocalDataAndSignOut`; cleared on every success/error/idle exit.
- Renders an accessible progress bar (`role=progressbar`, animated indeterminate when no percentage) in the cloud settings modal.