### PR TITLE
fix: keep WYSIWYG mode on other tab when closing active preview tab

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -27,6 +27,34 @@ function getMarkdownContent(page: Page): Promise<string | null> {
   });
 }
 
+test('closing the active WYSIWYG tab keeps the other markdown tab in WYSIWYG mode', async ({ page }) => {
+  await page.goto('/playground');
+  await page.evaluate(() => {
+    localStorage.setItem('user-settings', JSON.stringify({ playgroundPreferredLanguage: 'markdown' }));
+    localStorage.setItem('playground-markdown-mode', 'wysiwyg');
+    localStorage.setItem('files', JSON.stringify({
+      playground: JSON.stringify([
+        { fileId: 'n1', fileName: 'Notes', language: 'markdown', content: '# Notes', isOpen: false, order: 0, lastUpdated: Date.now() },
+        { fileId: 'n2', fileName: 'Tasks', language: 'markdown', content: '# Tasks', isOpen: false, order: 1, lastUpdated: Date.now() }
+      ])
+    }));
+  });
+  await page.reload();
+  const dismiss = page.getByRole('button', { name: 'Dismiss' });
+  if (await dismiss.isVisible().catch(() => false)) await dismiss.click();
+
+  // Open both files in WYSIWYG mode
+  await page.locator('.file-item', { hasText: 'Notes' }).click();
+  await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Notes');
+  await page.locator('.file-item', { hasText: 'Tasks' }).click();
+  await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Tasks');
+
+  // Close the active (Tasks) tab — the remaining Notes tab should stay in WYSIWYG
+  await page.locator('.tab:has-text("Tasks") .tab-close').click();
+  await expect(page.locator('.wysiwyg-editing')).toBeVisible();
+  await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Notes');
+});
+
 test('playground markdown editor pastes clipboard images as base64 markdown', async ({ page }) => {
   await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
   await openMarkdownPlayground(page);

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -1581,7 +1581,7 @@ func main() {
         if (isSpecialTabType(tabToClose?.type)) {
             const closedIdx = tabs.findIndex(t => t.fileId === fileId);
             tabs = tabs.filter(t => t.fileId !== fileId);
-            if (tabs[activeTabId]?.fileId === fileId || activeTabId >= tabs.length) {
+            if (!tabs[activeTabId]?.isOpen) {
                 let nextOpenIdx = -1;
                 for (let i = Math.min(closedIdx, tabs.length - 1); i >= 0; i--) {
                     if (tabs[i].isOpen) { nextOpenIdx = i; break; }


### PR DESCRIPTION
Closes the active WYSIWYG preview tab and shows the remaining markdown tab in Source mode instead.

## Root cause
When a markdown file is in WYSIWYG, its tab is replaced by a `preview` tab while the raw `source` tab stays in the array as closed. With two files in WYSIWYG the tabs are interleaved (`[previewA, sourceA, previewB, sourceB]`). Closing the active `previewB` filtered it out, then the guard in `closeTab` checked whether `tabs[activeTabId]?.fileId === fileId` — but the closed tab was already removed, so that never matched (only the `activeTabId >= tabs.length` case was handled). `activeTabId` kept pointing at the tab after the closed one, which was the closed source tab, so the editor fell back to raw markdown Source mode.

## Fix
Trigger the neighbor search whenever the tab now at the active index is not open (`!tabs[activeTabId]?.isOpen`), covering both the out-of-bounds and closed-neighbor cases. The existing search then selects the other open preview tab and WYSIWYG is restored.

## Verification
- Added e2e test reproducing the bug (fails before, passes after)
- All 16 markdown e2e tests pass