### PR TITLE
feat: Tab indents and Shift+Tab outdents list items in WYSIWYG editor

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -505,3 +505,74 @@ test('WYSIWYG checklist item merges keep checkboxes intact', async ({ page }) =>
   await expect.poll(() => getMarkdownContent(page)).toMatch(/three\s+four/);
 });
 
+test('WYSIWYG Tab indents list items and Shift+Tab outdents them', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('- one\n- two\n- three');
+  await expect.poll(() => getMarkdownContent(page)).toContain('three');
+
+  await page.getByRole('button', { name: 'WYSIWYG' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+
+  const indentOf = async (text: string) => {
+    const md = await getMarkdownContent(page);
+    const line = md?.split('\n').find((l) => l.includes(text));
+    return line ? (line.match(/^\s*/)?.[0].length ?? 0) : -1;
+  };
+
+  // Tab on the second item nests it under the first
+  await editable.locator('li').nth(1).click();
+  await page.keyboard.press('Tab');
+  await expect.poll(() => indentOf('two')).toBeGreaterThan(0);
+  await expect.poll(() => indentOf('three')).toBe(0);
+
+  // Tab on the third item joins the first item's nested list (same level as two)
+  await editable.locator('li').nth(2).click();
+  await page.keyboard.press('Tab');
+  const twoIndent = await indentOf('two');
+  await expect.poll(() => indentOf('three')).toBe(twoIndent);
+
+  // Tab again nests it under the second item
+  await page.keyboard.press('Tab');
+  await expect.poll(() => indentOf('three')).toBeGreaterThan(twoIndent);
+
+  // Shift+Tab moves it back one level
+  await page.keyboard.press('Shift+Tab');
+  await expect.poll(() => indentOf('three')).toBe(twoIndent);
+
+  // Shift+Tab again moves it back to the top level
+  await page.keyboard.press('Shift+Tab');
+  await expect.poll(() => indentOf('three')).toBe(0);
+});
+
+test('WYSIWYG Tab/Shift+Tab on checklists keeps checkboxes intact', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('- [ ] one\n- [x] two');
+  await expect.poll(() => getMarkdownContent(page)).toMatch(/\[\s\]\s+one/);
+
+  await page.getByRole('button', { name: 'WYSIWYG' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+  await expect(editable.locator('li input[type="checkbox"]')).toHaveCount(2);
+
+  // Tab nests the second checklist item under the first; checkbox states survive
+  await editable.locator('li').nth(1).click();
+  await page.keyboard.press('Tab');
+  await expect(editable.locator('li input[type="checkbox"]')).toHaveCount(2);
+  await expect(editable.locator('li').nth(1).locator('input[type="checkbox"]')).toBeChecked();
+  await expect.poll(() => getMarkdownContent(page)).toMatch(/- +\[ \] +one\s*\n\s+- +\[x\] +two/);
+
+  // Shift+Tab returns it to the top level
+  await page.keyboard.press('Shift+Tab');
+  await expect(editable.locator('li input[type="checkbox"]')).toHaveCount(2);
+  await expect(editable.locator('li').nth(1).locator('input[type="checkbox"]')).toBeChecked();
+  await expect.poll(() => getMarkdownContent(page)).toMatch(/- +\[ \] +one\s*\n- +\[x\] +two/);
+});
+
+

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -2777,6 +2777,88 @@ func main() {
         return true;
     }
 
+    // Tab/Shift+Tab inside a list item (bullet, ordered, or task list) indents
+    // and outdents. The <li> nodes are moved wholesale so checkboxes and any
+    // nested lists stay intact (the browser's native editing rebuilds items and
+    // drops checkbox inputs).
+    function handleWysiwygTab(e: KeyboardEvent): boolean {
+        const li = getListItemFromSelection();
+        if (!li || !wysiwygEl?.contains(li)) return false;
+        const list = li.parentElement;
+        if (!list || !/^(UL|OL)$/.test(list.tagName)) return false;
+        return e.shiftKey ? outdentListItem(li) : indentListItem(li);
+    }
+
+    // Remembers the caret position as (node, offset) plain values, so the
+    // position can be re-applied after a DOM move. (A cloned Range gets
+    // re-mapped by Chrome when list nodes are moved around in a
+    // contenteditable, silently dropping the caret into a neighboring text
+    // node.)
+    function saveWysiwygCaret(): { node: Node; offset: number } | null {
+        const selection = window.getSelection();
+        if (!selection || selection.rangeCount === 0) return null;
+        const range = selection.getRangeAt(0);
+        return { node: range.startContainer, offset: range.startOffset };
+    }
+
+    function restoreWysiwygCaret(caret: { node: Node; offset: number } | null) {
+        if (!caret) return;
+        const selection = window.getSelection();
+        const range = document.createRange();
+        try {
+            range.setStart(caret.node, caret.offset);
+        } catch {
+            return;
+        }
+        range.collapse(true);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+    }
+
+    // Nests the item (with its own nested lists) under the previous item.
+    function indentListItem(li: HTMLElement): boolean {
+        const list = li.parentElement;
+        if (!list || !/^(UL|OL)$/.test(list.tagName)) return false;
+        const prev = li.previousElementSibling;
+        if (!prev || prev.tagName !== 'LI') return false;
+
+        const savedCaret = saveWysiwygCaret();
+        let nested: HTMLElement | null = null;
+        for (let i = 0; i < prev.childNodes.length; i++) {
+            const child = prev.childNodes[i];
+            if (child instanceof HTMLElement && /^(UL|OL)$/.test(child.tagName)) {
+                nested = child;
+                break;
+            }
+        }
+        if (!nested) {
+            nested = document.createElement(list.tagName);
+            prev.appendChild(nested);
+        }
+        nested.appendChild(li);
+        restoreWysiwygCaret(savedCaret);
+        handleWysiwygInput();
+        return true;
+    }
+
+    // Moves the item out of its nested list, placing it after its parent item.
+    function outdentListItem(li: HTMLElement): boolean {
+        const list = li.parentElement;
+        if (!list || !/^(UL|OL)$/.test(list.tagName)) return false;
+        const parentLi = list.parentElement;
+        if (!parentLi || parentLi.tagName !== 'LI') return false;
+        const outerList = parentLi.parentElement;
+        if (!outerList || !/^(UL|OL)$/.test(outerList.tagName)) return false;
+
+        const savedCaret = saveWysiwygCaret();
+        li.remove();
+        if (!list.querySelector('li')) list.remove();
+        parentLi.after(li);
+        restoreWysiwygCaret(savedCaret);
+        handleWysiwygInput();
+        return true;
+    }
+
     // Repairs DOMs the browser already corrupted (e.g. a native merge put
     // several checkboxes into one <li>): split them back into separate items.
     function healTaskListStructure() {
@@ -3249,6 +3331,14 @@ func main() {
             if (e.key === 'Escape') {
                 e.preventDefault();
                 closeMentionPopup();
+                return;
+            }
+        }
+
+        // Tab/Shift+Tab indents/outdents list items (including checklists).
+        if (e.key === 'Tab' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+            if (handleWysiwygTab(e)) {
+                e.preventDefault();
                 return;
             }
         }


### PR DESCRIPTION
## Summary
Adds Tab/Shift+Tab indentation support for list items (bulleted, ordered, and checklists) in the WYSIWYG markdown editor.

- Tab nests the current item under its previous sibling's nested list (Word/Notion-style; first Tab joins the previous item's nested level, subsequent Tabs go deeper)
- Shift+Tab outdents the item to after its parent item, removing emptied nested lists
- Items are moved wholesale so checkboxes (and their checked state) and nested sublists survive
- Caret is preserved across the move via node+offset (a cloned Range gets re-mapped by Chrome during contenteditable list moves, dropping the caret into a neighboring text node)

## Tests
Two new Playwright e2e tests:
- `WYSIWYG Tab indents list items and Shift+Tab outdents them`
- `WYSIWYG Tab/Shift+Tab on checklists keeps checkboxes intact`

All 15 tests in `e2e/playground-markdown.test.ts` pass. `npm run check` shows only the 18 pre-existing errors.