### PR TITLE
fix: prevent recent file icons from shrinking with long names

### DIFF
--- a/src/lib/components/LanguageIcon.svelte
+++ b/src/lib/components/LanguageIcon.svelte
@@ -28,6 +28,7 @@
     xmlns="http://www.w3.org/2000/svg"
     aria-hidden="true"
     focusable="false"
+    style="flex-shrink: 0;"
 >
     <rect x="0.5" y="0.5" width="15" height="15" rx="3.5" fill={icon.bg} />
     {#if language === 'plaintext' || !icon.label}

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -4812,6 +4812,7 @@ func main() {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+        min-width: 0;
     }
     .recent-file-card-path {
         font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- Stop `LanguageIcon` from shrinking in flex layouts when filenames are long
- Allow recent file titles to ellipsize properly with `min-width: 0`

## Test plan
- [ ] Open playground empty state with long-named recent files
- [ ] Confirm language icons stay full size
- [ ] Confirm long titles ellipsize with `...`