### PR TITLE
fix: pointer cursor on WYSIWYG links and clean recent file paths

### DIFF
--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -3918,7 +3918,7 @@ func main() {
                                         <span class="recent-file-card-title">{file.fileName}</span>
                                     </div>
                                     {#if getFilePath(file.fileId) != '/'}
-                                      <span class="recent-file-card-path">{getFilePath(file.fileId)}</span>
+                                      <span class="recent-file-card-path">{getFilePath(file.fileId).replace(/^\/|\/$/g, '')}</span>
                                     {/if}
                                 </div>
                             {/each}
@@ -4720,6 +4720,10 @@ func main() {
     .wysiwyg-editing {
         outline: none;
         cursor: text;
+    }
+
+    .wysiwyg-editing :global(a) {
+        cursor: pointer;
     }
 
     .wysiwyg-editing:focus {


### PR DESCRIPTION
## Summary
- Show pointer cursor when hovering links in the playground WYSIWYG editor (use `:global(a)` so styles apply to dynamically rendered HTML)
- Strip leading/trailing slashes from paths in the recent files empty state (matches quick open)

## Test plan
- [ ] Open a markdown file in WYSIWYG mode, hover a link — cursor should be pointer
- [ ] Close all tabs to see Recent Files — paths should show as `Leetcode/Reviews` not `/Leetcode/Reviews/`