### PR TITLE
feat: open markdown links in new tab and auto-link pasted URLs

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -44,6 +44,32 @@ test('playground markdown editor pastes clipboard images as base64 markdown', as
   await expect.poll(() => getMarkdownContent(page)).toMatch(/^!\[image\]\(data:image\/png;base64,/);
 });
 
+test('WYSIWYG paste turns a URL string into a link', async ({ page }) => {
+  await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('before');
+  await expect.poll(() => getMarkdownContent(page)).toBe('before');
+
+  await page.getByRole('button', { name: 'Preview Markdown' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+
+  await editable.locator('> p:last-child').click();
+  await page.keyboard.press('End');
+  await page.keyboard.press('Enter');
+
+  await page.evaluate(async () => {
+    await navigator.clipboard.writeText('https://example.com/path');
+  });
+  await page.keyboard.press('ControlOrMeta+v');
+
+  await expect(editable.locator('a[href="https://example.com/path"]')).toHaveAttribute('target', '_blank');
+  await expect.poll(() => getMarkdownContent(page)).toContain('[https://example.com/path](https://example.com/path)');
+});
+
 test('playground markdown preview has a WYSIWYG editing mode', async ({ page }) => {
   await openMarkdownPlayground(page);
 

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown } from './markdown';
+import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, isUrlLike, normalizeUrl, linkHtml } from './markdown';
 
 describe('markdown utils', () => {
     it('renders markdown with the interactive code-block renderer', () => {
@@ -12,6 +12,31 @@ describe('markdown utils', () => {
         const html = renderMarkdownPlain('# Title\n\nSome **bold** text');
         expect(html).toContain('<h1>Title</h1>');
         expect(html).toContain('<strong>bold</strong>');
+    });
+
+    it('opens links in a new tab', () => {
+        const html = renderMarkdown('[link](https://example.com)') as string;
+        expect(html).toContain('href="https://example.com"');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+
+        const plain = renderMarkdownPlain('[link](https://example.com)') as string;
+        expect(plain).toContain('target="_blank"');
+        expect(plain).toContain('rel="noopener noreferrer"');
+    });
+
+    it('detects URL-like paste strings', () => {
+        expect(isUrlLike('https://example.com')).toBe(true);
+        expect(isUrlLike('http://example.com/path?q=1')).toBe(true);
+        expect(isUrlLike('www.example.com')).toBe(true);
+        expect(isUrlLike('  https://example.com  ')).toBe(true);
+        expect(isUrlLike('not a url')).toBe(false);
+        expect(isUrlLike('https://example.com and more')).toBe(false);
+        expect(isUrlLike('ftp://example.com')).toBe(false);
+        expect(normalizeUrl('www.example.com')).toBe('http://www.example.com');
+        expect(normalizeUrl('https://example.com')).toBe('https://example.com');
+        expect(linkHtml('https://example.com', 'https://example.com')).toContain('target="_blank"');
+        expect(linkHtml('https://example.com', 'click')).toContain('>click</a>');
     });
 
     it('round-trips markdown through HTML and back', () => {

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -155,6 +155,38 @@ function escapeHtmlAttr(value: string): string {
         .replace(/>/g, '&gt;');
 }
 
+// True when the entire string is a single URL-like token (no whitespace).
+// Accepts http(s)://... and www....
+export function isUrlLike(text: string): boolean {
+    const trimmed = text.trim();
+    if (!trimmed || /\s/.test(trimmed)) return false;
+    try {
+        if (/^https?:\/\//i.test(trimmed)) {
+            const url = new URL(trimmed);
+            return url.protocol === 'http:' || url.protocol === 'https:';
+        }
+        if (/^www\./i.test(trimmed)) {
+            new URL('http://' + trimmed);
+            return true;
+        }
+        return false;
+    } catch {
+        return false;
+    }
+}
+
+export function normalizeUrl(text: string): string {
+    const trimmed = text.trim();
+    if (/^https?:\/\//i.test(trimmed)) return trimmed;
+    if (/^www\./i.test(trimmed)) return 'http://' + trimmed;
+    return trimmed;
+}
+
+// HTML for a link that opens in a new tab (used by WYSIWYG paste / insert).
+export function linkHtml(href: string, text: string): string {
+    return `<a href="${escapeHtmlAttr(href)}" target="_blank" rel="noopener noreferrer">${escapeHtmlAttr(text)}</a>`;
+}
+
 // Renders an image as a small thumbnail with a delete button, instead of the
 // full-size image. Click handling (lightbox / delete) is done via event
 // delegation by the caller. contenteditable="false" makes the thumbnail an
@@ -233,8 +265,18 @@ export function wrapCodeBlocksWithCopy(root: HTMLElement) {
     }
 }
 
+function openLinksInNewTab(renderer: Renderer) {
+    const originalLink = renderer.link.bind(renderer);
+    renderer.link = (token: any) => {
+        const html = originalLink(token);
+        if (typeof html !== 'string' || !html.startsWith('<a ')) return html;
+        return html.replace(/^<a /, '<a target="_blank" rel="noopener noreferrer" ');
+    };
+}
+
 export function getMarkdownRenderer(options?: { imageThumbnails?: boolean }) {
     const renderer = new Renderer();
+    openLinksInNewTab(renderer);
     if (options?.imageThumbnails) {
         renderer.image = (token: any) => imageThumbnailHtml(token.href ?? '', token.text ?? '', token.title);
     }
@@ -291,7 +333,9 @@ export function renderMarkdown(content: string, options?: { imageThumbnails?: bo
 // Plain GFM rendering without the interactive code-block wrapper.
 // Used as the source HTML for WYSIWYG editing so it can round-trip back to markdown.
 export function renderMarkdownPlain(content: string): string {
-    return marked.parse(content, { async: false });
+    const renderer = new Renderer();
+    openLinksInNewTab(renderer);
+    return marked.parse(content, { async: false, renderer });
 }
 
 let turndownService: TurndownService | null = null;

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -14,7 +14,7 @@
     import fileStore, { isDotFileName, type FileEntry, fileSyncVersion } from '$lib/stores/fileStore.js';
     import userSettingsStorage, { type ThemeChoice, type ActivePanel } from '$lib/stores/userSettingsStorage';
     import { type ProgrammingLanguage } from '$lib/utils/util.js';
-    import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, wrapImageThumbnails, wrapCodeBlocksWithCopy, ensureTrailingEmptyLine, inlineCodeSpanHtml, INLINE_CODE_STYLE_MARKER, THUMB_WRAPPER_CLASS, THUMB_DELETE_CLASS } from '$lib/utils/markdown';
+    import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, wrapImageThumbnails, wrapCodeBlocksWithCopy, ensureTrailingEmptyLine, inlineCodeSpanHtml, INLINE_CODE_STYLE_MARKER, THUMB_WRAPPER_CLASS, THUMB_DELETE_CLASS, isUrlLike, normalizeUrl, linkHtml } from '$lib/utils/markdown';
     import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
     import QRCode from 'qrcode';
     import { onMount, tick } from 'svelte';
@@ -1232,28 +1232,59 @@ func main() {
         lastActiveTabFileId = activeTab?.fileId ?? null;
     }
 
-    // Paste images into the WYSIWYG area as base64 <img> elements
+    // Paste images into the WYSIWYG area as base64 <img> elements.
+    // Plain URL strings are inserted as clickable links (new tab).
     function handleWysiwygPaste(event: ClipboardEvent) {
         const items = event.clipboardData?.items;
-        if (!items) return;
-        for (const item of items) {
-            if (item.kind !== 'file' || !item.type.startsWith('image/')) continue;
-            const file = item.getAsFile();
-            if (!file) continue;
-            event.preventDefault();
-            const reader = new FileReader();
-            reader.onload = () => {
-                document.execCommand('insertImage', false, reader.result as string);
-                if (wysiwygEl) {
-                    wrapImageThumbnails(wysiwygEl);
-                    wrapCodeBlocksWithCopy(wysiwygEl);
-                    // Keep an empty line after the pasted image so the caret
-                    // can move past the contenteditable="false" thumbnail
-                    ensureTrailingEmptyLine(wysiwygEl);
-                }
-            };
-            reader.readAsDataURL(file);
-            break;
+        if (items) {
+            for (const item of items) {
+                if (item.kind !== 'file' || !item.type.startsWith('image/')) continue;
+                const file = item.getAsFile();
+                if (!file) continue;
+                event.preventDefault();
+                const reader = new FileReader();
+                reader.onload = () => {
+                    document.execCommand('insertImage', false, reader.result as string);
+                    if (wysiwygEl) {
+                        wrapImageThumbnails(wysiwygEl);
+                        wrapCodeBlocksWithCopy(wysiwygEl);
+                        // Keep an empty line after the pasted image so the caret
+                        // can move past the contenteditable="false" thumbnail
+                        ensureTrailingEmptyLine(wysiwygEl);
+                    }
+                };
+                reader.readAsDataURL(file);
+                return;
+            }
+        }
+
+        const pasted = event.clipboardData?.getData('text/plain') ?? '';
+        if (!isUrlLike(pasted)) return;
+
+        event.preventDefault();
+        const href = normalizeUrl(pasted);
+        const selection = window.getSelection();
+        const hasSelection =
+            !!selection &&
+            !selection.isCollapsed &&
+            !!wysiwygEl &&
+            !!selection.anchorNode &&
+            wysiwygEl.contains(selection.anchorNode);
+
+        if (hasSelection) {
+            document.execCommand('createLink', false, href);
+            ensureWysiwygLinksOpenInNewTab();
+        } else {
+            document.execCommand('insertHTML', false, linkHtml(href, pasted.trim()));
+        }
+        handleWysiwygInput();
+    }
+
+    function ensureWysiwygLinksOpenInNewTab() {
+        if (!wysiwygEl) return;
+        for (const a of wysiwygEl.querySelectorAll('a[href]')) {
+            a.setAttribute('target', '_blank');
+            a.setAttribute('rel', 'noopener noreferrer');
         }
     }
 
@@ -1326,7 +1357,15 @@ func main() {
                 selection?.removeAllRanges();
                 selection?.addRange(savedLinkRange);
             }
-            document.execCommand('createLink', false, url);
+            const href = isUrlLike(url) ? normalizeUrl(url) : url;
+            const selection = window.getSelection();
+            const hasSelection = !!selection && !selection.isCollapsed;
+            if (hasSelection) {
+                document.execCommand('createLink', false, href);
+            } else {
+                document.execCommand('insertHTML', false, linkHtml(href, url));
+            }
+            ensureWysiwygLinksOpenInNewTab();
             handleWysiwygInput();
         }
         showLinkInput = false;


### PR DESCRIPTION
## Summary
- Markdown links open in a new tab (`target="_blank"` + `rel="noopener noreferrer"`)
- Pasting a URL-like string in the WYSIWYG editor inserts it as a link; if text is selected, the selection is wrapped instead
- Unit and e2e coverage for the new behavior

## Test plan
- [x] `npx vitest run src/lib/utils/markdown.test.ts`
- [ ] Paste `https://example.com` in WYSIWYG → becomes a clickable link opening in a new tab
- [ ] Select text, paste a URL → selection becomes the link text
- [ ] Click a rendered markdown link → opens in a new tab