### PR TITLE
fix: stop local file changes modal from flashing in a refresh loop

### DIFF
--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -277,8 +277,11 @@ function saveUserMeta(context: OperationContext, userMeta: DeviceUserMeta): void
 	writeDeviceMeta(meta);
 }
 
-async function readLocalSnapshot(context: OperationContext): Promise<LocalSnapshot> {
-	window.dispatchEvent(new Event(CLOUD_FLUSH_EVENT));
+async function readLocalSnapshot(
+	context: OperationContext,
+	options: { flush?: boolean } = {}
+): Promise<LocalSnapshot> {
+	if (options.flush !== false) window.dispatchEvent(new Event(CLOUD_FLUSH_EVENT));
 	const data = collectProgressData(localStorage, { cloud: true });
 	const serialized = serializeProgressData(data);
 	const checksum = await hashProgress(serialized);
@@ -917,10 +920,10 @@ export function syncCloudNow(): Promise<void> {
 	return queueSync('push');
 }
 
-export async function refreshCloudLocalState(): Promise<boolean> {
+export async function refreshCloudLocalState(options: { flush?: boolean } = {}): Promise<boolean> {
 	const context = captureOperationContext();
 	if (!browser || !context || isCloudRestoreInProgress()) return false;
-	const local = await readLocalSnapshot(context);
+	const local = await readLocalSnapshot(context, options);
 	if (!isOperationCurrent(context)) return false;
 	const dirty = local.meta.lastSyncedHash
 		? local.checksum !== local.meta.lastSyncedHash
@@ -1259,11 +1262,14 @@ export function startCloudSync(): Promise<void> {
 
 	// Re-evaluate the local-changes resolution shortly after any local file
 	// save, so cloud indicators (e.g. the playground legend) stay current.
+	// The flush is skipped because this refresh is itself triggered by a file
+	// store save; flushing again would make flush handlers write to the store
+	// and retrigger this debounce in a self-sustaining loop.
 	fileStoreUnsubscribe = fileStore.subscribe(() => {
 		if (dirtyRefreshTimer) clearTimeout(dirtyRefreshTimer);
 		dirtyRefreshTimer = setTimeout(() => {
 			dirtyRefreshTimer = null;
-			void refreshCloudLocalState().catch(() => undefined);
+			void refreshCloudLocalState({ flush: false }).catch(() => undefined);
 		}, 500);
 	});
 

--- a/src/lib/components/CloudSyncModal.svelte
+++ b/src/lib/components/CloudSyncModal.svelte
@@ -94,8 +94,19 @@
 
     $: if (open) void openModal();
 
-    $: if (open && $cloudSyncState.resolution === 'local-changes') {
-        void loadCloudFileChanges();
+    // Load the file changes only when entering the local-changes state, not on
+    // every cloudSyncState emission. The store emits a new object for unrelated
+    // updates (e.g. dirty checks after local saves), and refetching on each one
+    // makes this section flicker between the diff and "Comparing with the cloud…".
+    let fileChangesLoadArmed = false;
+    $: {
+        const shouldLoadFileChanges = open && $cloudSyncState.resolution === 'local-changes';
+        if (shouldLoadFileChanges && !fileChangesLoadArmed) {
+            fileChangesLoadArmed = true;
+            void loadCloudFileChanges();
+        } else if (!shouldLoadFileChanges) {
+            fileChangesLoadArmed = false;
+        }
     }
 
     $: if (browser) {
@@ -111,6 +122,7 @@
     });
 
     async function loadCloudFileChanges() {
+        if (cloudFileChangesLoading) return;
         if ($cloudSyncState.authStatus !== 'signed-in' || $cloudSyncState.resolution !== 'local-changes') {
             cloudFileChanges = [];
             cloudFileChangesError = '';

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -788,6 +788,7 @@ func main() {
                 x.language === language
             );
             if (existingFile) {
+                if (existingFile.viewState === state) return s;
                 existingFile.viewState = state;
             }
             return {...s, [fkey]: JSON.stringify(files)};

--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -503,6 +503,7 @@
                 x.language === language
             );
             if (existingFile) {
+                if (existingFile.viewState === state) return s;
                 existingFile.viewState = state;
             }
             return {...s, [fkey]: JSON.stringify(files)};


### PR DESCRIPTION
## Problem
The **Local file changes** section in the cloud sync modal flickered endlessly — the diff appeared for a split second, disappeared back to `Comparing with the cloud…`, and repeated.

## Root cause
A self-sustaining feedback loop (~500ms per cycle):

1. The modal's reactive statement called `loadCloudFileChanges()` on **every** `cloudSyncState` emission (Svelte stores notify on any `update()` returning an object, even when the state value is unchanged).
2. Each fetch ran `readLocalSnapshot()`, which dispatches `CLOUD_FLUSH_EVENT`.
3. Editor pages' flush handlers called `fileStore.update(...)`, always producing a **new store object** even when the serialized content was identical.
4. The cloud-sync dirty-check debounce (500ms after any fileStore save) emitted another new state object → back to step 1.

The same loop also ran invisibly in the background whenever signed in on an editor page.

## Fix
- **`CloudSyncModal.svelte`**: the fetch is now edge-triggered (only when entering the `local-changes` state or reopening the modal), with a guard against overlapping fetches. Manual **Refresh** and post-discard reloads still work.
- **`cloudSync.ts`**: `readLocalSnapshot`/`refreshCloudLocalState` accept a `flush` option; the save-triggered dirty check skips the redundant flush, breaking the loop at its source.
- **Problem & playground pages**: `saveCurrentViewState()` returns the store unchanged when the view state is identical, so flushes no longer cause phantom saves.

## Verification
- `svelte-check`: no new errors (17 pre-existing, unchanged)
- `vitest run`: 73/73 tests pass
- `npm run build`: succeeds