### PR TITLE
fix: stop default Tauri window from showing startup error page

### DIFF
--- a/src-tauri/frontend/index.html
+++ b/src-tauri/frontend/index.html
@@ -51,7 +51,7 @@
 			<h1>Cojudge could not start</h1>
 			<p>
 				Close any process using <code>cojudge.localhost:5376</code>, then reopen Cojudge. If
-				the problem continues, check the macOS Console for backend errors.
+				the problem continues, check the system console for backend errors.
 			</p>
 		</main>
 	</body>

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -93,6 +93,7 @@ fn create_window(app: &tauri::AppHandle, url: tauri::Url) -> tauri::Result<()> {
         .inner_size(1400.0, 900.0)
         .min_inner_size(300.0, 300.0)
         .center()
+        .zoom_hotkeys_enabled(true)
         .on_navigation(move |url| {
             if url.origin().ascii_serialization() == allowed_origin {
                 true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,17 +10,12 @@
 		"frontendDist": "frontend"
 	},
 	"app": {
-		"windows": [
-  		{
-        "label": "main",
-    		"zoomHotkeysEnabled": true
-  		}
-		],
+		"windows": [],
 		"security": {
 			"capabilities": [
 				{
 					"identifier": "default",
-					"windows": ["main", "main-*"],
+					"windows": ["main-*"],
 					"permissions": ["allow-new-window", "allow-google-oauth-access-token", "opener:default", "core:webview:allow-set-webview-zoom"],
 					"remote": {
 						"urls": ["http://127.0.0.1:5173/*", "http://cojudge.localhost:5376/*"]


### PR DESCRIPTION
## Summary
- Remove the auto-created `main` window from `tauri.conf.json` so startup no longer opens the error HTML alongside the real app
- Enable zoom hotkeys on programmatically created windows
- Make the startup error copy platform-agnostic (no macOS-only Console wording)

## Test plan
- [ ] Launch the packaged desktop app and confirm only one window opens
- [ ] Confirm zoom hotkeys still work in the main window
- [ ] Force a backend startup failure and confirm the error window still appears with the updated message