### PR TITLE
feat: surface all local changes in cloud sync modal with discard buttons

### DIFF
--- a/src/lib/cloudFileChange.test.ts
+++ b/src/lib/cloudFileChange.test.ts
@@ -2,11 +2,21 @@ import { describe, expect, it } from 'vitest';
 import {
 	computeFileChanges,
 	computeLineDiff,
+	computeOtherChanges,
 	computeWhiteboardChange,
+	computeWorkspaceChanges,
+	discardChange,
 	discardFile,
 	isBlobContent,
+	CHECKBOXES_FILE_ID,
+	GAME_RESULT_FILE_ID_PREFIX,
+	SOLUTION_FILE_ID_PREFIX,
+	TESTCASES_FILE_ID_PREFIX,
+	USER_SETTINGS_FILE_ID,
 	WHITEBOARD_FILE_ID,
-	type FileStore
+	WORKSPACE_FILE_ID_PREFIX,
+	type FileStore,
+	type ProgressStore
 } from './cloudFileChange';
 
 function store(files: Array<{ fileId: string; fileName?: string; language: string; content: string }>): FileStore {
@@ -173,5 +183,142 @@ describe('discardFile', () => {
 		const entries = JSON.parse(updated.playground) as Array<Record<string, unknown>>;
 		expect(entries).toHaveLength(2);
 		expect(entries.map((entry) => entry.fileId).sort()).toEqual(['1', '2']);
+	});
+});
+
+describe('computeOtherChanges', () => {
+	it('detects a modified solution with a line diff', () => {
+		const local: ProgressStore = { solutions: { 'two-sum': 'return 2;' } };
+		const cloud: ProgressStore = { solutions: { 'two-sum': 'return 1;' } };
+		const changes = computeOtherChanges(local, cloud);
+		expect(changes).toHaveLength(1);
+		expect(changes[0].fileId).toBe(`${SOLUTION_FILE_ID_PREFIX}two-sum`);
+		expect(changes[0].fileName).toBe('Solution');
+		expect(changes[0].languages[0].lines).toContainEqual({ type: 'add', text: 'return 2;' });
+		expect(changes[0].languages[0].lines).toContainEqual({ type: 'remove', text: 'return 1;' });
+	});
+
+	it('detects test cases that only exist locally', () => {
+		const local: ProgressStore = { testcases: { 'two-sum': [{ input: '[2,7]' }] } };
+		const changes = computeOtherChanges(local, {});
+		expect(changes).toHaveLength(1);
+		expect(changes[0].fileId).toBe(`${TESTCASES_FILE_ID_PREFIX}two-sum`);
+		expect(changes[0].languages[0].local).toBe(true);
+		expect(changes[0].languages[0].cloud).toBe(false);
+	});
+
+	it('ignores test cases that match the cloud', () => {
+		const cases = { 'two-sum': [{ input: '[2,7]' }] };
+		expect(computeOtherChanges({ testcases: cases }, { testcases: cases })).toEqual([]);
+	});
+
+	it('detects game results differences', () => {
+		const local: ProgressStore = { 'game-results': { 'two-sum': [{ totalScore: 90 }] } };
+		const cloud: ProgressStore = { 'game-results': { 'two-sum': [] } };
+		const changes = computeOtherChanges(local, cloud);
+		expect(changes).toHaveLength(1);
+		expect(changes[0].fileId).toBe(`${GAME_RESULT_FILE_ID_PREFIX}two-sum`);
+	});
+
+	it('aggregates checkbox flips into one change', () => {
+		const local: ProgressStore = { 'user-checkboxes': { 'two-sum': true } };
+		const cloud: ProgressStore = { 'user-checkboxes': { 'two-sum': false, 'add-two-numbers': true } };
+		const changes = computeOtherChanges(local, cloud);
+		const checkbox = changes.find((change) => change.fileId === CHECKBOXES_FILE_ID);
+		expect(checkbox).toBeDefined();
+		const texts = checkbox!.languages[0].lines.map((line) => line.text);
+		expect(texts).toContain('two-sum: unchecked → checked');
+		expect(texts).toContain('add-two-numbers: checked → unchecked');
+	});
+
+	it('detects shared whiteboard keys', () => {
+		const local: ProgressStore = { 'cojudge-whiteboard-v1:share:abc': { elements: [{}] } };
+		const changes = computeOtherChanges(local, {});
+		expect(changes).toHaveLength(1);
+		expect(changes[0].fileId).toBe('storage:cojudge-whiteboard-v1:share:abc');
+		expect(changes[0].fileName).toContain('Shared whiteboard');
+	});
+
+	it('detects settings field changes with a readable diff', () => {
+		const local: ProgressStore = { 'user-settings': { theme: 'dark', fontSize: 14 } };
+		const cloud: ProgressStore = { 'user-settings': { theme: 'light', fontSize: 14 } };
+		const changes = computeOtherChanges(local, cloud);
+		const settings = changes.find((change) => change.fileId === USER_SETTINGS_FILE_ID);
+		expect(settings).toBeDefined();
+		const lines = settings!.languages[0].lines;
+		expect(lines).toContainEqual({ type: 'remove', text: 'theme: "light"' });
+		expect(lines).toContainEqual({ type: 'add', text: 'theme: "dark"' });
+		expect(lines.some((line) => String(line.text).startsWith('fontSize'))).toBe(false);
+	});
+});
+
+describe('computeWorkspaceChanges', () => {
+	it('flags a rename that produces no content diff', () => {
+		const local: ProgressStore = {
+			files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Renamed', language: 'python', content: 'x=1' }]) }
+		};
+		const cloud: ProgressStore = {
+			files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Original', language: 'python', content: 'x=1' }]) }
+		};
+		const changes = computeWorkspaceChanges(local, cloud, new Set());
+		expect(changes).toHaveLength(1);
+		expect(changes[0].fileId).toBe(`${WORKSPACE_FILE_ID_PREFIX}playground`);
+	});
+
+	it('skips workspaces already covered by a content change', () => {
+		const local: ProgressStore = {
+			files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Renamed', language: 'python', content: 'x=1' }]) }
+		};
+		const cloud: ProgressStore = {
+			files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Original', language: 'python', content: 'x=1' }]) }
+		};
+		expect(computeWorkspaceChanges(local, cloud, new Set(['playground']))).toEqual([]);
+	});
+
+	it('ignores identical workspaces', () => {
+		const files = { playground: JSON.stringify([{ fileId: '1', fileName: 'A', language: 'python', content: 'x=1' }]) };
+		expect(computeWorkspaceChanges({ files }, { files }, new Set())).toEqual([]);
+	});
+});
+
+describe('discardChange', () => {
+	it('restores a solution from the cloud', () => {
+		const local: ProgressStore = { solutions: { 'two-sum': 'return 2;' } };
+		const cloud: ProgressStore = { solutions: { 'two-sum': 'return 1;' } };
+		const updated = discardChange(local, `${SOLUTION_FILE_ID_PREFIX}two-sum`, cloud);
+		expect(updated.solutions).toEqual({ 'two-sum': 'return 1;' });
+	});
+
+	it('removes a solution that does not exist in the cloud', () => {
+		const local: ProgressStore = { solutions: { 'two-sum': 'return 2;', other: 'x' } };
+		const updated = discardChange(local, `${SOLUTION_FILE_ID_PREFIX}two-sum`, {});
+		expect(updated.solutions).toEqual({ other: 'x' });
+	});
+
+	it('restores test cases from the cloud', () => {
+		const local: ProgressStore = { testcases: { 'two-sum': [{ input: 'local' }] } };
+		const cloud: ProgressStore = { testcases: { 'two-sum': [{ input: 'cloud' }] } };
+		const updated = discardChange(local, `${TESTCASES_FILE_ID_PREFIX}two-sum`, cloud);
+		expect(updated.testcases).toEqual({ 'two-sum': [{ input: 'cloud' }] });
+	});
+
+	it('restores the checkboxes map wholesale', () => {
+		const local: ProgressStore = { 'user-checkboxes': { a: true } };
+		const cloud: ProgressStore = { 'user-checkboxes': { b: true } };
+		const updated = discardChange(local, CHECKBOXES_FILE_ID, cloud);
+		expect(updated['user-checkboxes']).toEqual({ b: true });
+	});
+
+	it('removes a shared whiteboard that does not exist in the cloud', () => {
+		const local: ProgressStore = { 'cojudge-whiteboard-v1:share:abc': { elements: [{}] } };
+		const updated = discardChange(local, 'storage:cojudge-whiteboard-v1:share:abc', {});
+		expect(updated['cojudge-whiteboard-v1:share:abc']).toBeUndefined();
+	});
+
+	it('restores a workspace files list from the cloud', () => {
+		const local: ProgressStore = { files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Renamed' }]) } };
+		const cloud: ProgressStore = { files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Original' }]) } };
+		const updated = discardChange(local, `${WORKSPACE_FILE_ID_PREFIX}playground`, cloud);
+		expect(JSON.parse((updated.files as Record<string, string>).playground)[0].fileName).toBe('Original');
 	});
 });

--- a/src/lib/cloudFileChange.ts
+++ b/src/lib/cloudFileChange.ts
@@ -3,6 +3,7 @@
 // raw store maps so this stays unit-testable.
 
 export type FileStore = Record<string, string>;
+export type ProgressStore = Record<string, unknown>;
 
 type EntryLike = {
 	fileId?: unknown;
@@ -41,6 +42,20 @@ export type FileChange = {
 export const WHITEBOARD_FILE_ID = 'whiteboard';
 export const WHITEBOARD_BOARD_KEY = 'cojudge-whiteboard-v1';
 export const WHITEBOARD_RESTORED_EVENT = 'cojudge:whiteboard-restored';
+export const SOLUTION_FILE_ID_PREFIX = 'solution:';
+export const TESTCASES_FILE_ID_PREFIX = 'testcases:';
+export const GAME_RESULT_FILE_ID_PREFIX = 'game-result:';
+export const WORKSPACE_FILE_ID_PREFIX = 'workspace:';
+export const STORAGE_FILE_ID_PREFIX = 'storage:';
+export const CHECKBOXES_FILE_ID = 'checkboxes';
+export const USER_SETTINGS_FILE_ID = 'user-settings';
+export const OTHER_CHANGE_FILE_ID_PREFIXES = [
+	SOLUTION_FILE_ID_PREFIX,
+	TESTCASES_FILE_ID_PREFIX,
+	GAME_RESULT_FILE_ID_PREFIX,
+	WORKSPACE_FILE_ID_PREFIX,
+	STORAGE_FILE_ID_PREFIX
+] as const;
 
 // UI/runtime fields that belong to the editor, not to the file itself. They are
 // carried over when a local file is discarded back to its cloud version.
@@ -195,6 +210,303 @@ export function computeFileChanges(localStore: FileStore, cloudStore: FileStore)
 		});
 	}
 	return changes;
+}
+
+function stableStringify(value: unknown): string {
+	if (value === null || typeof value !== 'object') return JSON.stringify(value) ?? 'null';
+	if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+	const entries = Object.entries(value as Record<string, unknown>)
+		.filter(([, v]) => v !== undefined)
+		.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+		.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+	return `{${entries.join(',')}}`;
+}
+
+function valuesEqual(a: unknown, b: unknown): boolean {
+	return stableStringify(a) === stableStringify(b);
+}
+
+function recordFrom(value: unknown): Record<string, unknown> {
+	return value && typeof value === 'object' && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function stringRecordFrom(value: unknown): Record<string, string> {
+	const result: Record<string, string> = {};
+	for (const [key, entry] of Object.entries(recordFrom(value))) {
+		if (typeof entry === 'string') result[key] = entry;
+	}
+	return result;
+}
+
+function summarizeValue(value: unknown): string {
+	if (value === undefined) return '';
+	const serialized = stableStringify(value);
+	return serialized.length > 200 ? `${serialized.slice(0, 200)}…` : serialized;
+}
+
+// Fallback change for a whole storage key when finer-grained diffing is not
+// available. Used for compound records (e.g. test case arrays) so users can
+// still see and discard the change.
+function wholeRecordChange(fileId: string, slug: string, fileName: string, localValue: unknown, cloudValue: unknown): FileChange {
+	const localContent = localValue === undefined ? null : JSON.stringify(localValue, null, 2);
+	const cloudContent = cloudValue === undefined ? null : JSON.stringify(cloudValue, null, 2);
+	return {
+		fileId,
+		slug,
+		fileName,
+		languages: [
+			{
+				language: 'value',
+				local: localValue !== undefined,
+				cloud: cloudValue !== undefined,
+				localContent,
+				cloudContent,
+				blob: true,
+				lines: []
+			}
+		]
+	};
+}
+
+// Compares the non-file parts of the cloud snapshot: solutions, test cases,
+// game results, checkboxes, shared whiteboards and settings.
+export function computeOtherChanges(localData: ProgressStore, cloudData: ProgressStore): FileChange[] {
+	const changes: FileChange[] = [];
+
+	// Solutions: one code string per problem slug.
+	const localSolutions = stringRecordFrom(localData['solutions']);
+	const cloudSolutions = stringRecordFrom(cloudData['solutions']);
+	for (const slug of new Set([...Object.keys(localSolutions), ...Object.keys(cloudSolutions)])) {
+		const localContent = localSolutions[slug] ?? null;
+		const cloudContent = cloudSolutions[slug] ?? null;
+		if (localContent === cloudContent) continue;
+		const blob = isBlobContent(localContent) || isBlobContent(cloudContent);
+		changes.push({
+			fileId: `${SOLUTION_FILE_ID_PREFIX}${slug}`,
+			slug,
+			fileName: 'Solution',
+			languages: [
+				{
+					language: 'code',
+					local: slug in localSolutions,
+					cloud: slug in cloudSolutions,
+					localContent,
+					cloudContent,
+					blob,
+					lines: blob
+						? []
+						: computeLineDiff(cloudContent?.split('\n') ?? [], localContent?.split('\n') ?? [])
+				}
+			]
+		});
+	}
+
+	// Test cases: one array of cases per problem slug. The cases are compact
+	// objects without a stable identity, so the whole array is treated as one
+	// blob change.
+	const localTestcases = recordFrom(localData['testcases']);
+	const cloudTestcases = recordFrom(cloudData['testcases']);
+	for (const slug of new Set([...Object.keys(localTestcases), ...Object.keys(cloudTestcases)])) {
+		const localValue = localTestcases[slug];
+		const cloudValue = cloudTestcases[slug];
+		if (valuesEqual(localValue, cloudValue)) continue;
+		changes.push(
+			wholeRecordChange(`${TESTCASES_FILE_ID_PREFIX}${slug}`, slug, 'Test cases', localValue, cloudValue)
+		);
+	}
+
+	// Game results: one array of results per problem slug, also compared whole.
+	const localResults = recordFrom(localData['game-results']);
+	const cloudResults = recordFrom(cloudData['game-results']);
+	for (const slug of new Set([...Object.keys(localResults), ...Object.keys(cloudResults)])) {
+		const localValue = localResults[slug];
+		const cloudValue = cloudResults[slug];
+		if (valuesEqual(localValue, cloudValue)) continue;
+		changes.push(
+			wholeRecordChange(`${GAME_RESULT_FILE_ID_PREFIX}${slug}`, slug, 'Game results', localValue, cloudValue)
+		);
+	}
+
+	// Progress checkboxes: aggregate into a single change listing each problem.
+	const localChecks = recordFrom(localData['user-checkboxes']);
+	const cloudChecks = recordFrom(cloudData['user-checkboxes']);
+	const checkboxLines: DiffLine[] = [];
+	for (const slug of new Set([...Object.keys(localChecks), ...Object.keys(cloudChecks)])) {
+		const localChecked = localChecks[slug] === true || localChecks[slug] === 'true';
+		const cloudChecked = cloudChecks[slug] === true || cloudChecks[slug] === 'true';
+		if (!(slug in localChecks) || !(slug in cloudChecks) || localChecked !== cloudChecked) {
+			checkboxLines.push({
+				type: 'same',
+				text: `${slug}: ${cloudChecked ? 'checked' : 'unchecked'} → ${localChecked ? 'checked' : 'unchecked'}`
+			});
+		}
+	}
+	if (checkboxLines.length > 0) {
+		changes.push({
+			fileId: CHECKBOXES_FILE_ID,
+			slug: 'solved',
+			fileName: 'Solved checkboxes',
+			languages: [
+				{
+					language: 'progress',
+					local: Object.keys(localChecks).length > 0,
+					cloud: Object.keys(cloudChecks).length > 0,
+					localContent: null,
+					cloudContent: null,
+					blob: false,
+					lines: checkboxLines
+				}
+			]
+		});
+	}
+
+	// Shared whiteboard boards, one extra localStorage key per shared board.
+	const sharePrefix = `${WHITEBOARD_BOARD_KEY}:share:`;
+	const shareKeys = new Set(
+		[...Object.keys(localData), ...Object.keys(cloudData)].filter((key) => key.startsWith(sharePrefix))
+	);
+	for (const key of shareKeys) {
+		const localBoard = localData[key];
+		const cloudBoard = cloudData[key];
+		const change = computeWhiteboardChange(localBoard, cloudBoard);
+		if (!change) continue;
+		change.fileId = `storage:${key}`;
+		change.fileName = `Shared whiteboard (${key.slice(sharePrefix.length)})`;
+		changes.push(change);
+	}
+
+	// User settings, compared per field so the diff stays readable.
+	const localSettings = recordFrom(localData['user-settings']);
+	const cloudSettings = recordFrom(cloudData['user-settings']);
+	const settingLines: DiffLine[] = [];
+	for (const key of new Set([...Object.keys(localSettings), ...Object.keys(cloudSettings)])) {
+		const localValue = localSettings[key];
+		const cloudValue = cloudSettings[key];
+		if (valuesEqual(localValue, cloudValue)) continue;
+		if (key in cloudSettings) {
+			settingLines.push({ type: 'remove', text: `${key}: ${summarizeValue(cloudValue)}` });
+		}
+		if (key in localSettings) {
+			settingLines.push({ type: 'add', text: `${key}: ${summarizeValue(localValue)}` });
+		}
+	}
+	if (settingLines.length > 0) {
+		changes.push({
+			fileId: USER_SETTINGS_FILE_ID,
+			slug: 'settings',
+			fileName: 'Settings',
+			languages: [
+				{
+					language: 'settings',
+					local: true,
+					cloud: true,
+					localContent: null,
+					cloudContent: null,
+					blob: false,
+					lines: settingLines
+				}
+			]
+		});
+	}
+
+	return changes;
+}
+
+// Catch-all for `files` store differences that produce no content diff (file
+// renames, reorders, or other metadata edits): one blob change per workspace
+// slug, skipped when a content-level change already covers that workspace.
+export function computeWorkspaceChanges(
+	localData: ProgressStore,
+	cloudData: ProgressStore,
+	coveredSlugs: Set<string>
+): FileChange[] {
+	const changes: FileChange[] = [];
+	const localFiles = recordFrom(localData['files']);
+	const cloudFiles = recordFrom(cloudData['files']);
+	for (const slug of new Set([...Object.keys(localFiles), ...Object.keys(cloudFiles)])) {
+		if (coveredSlugs.has(slug)) continue;
+		if (valuesEqual(localFiles[slug], cloudFiles[slug])) continue;
+		changes.push({
+			fileId: `${WORKSPACE_FILE_ID_PREFIX}${slug}`,
+			slug,
+			fileName: 'Files (names or order)',
+			languages: [
+				{
+					language: 'workspace',
+					local: slug in localFiles,
+					cloud: slug in cloudFiles,
+					localContent: null,
+					cloudContent: null,
+					blob: true,
+					lines: []
+				}
+			]
+		});
+	}
+	return changes;
+}
+
+// Reverts one non-file change to its cloud value inside a progress data map,
+// returning the updated map. Unknown fileIds are ignored.
+export function discardChange(data: ProgressStore, fileId: string, cloudData: ProgressStore): ProgressStore {
+	const result: ProgressStore = { ...data };
+	const assign = (key: string, value: unknown) => {
+		if (value === undefined) delete result[key];
+		else result[key] = value;
+	};
+
+	if (fileId.startsWith(SOLUTION_FILE_ID_PREFIX)) {
+		const slug = fileId.slice(SOLUTION_FILE_ID_PREFIX.length);
+		const solutions = { ...stringRecordFrom(result['solutions']) };
+		const cloudSolutions = stringRecordFrom(cloudData['solutions']);
+		if (slug in cloudSolutions) solutions[slug] = cloudSolutions[slug];
+		else delete solutions[slug];
+		assign('solutions', solutions);
+		return result;
+	}
+	if (fileId.startsWith(TESTCASES_FILE_ID_PREFIX)) {
+		const slug = fileId.slice(TESTCASES_FILE_ID_PREFIX.length);
+		const testcases = { ...recordFrom(result['testcases']) };
+		const cloudTestcases = recordFrom(cloudData['testcases']);
+		if (slug in cloudTestcases) testcases[slug] = cloudTestcases[slug];
+		else delete testcases[slug];
+		assign('testcases', testcases);
+		return result;
+	}
+	if (fileId.startsWith(GAME_RESULT_FILE_ID_PREFIX)) {
+		const slug = fileId.slice(GAME_RESULT_FILE_ID_PREFIX.length);
+		const results = { ...recordFrom(result['game-results']) };
+		const cloudResults = recordFrom(cloudData['game-results']);
+		if (slug in cloudResults) results[slug] = cloudResults[slug];
+		else delete results[slug];
+		assign('game-results', results);
+		return result;
+	}
+	if (fileId === CHECKBOXES_FILE_ID) {
+		assign('user-checkboxes', cloudData['user-checkboxes']);
+		return result;
+	}
+	if (fileId === USER_SETTINGS_FILE_ID) {
+		assign('user-settings', cloudData['user-settings']);
+		return result;
+	}
+	if (fileId.startsWith(WORKSPACE_FILE_ID_PREFIX)) {
+		const slug = fileId.slice(WORKSPACE_FILE_ID_PREFIX.length);
+		const files = { ...recordFrom(result['files']) };
+		const cloudFiles = recordFrom(cloudData['files']);
+		if (slug in cloudFiles) files[slug] = cloudFiles[slug];
+		else delete files[slug];
+		assign('files', files);
+		return result;
+	}
+	if (fileId.startsWith(STORAGE_FILE_ID_PREFIX)) {
+		const key = fileId.slice(STORAGE_FILE_ID_PREFIX.length);
+		assign(key, cloudData[key]);
+		return result;
+	}
+	return result;
 }
 
 // Describes whether the whiteboard board differs from the cloud. The board is a

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -47,13 +47,20 @@ import { FORK_TRANSFER_STORAGE_KEY } from '$lib/forkTransfer';
 import fileStore, { fileSyncVersion } from '$lib/stores/fileStore';
 import {
 	computeFileChanges,
+	computeOtherChanges,
 	computeWhiteboardChange,
+	computeWorkspaceChanges,
+	discardChange,
 	discardFile,
+	OTHER_CHANGE_FILE_ID_PREFIXES,
+	CHECKBOXES_FILE_ID,
+	USER_SETTINGS_FILE_ID,
 	WHITEBOARD_BOARD_KEY,
 	WHITEBOARD_FILE_ID,
 	WHITEBOARD_RESTORED_EVENT,
 	type FileChange,
-	type FileStore
+	type FileStore,
+	type ProgressStore
 } from '$lib/cloudFileChange';
 
 const DEVICE_META_KEY = 'cojudge-cloud-sync-meta';
@@ -957,10 +964,14 @@ export async function fetchCloudFileChanges(): Promise<FileChange[]> {
 	const localFiles = (local.data.files as FileStore | undefined) ?? {};
 	const localBoard = local.data[WHITEBOARD_BOARD_KEY];
 
-	const changes: FileChange[] = computeFileChanges(localFiles, {});
-	const localBoardChange = computeWhiteboardChange(localBoard, null);
-	if (localBoardChange) changes.push(localBoardChange);
-	if (!remote) return changes;
+	if (!remote) {
+		const changes: FileChange[] = computeFileChanges(localFiles, {});
+		const localBoardChange = computeWhiteboardChange(localBoard, null);
+		if (localBoardChange) changes.push(localBoardChange);
+		changes.push(...computeOtherChanges(local.data, {}));
+		changes.push(...computeWorkspaceChanges(local.data, {}, new Set(changes.map((change) => change.slug))));
+		return changes;
+	}
 
 	const downloaded = await downloadSnapshot(context.db, context.uid, remote);
 	if (!isOperationCurrent(context)) return [];
@@ -970,6 +981,10 @@ export async function fetchCloudFileChanges(): Promise<FileChange[]> {
 	const mergedChanges: FileChange[] = computeFileChanges(localFiles, cloudFiles);
 	const whiteboardChange = computeWhiteboardChange(localBoard, cloudBoard);
 	if (whiteboardChange) mergedChanges.push(whiteboardChange);
+	mergedChanges.push(...computeOtherChanges(local.data, downloaded));
+	mergedChanges.push(
+		...computeWorkspaceChanges(local.data, downloaded, new Set(mergedChanges.map((change) => change.slug)))
+	);
 	return mergedChanges;
 }
 
@@ -995,6 +1010,11 @@ export async function discardLocalFileChange(fileId: string): Promise<void> {
 			localStorage.setItem(WHITEBOARD_BOARD_KEY, JSON.stringify(cloudBoard));
 		}
 		window.dispatchEvent(new CustomEvent(WHITEBOARD_RESTORED_EVENT));
+	} else if (isOtherChangeFileId(fileId)) {
+		const contextSnapshot = await readLocalSnapshot(context);
+		if (!isOperationCurrent(context)) return;
+		const updated = discardChange(contextSnapshot.data as ProgressStore, fileId, downloaded);
+		applyProgressData(updated, { replace: true });
 	} else {
 		const cloudFiles = (downloaded.files ?? {}) as FileStore;
 		const localStore = readLocalFilesStore();
@@ -1004,6 +1024,14 @@ export async function discardLocalFileChange(fileId: string): Promise<void> {
 		fileSyncVersion.update((version) => version + 1);
 	}
 	await refreshCloudLocalState();
+}
+
+function isOtherChangeFileId(fileId: string): boolean {
+	return (
+		fileId === CHECKBOXES_FILE_ID
+		|| fileId === USER_SETTINGS_FILE_ID
+		|| OTHER_CHANGE_FILE_ID_PREFIXES.some((prefix) => fileId.startsWith(prefix))
+	);
 }
 
 async function inspectCloudSignOut(context: OperationContext): Promise<CloudSignOutCheck> {

--- a/src/lib/components/CloudSyncModal.svelte
+++ b/src/lib/components/CloudSyncModal.svelte
@@ -451,7 +451,7 @@
                 {#if $cloudSyncState.resolution === 'local-changes'}
                     <div class="cloud-file-changes">
                         <div class="cloud-file-changes-heading">
-                            <strong>Local file changes</strong>
+                            <strong>Local changes</strong>
                             <button class="btn cloud-file-reload" type="button" onclick={loadCloudFileChanges} disabled={cloudActionPending}>{cloudFileChangesLoading ? 'Comparing…' : 'Refresh'}</button>
                         </div>
                         {#if cloudFileChangesError}
@@ -459,7 +459,7 @@
                         {:else if cloudFileChangesLoading}
                             <p class="cloud-file-changes-empty">Comparing with the cloud…</p>
                         {:else if cloudFileChanges.length === 0}
-                            <p class="cloud-file-changes-empty">No file content differs. There may still be changes in solutions, test cases, whiteboard drawings or settings.</p>
+                            <p class="cloud-file-changes-empty">No differences found. Local data matches the latest cloud version.</p>
                         {:else}
                             {#each cloudFileChanges as change}
                                 <div class="cloud-file-change">


### PR DESCRIPTION
The cloud sync modal previously only compared file contents, so changes to solutions, test cases, game results, checkboxes, whiteboards, or settings fell back to a static `No file content differs` message with no way to discard them.

Now every changed entry is listed with a readable diff (or a blob note for JSON payloads) and a Discard button that restores just that item from the cloud.