### PR TITLE
fix: cloud sync UX polish and discard/whiteboard bugs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
+				"@tauri-apps/api": "^2.11.1",
 				"dockerode": "^5.0.1",
 				"tar-stream": "^3.1.7",
 				"turndown": "^7.2.4",
@@ -1990,6 +1991,16 @@
 				"@sveltejs/vite-plugin-svelte": "^6.0.0-next.0",
 				"svelte": "^5.0.0",
 				"vite": "^6.3.0 || ^7.0.0"
+			}
+		},
+		"node_modules/@tauri-apps/api": {
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.11.1.tgz",
+			"integrity": "sha512-M2FPuYND2m+wh5hfW9ZpSdxMPdEJovPBWwoHJmwUpysTYNHaOkVFN419m/K0LIgjb/7KU2vBgsUepJWugQCvAA==",
+			"license": "Apache-2.0 OR MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/tauri"
 			}
 		},
 		"node_modules/@tauri-apps/cli": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"vitest": "^1.1.5"
 	},
 	"dependencies": {
+		"@tauri-apps/api": "^2.11.1",
 		"dockerode": "^5.0.1",
 		"tar-stream": "^3.1.7",
 		"turndown": "^7.2.4",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,13 +10,18 @@
 		"frontendDist": "frontend"
 	},
 	"app": {
-		"windows": [],
+		"windows": [
+  		{
+        "label": "main",
+    		"zoomHotkeysEnabled": true
+  		}
+		],
 		"security": {
 			"capabilities": [
 				{
 					"identifier": "default",
-					"windows": ["main-*"],
-					"permissions": ["allow-new-window", "allow-google-oauth-access-token", "opener:default"],
+					"windows": ["main", "main-*"],
+					"permissions": ["allow-new-window", "allow-google-oauth-access-token", "opener:default", "core:webview:allow-set-webview-zoom"],
 					"remote": {
 						"urls": ["http://127.0.0.1:5173/*", "http://cojudge.localhost:5376/*"]
 					}

--- a/src/lib/cloudFileChange.test.ts
+++ b/src/lib/cloudFileChange.test.ts
@@ -155,6 +155,47 @@ describe('discardFile', () => {
 		expect(entries[0].lastUpdated).toBe(200);
 	});
 
+	it('restores cloud order instead of keeping the local order field', () => {
+		const localStore: FileStore = {
+			playground: JSON.stringify([
+				{ fileId: '1', fileName: 'Solution', language: 'python', content: 'print(2)', order: 5, isOpen: true }
+			])
+		};
+		const cloudStore: FileStore = {
+			playground: JSON.stringify([
+				{ fileId: '1', fileName: 'Solution', language: 'python', content: 'print(1)', order: 1 }
+			])
+		};
+
+		const updated = discardFile(localStore, '1', cloudStore);
+		const entries = JSON.parse(updated.playground) as Array<Record<string, unknown>>;
+		expect(entries[0].content).toBe('print(1)');
+		expect(entries[0].order).toBe(1);
+		expect(entries[0].isOpen).toBe(true);
+	});
+
+	it('replaces a file in place so sibling order (and local-only files) stay put', () => {
+		const localStore: FileStore = {
+			playground: JSON.stringify([
+				{ fileId: '1', fileName: 'A', language: 'python', content: 'local-a' },
+				{ fileId: 'dot', fileName: '.env', language: 'text', content: 'SECRET=1' },
+				{ fileId: '2', fileName: 'B', language: 'python', content: 'b' }
+			])
+		};
+		const cloudStore: FileStore = {
+			playground: JSON.stringify([
+				{ fileId: '1', fileName: 'A', language: 'python', content: 'cloud-a' },
+				{ fileId: '2', fileName: 'B', language: 'python', content: 'b' }
+			])
+		};
+
+		const updated = discardFile(localStore, '1', cloudStore);
+		const entries = JSON.parse(updated.playground) as Array<Record<string, unknown>>;
+		expect(entries.map((entry) => entry.fileId)).toEqual(['1', 'dot', '2']);
+		expect(entries[0].content).toBe('cloud-a');
+		expect(entries[1].fileName).toBe('.env');
+	});
+
 	it('removes a local-only file when discarded', () => {
 		const localStore: FileStore = {
 			playground: JSON.stringify([
@@ -320,5 +361,31 @@ describe('discardChange', () => {
 		const cloud: ProgressStore = { files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Original' }]) } };
 		const updated = discardChange(local, `${WORKSPACE_FILE_ID_PREFIX}playground`, cloud);
 		expect(JSON.parse((updated.files as Record<string, string>).playground)[0].fileName).toBe('Original');
+	});
+});
+
+describe('discard residual workspace noise', () => {
+	it('does not leave a workspace change after discarding matching content in place', () => {
+		// Mirrors cloud-sanitized entries (no editor-only fields). Previously,
+		// discardFile appended restored entries and kept local `order`, which
+		// made a phantom "Files (names or order)" change appear after discard.
+		const localStore: FileStore = {
+			playground: JSON.stringify([
+				{ fileId: '1', fileName: 'A', language: 'python', content: 'local', order: 2 },
+				{ fileId: '2', fileName: 'B', language: 'python', content: 'b', order: 1 }
+			])
+		};
+		const cloudStore: FileStore = {
+			playground: JSON.stringify([
+				{ fileId: '1', fileName: 'A', language: 'python', content: 'cloud', order: 0 },
+				{ fileId: '2', fileName: 'B', language: 'python', content: 'b', order: 1 }
+			])
+		};
+
+		const updated = discardFile(localStore, '1', cloudStore);
+		expect(computeFileChanges(updated, cloudStore)).toEqual([]);
+		expect(
+			computeWorkspaceChanges({ files: updated }, { files: cloudStore }, new Set())
+		).toEqual([]);
 	});
 });

--- a/src/lib/cloudFileChange.ts
+++ b/src/lib/cloudFileChange.ts
@@ -59,6 +59,9 @@ export const OTHER_CHANGE_FILE_ID_PREFIXES = [
 
 // UI/runtime fields that belong to the editor, not to the file itself. They are
 // carried over when a local file is discarded back to its cloud version.
+// Note: `order` is intentionally excluded — it is a cloud-synced field, so
+// discarding must restore the cloud order or a residual "Files (names or order)"
+// change appears after every content discard.
 const UI_FIELDS = [
 	'isOpen',
 	'isActive',
@@ -66,8 +69,7 @@ const UI_FIELDS = [
 	'viewState',
 	'output',
 	'logs',
-	'lastSharedContent',
-	'order'
+	'lastSharedContent'
 ] as const;
 
 function parseEntries(store: FileStore, slug: string): Array<Record<string, unknown>> {
@@ -536,7 +538,9 @@ export function computeWhiteboardChange(localBoard: unknown, cloudBoard: unknown
 
 // Reverts a single file to its cloud version: locals that only exist locally are
 // removed, and entries the file still owns in the cloud are restored while
-// carrying over editor UI state.
+// carrying over editor UI state. Restored entries replace matching local slots
+// in place so sibling files (and array order) stay put — otherwise discarding
+// content leaves a residual "Files (names or order)" workspace change.
 export function discardFile(
 	localStore: FileStore,
 	fileId: string,
@@ -550,26 +554,45 @@ export function discardFile(
 		const cloudEntries = parseEntries(cloudStore, slug).filter((entry) => entry['fileId'] === fileId);
 		if (localEntries.length === 0 && cloudEntries.length === 0) continue;
 
-		const kept = entries.filter((entry) => entry['fileId'] !== fileId);
 		if (cloudEntries.length === 0) {
-			result[slug] = JSON.stringify(kept);
+			result[slug] = JSON.stringify(entries.filter((entry) => entry['fileId'] !== fileId));
 			continue;
 		}
 
-		const restored = cloudEntries.map((cloudEntry) => {
-			const localEntry = localEntries.find(
-				(entry) => entry['language'] === cloudEntry['language']
-			);
+		const restoredByLanguage = new Map<string, Record<string, unknown>>();
+		for (const cloudEntry of cloudEntries) {
+			const language = cloudEntry['language'];
+			const langKey = typeof language === 'string' ? language : '';
+			const localEntry = localEntries.find((entry) => entry['language'] === cloudEntry['language']);
 			const merged = { ...cloudEntry };
 			if (localEntry) {
 				for (const field of UI_FIELDS) {
 					if (localEntry[field] !== undefined) merged[field] = localEntry[field];
 				}
 			}
-			return merged;
-		});
+			restoredByLanguage.set(langKey, merged);
+		}
 
-		result[slug] = JSON.stringify([...kept, ...restored]);
+		const usedLanguages = new Set<string>();
+		const next: Array<Record<string, unknown>> = [];
+		for (const entry of entries) {
+			if (entry['fileId'] !== fileId) {
+				next.push(entry);
+				continue;
+			}
+			const language = entry['language'];
+			const langKey = typeof language === 'string' ? language : '';
+			const restored = restoredByLanguage.get(langKey);
+			if (restored) {
+				next.push(restored);
+				usedLanguages.add(langKey);
+			}
+		}
+		for (const [langKey, restored] of restoredByLanguage) {
+			if (!usedLanguages.has(langKey)) next.push(restored);
+		}
+
+		result[slug] = JSON.stringify(next);
 	}
 	return result;
 }

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -64,6 +64,7 @@ import {
 } from '$lib/cloudFileChange';
 
 const DEVICE_META_KEY = 'cojudge-cloud-sync-meta';
+const CLOUD_CLONE_KEY = 'cojudge-cloud-clone';
 const LOCAL_CLEAR_COMPLETE_KEY = 'cojudge-cloud-local-clear-complete';
 const SYNC_INTERVAL_MS = 5 * 60 * 1000;
 const MAX_SNAPSHOT_BYTES = 6 * 1024 * 1024;
@@ -138,6 +139,18 @@ type RemoteSnapshotMeta = {
 	meaningful: boolean;
 };
 
+type CloudCloneRecord = {
+	accountId: string;
+	checksum: string;
+	revisionId: string | null;
+	serialized: string;
+};
+
+type DownloadedSnapshot = {
+	data: ProgressData;
+	serialized: string;
+};
+
 type SyncMode = SyncIntent | 'force-upload' | 'force-download';
 
 type OperationContext = {
@@ -198,6 +211,7 @@ let syncContext: OperationContext | null = null;
 let authEpoch = 0;
 let generation = 0;
 let observedAuthIdentity = '';
+let memoryCloudClone: CloudCloneRecord | null = null;
 
 function userView(user: User): CloudUser {
 	return {
@@ -282,6 +296,70 @@ function saveUserMeta(context: OperationContext, userMeta: DeviceUserMeta): void
 	const meta = readDeviceMeta();
 	meta.users[cloudAccountId(context.projectId, context.uid)] = userMeta;
 	writeDeviceMeta(meta);
+}
+
+function parseCloudCloneRecord(raw: string | null): CloudCloneRecord | null {
+	if (!raw) return null;
+	try {
+		const parsed = JSON.parse(raw) as Partial<CloudCloneRecord>;
+		if (
+			typeof parsed.accountId !== 'string'
+			|| typeof parsed.checksum !== 'string'
+			|| typeof parsed.serialized !== 'string'
+			|| (parsed.revisionId !== null && typeof parsed.revisionId !== 'string' && parsed.revisionId !== undefined)
+		) {
+			return null;
+		}
+		return {
+			accountId: parsed.accountId,
+			checksum: parsed.checksum,
+			revisionId: typeof parsed.revisionId === 'string' ? parsed.revisionId : null,
+			serialized: parsed.serialized
+		};
+	} catch {
+		return null;
+	}
+}
+
+function readCloudClone(accountId: string): { checksum: string; revisionId: string | null; data: ProgressData } | null {
+	const record =
+		memoryCloudClone?.accountId === accountId
+			? memoryCloudClone
+			: parseCloudCloneRecord(browser ? localStorage.getItem(CLOUD_CLONE_KEY) : null);
+	if (!record || record.accountId !== accountId) return null;
+	if (memoryCloudClone?.accountId !== accountId) memoryCloudClone = record;
+	try {
+		const parsed = JSON.parse(record.serialized);
+		if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+		return {
+			checksum: record.checksum,
+			revisionId: record.revisionId,
+			data: parsed as ProgressData
+		};
+	} catch {
+		return null;
+	}
+}
+
+function writeCloudClone(
+	accountId: string,
+	checksum: string,
+	serialized: string,
+	revisionId: string | null = null
+): void {
+	const record: CloudCloneRecord = { accountId, checksum, revisionId, serialized };
+	memoryCloudClone = record;
+	if (!browser) return;
+	try {
+		localStorage.setItem(CLOUD_CLONE_KEY, JSON.stringify(record));
+	} catch (error) {
+		console.warn('Cojudge Cloud could not persist the local cloud clone:', error);
+	}
+}
+
+function clearCloudClone(): void {
+	memoryCloudClone = null;
+	if (browser) localStorage.removeItem(CLOUD_CLONE_KEY);
 }
 
 async function readLocalSnapshot(
@@ -629,7 +707,7 @@ async function downloadSnapshot(
 	db: Firestore,
 	uid: string,
 	meta: RemoteSnapshotMeta
-): Promise<ProgressData> {
+): Promise<DownloadedSnapshot> {
 	const result = await getDocsFromServer(query(partsRef(db, uid, meta.snapshotId), orderBy('index')));
 	if (result.size !== meta.partCount) throw new Error('Cloud snapshot is incomplete.');
 
@@ -649,7 +727,21 @@ async function downloadSnapshot(
 	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
 		throw new Error('Cloud snapshot has an invalid format.');
 	}
-	return parsed as ProgressData;
+	return { data: parsed as ProgressData, serialized };
+}
+
+async function ensureCloudClone(
+	context: OperationContext,
+	remote: RemoteSnapshotMeta
+): Promise<ProgressData> {
+	const accountId = cloudAccountId(context.projectId, context.uid);
+	const cached = readCloudClone(accountId);
+	if (cached && cached.checksum === remote.checksum) return cached.data;
+
+	const downloaded = await downloadSnapshot(context.db, context.uid, remote);
+	if (!isOperationCurrent(context)) return downloaded.data;
+	writeCloudClone(accountId, remote.checksum, downloaded.serialized, remote.revisionId);
+	return downloaded.data;
 }
 
 function markSynced(
@@ -814,8 +906,17 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 						mode
 					);
 		if (direction === 'none') {
-			if (remote) await finalizeCloudRevision(context, remote.checksum);
-			else {
+			if (remote) {
+				if (local.checksum === remote.checksum) {
+					writeCloudClone(
+						cloudAccountId(context.projectId, context.uid),
+						remote.checksum,
+						local.serialized,
+						remote.revisionId
+					);
+				}
+				await finalizeCloudRevision(context, remote.checksum);
+			} else {
 				if (!isOperationCurrent(context)) return;
 				cloudSyncState.update((state) => ({
 					...state,
@@ -828,7 +929,15 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 			return;
 		}
 		if (direction === 'pending-upload') {
-			if (!isOperationCurrent(context)) return;
+			if (remote) {
+				setCloudProgress('Caching cloud copy…', 70);
+				try {
+					await ensureCloudClone(context, remote);
+				} catch {
+					// Compare can still fall back to a live download later.
+				}
+				if (!isOperationCurrent(context)) return;
+			}
 			cloudSyncState.update((state) => ({
 				...state,
 				resolution: 'local-changes',
@@ -839,7 +948,15 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 			return;
 		}
 		if (direction === 'conflict') {
-			if (!isOperationCurrent(context)) return;
+			if (remote) {
+				setCloudProgress('Caching cloud copy…', 70);
+				try {
+					await ensureCloudClone(context, remote);
+				} catch {
+					// Compare can still fall back to a live download later.
+				}
+				if (!isOperationCurrent(context)) return;
+			}
 			cloudSyncState.update((state) => ({
 				...state,
 				resolution: 'conflict',
@@ -853,6 +970,12 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 			setCloudProgress('Uploading progress…', 55);
 			const uploaded = await uploadSnapshot(context.db, context.uid, local, remote);
 			if (!isOperationCurrent(context)) return;
+			writeCloudClone(
+				cloudAccountId(context.projectId, context.uid),
+				uploaded.checksum,
+				local.serialized,
+				uploaded.revisionId
+			);
 			setCloudProgress('Finalizing…', 85);
 			const updatedHistory = await readRemoteHistory(context.db, context.uid, uploaded);
 			if (!isOperationCurrent(context)) return;
@@ -868,13 +991,19 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 		setCloudProgress('Downloading from cloud…', 55);
 		const downloaded = await downloadSnapshot(context.db, context.uid, remote);
 		if (!isOperationCurrent(context)) return;
+		writeCloudClone(
+			cloudAccountId(context.projectId, context.uid),
+			remote.checksum,
+			downloaded.serialized,
+			remote.revisionId
+		);
 		setCloudProgress('Applying cloud data…', 85);
 		const latest = await readRemoteMeta(context.db, context.uid);
 		if (!isOperationCurrent(context)) return;
 		if (!latest || latest.revisionId !== remote.revisionId) {
 			throw new Error('Cloud progress changed while downloading. Try again.');
 		}
-		await applyDownloadedSnapshot(context, downloaded, local, latest.checksum);
+		await applyDownloadedSnapshot(context, downloaded.data, local, latest.checksum);
 		clearCloudProgress();
 	} catch (error) {
 		if (!isOperationCurrent(context)) return;
@@ -954,15 +1083,40 @@ function readLocalFilesStore(): FileStore {
 	}
 }
 
+function fileChangesAgainstCloud(local: ProgressData, cloud: ProgressData): FileChange[] {
+	const localFiles = (local.files as FileStore | undefined) ?? {};
+	const cloudFiles = (cloud.files as FileStore | undefined) ?? {};
+	const localBoard = local[WHITEBOARD_BOARD_KEY];
+	const cloudBoard = cloud[WHITEBOARD_BOARD_KEY];
+
+	const mergedChanges: FileChange[] = computeFileChanges(localFiles, cloudFiles);
+	const whiteboardChange = computeWhiteboardChange(localBoard, cloudBoard);
+	if (whiteboardChange) mergedChanges.push(whiteboardChange);
+	mergedChanges.push(...computeOtherChanges(local, cloud));
+	mergedChanges.push(
+		...computeWorkspaceChanges(local, cloud, new Set(mergedChanges.map((change) => change.slug)))
+	);
+	return mergedChanges;
+}
+
 export async function fetchCloudFileChanges(): Promise<FileChange[]> {
 	const context = captureOperationContext();
 	if (!browser || !context || isCloudRestoreInProgress()) return [];
 	const local = await readLocalSnapshot(context);
 	if (!isOperationCurrent(context)) return [];
-	const remote = await readRemoteMeta(context.db, context.uid);
-	if (!isOperationCurrent(context)) return [];
+	const accountId = cloudAccountId(context.projectId, context.uid);
 	const localFiles = (local.data.files as FileStore | undefined) ?? {};
 	const localBoard = local.data[WHITEBOARD_BOARD_KEY];
+
+	// Prefer the local cloud clone so diffs never wait on the network when the
+	// last-synced cloud copy is already cached (the common local-changes case).
+	const cached = readCloudClone(accountId);
+	if (cached && local.meta.lastSyncedHash && cached.checksum === local.meta.lastSyncedHash) {
+		return fileChangesAgainstCloud(local.data, cached.data);
+	}
+
+	const remote = await readRemoteMeta(context.db, context.uid);
+	if (!isOperationCurrent(context)) return [];
 
 	if (!remote) {
 		const changes: FileChange[] = computeFileChanges(localFiles, {});
@@ -973,19 +1127,9 @@ export async function fetchCloudFileChanges(): Promise<FileChange[]> {
 		return changes;
 	}
 
-	const downloaded = await downloadSnapshot(context.db, context.uid, remote);
+	const cloudData = await ensureCloudClone(context, remote);
 	if (!isOperationCurrent(context)) return [];
-	const cloudFiles = (downloaded.files as FileStore | undefined) ?? {};
-	const cloudBoard = downloaded[WHITEBOARD_BOARD_KEY];
-
-	const mergedChanges: FileChange[] = computeFileChanges(localFiles, cloudFiles);
-	const whiteboardChange = computeWhiteboardChange(localBoard, cloudBoard);
-	if (whiteboardChange) mergedChanges.push(whiteboardChange);
-	mergedChanges.push(...computeOtherChanges(local.data, downloaded));
-	mergedChanges.push(
-		...computeWorkspaceChanges(local.data, downloaded, new Set(mergedChanges.map((change) => change.slug)))
-	);
-	return mergedChanges;
+	return fileChangesAgainstCloud(local.data, cloudData);
 }
 
 export async function discardLocalFileChange(fileId: string): Promise<void> {
@@ -999,8 +1143,13 @@ export async function discardLocalFileChange(fileId: string): Promise<void> {
 	if (!remote) {
 		throw new Error('No Cojudge Cloud snapshot exists for this account yet.');
 	}
-	const downloaded = await downloadSnapshot(context.db, context.uid, remote);
+	const downloaded = await ensureCloudClone(context, remote);
 	if (!isOperationCurrent(context)) return;
+
+	// Dotfiles are local-only and stripped from cloud snapshots. Capture them
+	// before any discard path that rewrites `files` so secrets like `.env` are
+	// never wiped when restoring cloud content.
+	const localDotFiles = extractDotFilesData(localStorage);
 
 	if (fileId === WHITEBOARD_FILE_ID) {
 		const cloudBoard = downloaded[WHITEBOARD_BOARD_KEY];
@@ -1023,6 +1172,21 @@ export async function discardLocalFileChange(fileId: string): Promise<void> {
 		fileStore.set(updated);
 		fileSyncVersion.update((version) => version + 1);
 	}
+
+	if (localDotFiles !== null) {
+		const merged = mergeDotFilesData(localStorage.getItem('files'), localDotFiles);
+		localStorage.setItem('files', merged);
+		try {
+			const parsed = JSON.parse(merged) as FileStore;
+			if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+				fileStore.set(parsed);
+				fileSyncVersion.update((version) => version + 1);
+			}
+		} catch {
+			// keep whatever apply wrote if the merge payload is malformed
+		}
+	}
+
 	await refreshCloudLocalState();
 }
 
@@ -1103,13 +1267,21 @@ async function runRevisionRestore(
 		setCloudProgress('Downloading backup…', 65);
 		const downloaded = await downloadSnapshot(context.db, context.uid, selected);
 		if (!isOperationCurrent(context)) return;
+		if (selected.revisionId === remote.revisionId) {
+			writeCloudClone(
+				cloudAccountId(context.projectId, context.uid),
+				selected.checksum,
+				downloaded.serialized,
+				selected.revisionId
+			);
+		}
 		setCloudProgress('Applying backup…', 85);
 		const latest = await readRemoteMeta(context.db, context.uid);
 		if (!latest || latest.revisionId !== remote.revisionId) {
 			throw new Error('Cloud progress changed while restoring. Try again.');
 		}
 		if (!isOperationCurrent(context)) return;
-		await applyDownloadedSnapshot(context, downloaded, local, latest.checksum);
+		await applyDownloadedSnapshot(context, downloaded.data, local, latest.checksum);
 		clearCloudProgress();
 	} catch (error) {
 		if (!isOperationCurrent(context)) return;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -197,8 +197,47 @@
             }
         }
 
+        let zoom = 1;
+    
+        const handleZoomShortcut = async (event: KeyboardEvent) => {
+          if (!event.metaKey || event.ctrlKey || event.altKey) return;
+    
+          const zoomIn =
+            event.key === '+' ||
+            event.key === '=' ||
+            event.code === 'Equal';
+    
+          const zoomOut =
+            event.key === '-' ||
+            event.code === 'Minus';
+    
+          const resetZoom = event.key === '0' || event.code === 'Digit0';
+    
+          if (!zoomIn && !zoomOut && !resetZoom) return;
+    
+          event.preventDefault();
+          event.stopPropagation();
+    
+          if (resetZoom) {
+            zoom = 1;
+          } else if (zoomIn) {
+            zoom = Math.min(10, zoom + 0.2);
+          } else {
+            zoom = Math.max(0.2, zoom - 0.2);
+          }
+    
+          const { getCurrentWebview } =
+            await import('@tauri-apps/api/webview');
+    
+          await getCurrentWebview().setZoom(zoom);
+        };
+    
+        // Capture phase helps when editors/components intercept the shortcut.
+        window.addEventListener('keydown', handleZoomShortcut, true);
+
         return () => {
             window.removeEventListener("click", handleClickOutside);
+            window.removeEventListener('keydown', handleZoomShortcut, true);
         };
     });
 
@@ -482,9 +521,9 @@
     function cloudMenuStatus() {
         if ($cloudSyncState.authStatus === 'unavailable') return 'Off';
         if ($cloudSyncState.authStatus !== 'signed-in') return 'Sign in';
+        if ($cloudSyncState.syncStatus === 'syncing' || $cloudSyncState.remoteStatus === 'loading') return 'Syncing';
         if ($cloudSyncState.resolution === 'local-changes') return '* Unsynced';
         if ($cloudSyncState.resolution) return '* Review';
-        if ($cloudSyncState.syncStatus === 'syncing') return 'Syncing';
         if ($cloudSyncState.syncStatus === 'offline') return 'Offline';
         if ($cloudSyncState.syncStatus === 'error') return 'Error';
         if ($cloudSyncState.remoteStatus === 'unknown') return 'Checking';
@@ -719,7 +758,9 @@
                     <line x1="3" y1="6" x2="21" y2="6"></line>
                     <line x1="3" y1="18" x2="21" y2="18"></line>
                 </svg>
-                {#if $cloudSyncState.authStatus === 'signed-in' && $cloudSyncState.resolution}
+                {#if $cloudSyncState.authStatus === 'signed-in' && ($cloudSyncState.syncStatus === 'syncing' || $cloudSyncState.remoteStatus === 'loading')}
+                    <span class="dropdown-cloud-loading" title="Syncing with Cojudge Cloud" aria-hidden="true"></span>
+                {:else if $cloudSyncState.authStatus === 'signed-in' && $cloudSyncState.resolution}
                     <span class="dropdown-cloud-dirty" title="Local or conflicting cloud changes need attention" aria-hidden="true">*</span>
                 {/if}
                 <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: block;">
@@ -738,10 +779,15 @@
                             Cojudge Cloud
                         </span>
                         <span
-                            class:configured={$cloudSyncState.authStatus === 'signed-in'}
-                            class:pending={Boolean($cloudSyncState.resolution)}
+                            class:configured={$cloudSyncState.authStatus === 'signed-in' && !$cloudSyncState.resolution && $cloudSyncState.syncStatus !== 'syncing' && $cloudSyncState.remoteStatus !== 'loading'}
+                            class:pending={Boolean($cloudSyncState.resolution) && $cloudSyncState.syncStatus !== 'syncing' && $cloudSyncState.remoteStatus !== 'loading'}
+                            class:syncing={$cloudSyncState.syncStatus === 'syncing' || $cloudSyncState.remoteStatus === 'loading'}
                             class="firebase-menu-status"
-                            title={$cloudSyncState.resolution === 'local-changes' ? 'Local changes have not been pushed to Cojudge Cloud' : undefined}
+                            title={$cloudSyncState.syncStatus === 'syncing' || $cloudSyncState.remoteStatus === 'loading'
+                                ? 'Syncing with Cojudge Cloud'
+                                : $cloudSyncState.resolution === 'local-changes'
+                                    ? 'Local changes have not been pushed to Cojudge Cloud'
+                                    : undefined}
                         >
                             {cloudMenuStatus()}
                         </span>
@@ -1354,6 +1400,20 @@
         font-weight: 800;
         line-height: 1;
     }
+    .dropdown-cloud-loading {
+        width: 0.65rem;
+        height: 0.65rem;
+        border-radius: 50%;
+        border: 1.5px solid var(--color-text-secondary);
+        border-top-color: var(--color-highlight, var(--color-text));
+        animation: dropdown-cloud-spin 0.7s linear infinite;
+        flex-shrink: 0;
+    }
+    @keyframes dropdown-cloud-spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
     .playground-btn.btn {
         font-size: 0.5rem;
     }
@@ -1430,6 +1490,10 @@
     .firebase-menu-status.pending {
         background: color-mix(in srgb, var(--color-medium) 18%, transparent);
         color: var(--color-medium);
+    }
+    .firebase-menu-status.syncing {
+        background: color-mix(in srgb, var(--color-highlight, var(--color-text)) 14%, transparent);
+        color: var(--color-text);
     }
     .btn {
         appearance: none;

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -1938,7 +1938,9 @@ func main() {
                 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
-                {#if $cloudSyncState.resolution}
+                {#if $cloudSyncState.syncStatus === 'syncing' || $cloudSyncState.remoteStatus === 'loading'}
+                    <span class="cloud-icon-legend loading" title="Syncing with Cojudge Cloud" aria-hidden="true"></span>
+                {:else if $cloudSyncState.resolution}
                     <span class="cloud-icon-legend" title="Local or conflicting cloud changes need attention" aria-hidden="true"></span>
                 {/if}
             {:else}
@@ -2681,6 +2683,20 @@ func main() {
         border-radius: 50%;
         background: var(--color-medium);
         box-shadow: 0 0 0 2px var(--color-bg);
+    }
+
+    .cloud-icon-legend.loading {
+        background: transparent;
+        border: 1.5px solid var(--color-text-secondary);
+        border-top-color: var(--color-highlight, var(--color-text));
+        box-shadow: 0 0 0 1px var(--color-bg);
+        animation: cloud-icon-spin 0.7s linear infinite;
+    }
+
+    @keyframes cloud-icon-spin {
+        to {
+            transform: rotate(360deg);
+        }
     }
 
     .cloud-icon-offline {

--- a/src/routes/whiteboard/+page.svelte
+++ b/src/routes/whiteboard/+page.svelte
@@ -169,6 +169,7 @@
 	let clipboardElements: BoardElement[] = [];
 	let mounted = false;
 	let saveTimer: ReturnType<typeof setTimeout> | undefined;
+	let dirtyRefreshTimer: ReturnType<typeof setTimeout> | undefined;
 	let toastTimer: ReturnType<typeof setTimeout> | undefined;
 	let activeStorageKey = STORAGE_KEY;
 	let saveState: 'saved' | 'saving' | 'error' = 'saved';
@@ -245,6 +246,7 @@
 			wheelTarget?.removeEventListener('wheel', handleWheel, { capture: true });
 			document.removeEventListener('pointerdown', closeMenusOnOutsideClick);
 			if (toastTimer) clearTimeout(toastTimer);
+			if (dirtyRefreshTimer) clearTimeout(dirtyRefreshTimer);
 		};
 	});
 
@@ -446,7 +448,13 @@
 		try {
 			localStorage.setItem(activeStorageKey, JSON.stringify(board));
 			saveState = 'saved';
-			void refreshCloudLocalState();
+			// Skip flush: this save is itself the flush handler for CLOUD_FLUSH_EVENT.
+			// Flushing again would re-enter saveBoardNow in a synchronous loop when signed in.
+			if (dirtyRefreshTimer) clearTimeout(dirtyRefreshTimer);
+			dirtyRefreshTimer = setTimeout(() => {
+				dirtyRefreshTimer = undefined;
+				void refreshCloudLocalState({ flush: false }).catch(() => undefined);
+			}, 500);
 		} catch {
 			saveState = 'error';
 			showToast('The board is too large to save locally');


### PR DESCRIPTION
## Summary
- Add syncing spinner legend on cloud menu/icons while sync is in progress
- Enable zoom-in / zoom-out (and reset) shortcuts on the desktop app
- Preserve dotfiles and file order when discarding individual cloud changes
- Fix whiteboard lag when signed in by breaking the CLOUD_FLUSH_EVENT → saveBoardNow feedback loop

## Test plan
- [ ] Sign in, open whiteboard, draw/pan/zoom — should stay responsive (no freeze/stack blowup)
- [ ] Confirm cloud menu shows spinner while syncing, then dirty `*` when local changes need attention
- [ ] Desktop: Cmd+/Cmd-/Cmd+0 zoom in/out/reset
- [ ] Discard a single file change that sits next to a local-only `.env` — dotfile remains and no phantom "Files (names or order)" change
- [ ] Discard content-only change — cloud `order` restored, sibling files stay in place