### PR TITLE
fix: highlight source file in explorer during markdown preview modes

### DIFF
--- a/e2e/playground-folders.test.ts
+++ b/e2e/playground-folders.test.ts
@@ -65,3 +65,73 @@ test('folder collapse/expand state persists to localStorage across reloads', asy
   );
   expect(stored2['folder-a']).toBe(false);
 });
+
+test('explorer highlights markdown files in nested folders while in WYSIWYG mode', async ({ page }) => {
+  await page.goto('/playground');
+  await page.evaluate(() => {
+    localStorage.removeItem('files');
+    localStorage.removeItem('playground-collapsed-folders');
+    localStorage.setItem('playground-markdown-mode', 'wysiwyg');
+    const now = Date.now();
+    const files = [
+      {
+        fileId: 'folder-a',
+        fileName: 'FolderA',
+        type: 'folder',
+        content: '',
+        language: 'plaintext',
+        order: 0,
+        lastUpdated: now
+      },
+      {
+        fileId: 'note-a',
+        fileName: 'NoteA',
+        language: 'markdown',
+        lastLanguage: 'markdown',
+        content: '# A',
+        viewState: null,
+        output: '',
+        logs: '',
+        order: 1,
+        isOpen: true,
+        lastUpdated: now,
+        parentId: 'folder-a'
+      },
+      {
+        fileId: 'folder-b',
+        fileName: 'FolderB',
+        type: 'folder',
+        content: '',
+        language: 'plaintext',
+        order: 2,
+        lastUpdated: now
+      },
+      {
+        fileId: 'note-b',
+        fileName: 'NoteB',
+        language: 'markdown',
+        lastLanguage: 'markdown',
+        content: '# B',
+        viewState: null,
+        output: '',
+        logs: '',
+        order: 3,
+        isOpen: true,
+        lastUpdated: now - 1,
+        parentId: 'folder-b'
+      }
+    ];
+    localStorage.setItem('files', JSON.stringify({ playground: JSON.stringify(files) }));
+  });
+  await page.reload();
+  await expect(page.locator('[data-explorer-id="note-a"]')).toBeVisible();
+
+  await page.locator('[data-explorer-id="note-b"]').click();
+  await expect(page.locator('.markdown-mode-switch')).toBeVisible();
+  await expect(page.locator('[data-explorer-id="note-b"]')).toHaveClass(/active/);
+  await expect(page.locator('.file-item.active')).toHaveCount(1);
+
+  await page.locator('[data-explorer-id="note-a"]').click();
+  await expect(page.locator('[data-explorer-id="note-a"]')).toHaveClass(/active/);
+  await expect(page.locator('[data-explorer-id="note-b"]')).not.toHaveClass(/active/);
+});

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -3417,6 +3417,11 @@ func main() {
     $: hasOpenTabs = tabs.some(t => t.isOpen);
     $: activeTabName = tabs[activeTabId]?.fileName;
     $: activeTab = tabs[activeTabId];
+    // Preview tabs use a distinct fileId; explorer should highlight the source file.
+    $: activeExplorerFileId =
+        activeTab?.type === 'preview' && activeTab.sourceFileId
+            ? activeTab.sourceFileId
+            : activeTab?.fileId;
     $: fileStoreValue = $fileStore;
     $: tabLanguages = (() => {
         fileStoreValue;
@@ -3694,7 +3699,7 @@ func main() {
                     </div>
                 {:else}
                     <div
-                        class="file-item {t.kind === 'folder' ? 'folder-item' : ''} {isDotFileName(t.fileName) ? 'dotfile' : ''} {t.kind === 'file' && hasOpenTabs && t.fileId === tabs[activeTabId]?.fileId ? 'active' : ''} {explorerDragOverId === t.fileId ? 'drag-over-folder' : ''} {explorerPointerDrag?.active && explorerPointerDrag.id === t.fileId ? 'is-dragging' : ''}"
+                        class="file-item {t.kind === 'folder' ? 'folder-item' : ''} {isDotFileName(t.fileName) ? 'dotfile' : ''} {t.kind === 'file' && hasOpenTabs && t.fileId === activeExplorerFileId ? 'active' : ''} {explorerDragOverId === t.fileId ? 'drag-over-folder' : ''} {explorerPointerDrag?.active && explorerPointerDrag.id === t.fileId ? 'is-dragging' : ''}"
                         style="padding-left: {8 + t.depth * 14}px"
                         data-explorer-id={t.fileId}
                         data-explorer-kind={t.kind}


### PR DESCRIPTION
## Summary
- Markdown WYSIWYG/preview opens a separate preview tab with its own `fileId`, so explorer `file-item active` never matched the source file (regression from #44).
- Resolve `activeExplorerFileId` via `sourceFileId` for preview tabs.
- Add e2e coverage for nested-folder markdown highlighting in WYSIWYG mode.

## Test plan
- [x] Manual: open markdown files in multiple folders; confirm explorer active highlight in WYSIWYG/Preview/Source
- [x] Manual: non-markdown files still highlight correctly
- [ ] `npm run test:e2e -- e2e/playground-folders.test.ts`