### PR TITLE
feat: store pasted images in IndexedDB and sync them with cloud backup

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -131,6 +131,12 @@
   margin-bottom: 16px;
 }
 
+/* Pasted images reference IndexedDB via a fake link (cojudge://image/<id>);
+   hide them until the payload is resolved into src (resolvePastedImages). */
+.markdown-body img[src^="cojudge://image/"] {
+  visibility: hidden;
+}
+
 .markdown-body .md-thumb img {
   max-width: 240px;
   max-height: 160px;

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -43,6 +43,14 @@ import {
 	type ProgressData
 } from '$lib/progressBackup';
 import { applyProgressData } from '$lib/progressBackupClient';
+import {
+	PASTED_IMAGES_KEY,
+	parsePastedImageLink,
+	findPastedImageLinks,
+	getAllPastedImages,
+	importPastedImages,
+	extractPastedImages
+} from '$lib/utils/imageStore';
 import { FORK_TRANSFER_STORAGE_KEY } from '$lib/forkTransfer';
 import fileStore, { fileSyncVersion } from '$lib/stores/fileStore';
 import {
@@ -123,6 +131,9 @@ type DeviceMeta = {
 type LocalSnapshot = {
 	data: ProgressData;
 	serialized: string;
+	// localStorage-only serialization (no pasted-images key), used by the
+	// pre-apply integrity check that compares against a fresh re-read.
+	storageSerialized: string;
 	checksum: string;
 	meaningful: boolean;
 	meta: DeviceUserMeta;
@@ -362,12 +373,51 @@ function clearCloudClone(): void {
 	if (browser) localStorage.removeItem(CLOUD_CLONE_KEY);
 }
 
+// Collects the IndexedDB-backed pasted images referenced by markdown file
+// contents, as { [id]: dataUrl }. Returns null when none are referenced so the
+// snapshot stays image-free (and checksums unchanged) for image-less documents.
+async function collectReferencedPastedImages(filesValue: unknown): Promise<Record<string, string> | null> {
+	const links = new Set<string>();
+	if (filesValue && typeof filesValue === 'object' && !Array.isArray(filesValue)) {
+		for (const serialized of Object.values(filesValue)) {
+			if (typeof serialized !== 'string') continue;
+			let entries: unknown;
+			try {
+				entries = JSON.parse(serialized);
+			} catch {
+				continue;
+			}
+			if (!Array.isArray(entries)) continue;
+			for (const entry of entries) {
+				if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
+				const file = entry as Record<string, unknown>;
+				if (file.language !== 'markdown' || typeof file.content !== 'string') continue;
+				for (const link of findPastedImageLinks(file.content)) links.add(link);
+			}
+		}
+	}
+	if (links.size === 0) return null;
+
+	const all = await getAllPastedImages();
+	const record: Record<string, string> = {};
+	for (const link of links) {
+		const id = parsePastedImageLink(link);
+		if (!id) continue;
+		const dataUrl = all[id];
+		if (dataUrl) record[id] = dataUrl;
+	}
+	return Object.keys(record).length > 0 ? record : null;
+}
+
 async function readLocalSnapshot(
 	context: OperationContext,
 	options: { flush?: boolean } = {}
 ): Promise<LocalSnapshot> {
 	if (options.flush !== false) window.dispatchEvent(new Event(CLOUD_FLUSH_EVENT));
 	const data = collectProgressData(localStorage, { cloud: true });
+	const storageSerialized = serializeProgressData(data);
+	const pastedImages = await collectReferencedPastedImages(data.files);
+	if (pastedImages) data[PASTED_IMAGES_KEY] = pastedImages;
 	const serialized = serializeProgressData(data);
 	const checksum = await hashProgress(serialized);
 	const meaningful = isMeaningfulProgress(data);
@@ -377,7 +427,7 @@ async function readLocalSnapshot(
 		...device.users[cloudAccountId(context.projectId, context.uid)]
 	};
 
-	return { data, serialized, checksum, meaningful, meta };
+	return { data, serialized, storageSerialized, checksum, meaningful, meta };
 }
 
 function reloadForCloudRestore(): void {
@@ -803,9 +853,12 @@ async function applyDownloadedSnapshot(
 				const finalSerialized = serializeProgressData(
 					collectProgressData(localStorage, { cloud: true })
 				);
+				// The re-read snapshot includes IndexedDB pasted images, so the
+				// "did anything change" check compares the localStorage-only
+				// serialization against the fresh localStorage read.
 				if (
 					latestLocal.checksum !== expectedLocal.checksum
-					|| finalSerialized !== latestLocal.serialized
+					|| finalSerialized !== latestLocal.storageSerialized
 				) {
 					throw new Error('Local progress changed during sync. Sync again to reconcile it safely.');
 				}
@@ -818,6 +871,10 @@ async function applyDownloadedSnapshot(
 				if (localDotFiles !== null) {
 					localStorage.setItem('files', mergeDotFilesData(localStorage.getItem('files'), localDotFiles));
 				}
+				// The markdown files may reference pasted images; write the payloads
+				// back into IndexedDB before the reload so previews can resolve them.
+				const pastedImages = extractPastedImages(downloaded);
+				if (pastedImages) await importPastedImages(pastedImages);
 				applied = true;
 				markSynced(context, baseHash);
 				announceCloudRestore();
@@ -1145,6 +1202,11 @@ export async function discardLocalFileChange(fileId: string): Promise<void> {
 	}
 	const downloaded = await ensureCloudClone(context, remote);
 	if (!isOperationCurrent(context)) return;
+
+	// Reverted markdown may reference pasted images; make sure the payloads are
+	// available locally before the cloud content is applied.
+	const pastedImages = extractPastedImages(downloaded);
+	if (pastedImages) await importPastedImages(pastedImages);
 
 	// Dotfiles are local-only and stripped from cloud snapshots. Capture them
 	// before any discard path that rewrites `files` so secrets like `.env` are

--- a/src/lib/components/CodeEditor.svelte
+++ b/src/lib/components/CodeEditor.svelte
@@ -15,7 +15,8 @@
     export let debugJobId: string | null = null;
     // When set, pasting an image from the clipboard is intercepted and the
     // returned text (e.g. markdown image syntax) is inserted at the cursor.
-    export let onPasteImage: ((dataUrl: string, file: File) => string) | undefined = undefined;
+    // May return a Promise (e.g. when the image is stored asynchronously).
+    export let onPasteImage: ((dataUrl: string, file: File) => string | Promise<string>) | undefined = undefined;
 
     let editor: Monaco.editor.IStandaloneCodeEditor | null = null;
     let editorElement: HTMLDivElement;
@@ -86,8 +87,9 @@
             reader.onload = () => {
                 const dataUrl = reader.result as string;
                 if (!editor || !onPasteImage) return;
-                const text = onPasteImage(dataUrl, file);
-                if (text) insertTextAtCursor(text);
+                Promise.resolve(onPasteImage(dataUrl, file)).then((text) => {
+                    if (text) insertTextAtCursor(text);
+                });
             };
             reader.readAsDataURL(file);
             break;

--- a/src/lib/utils/imageStore.test.ts
+++ b/src/lib/utils/imageStore.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+    PASTED_IMAGE_SCHEME,
+    PASTED_IMAGES_KEY,
+    pastedImageLink,
+    parsePastedImageLink,
+    findPastedImageLinks,
+    extractPastedImages
+} from './imageStore';
+
+describe('imageStore fake links', () => {
+    it('builds fake links from ids', () => {
+        expect(pastedImageLink('abc-123')).toBe('cojudge://image/abc-123');
+        expect(PASTED_IMAGE_SCHEME).toBe('cojudge://image/');
+    });
+
+    it('parses ids out of fake links', () => {
+        expect(parsePastedImageLink('cojudge://image/abc-123')).toBe('abc-123');
+        expect(parsePastedImageLink('cojudge://image/')).toBe(null);
+        expect(parsePastedImageLink('https://example.com/x.png')).toBe(null);
+        expect(parsePastedImageLink('data:image/png;base64,iVBORw0KGgo=')).toBe(null);
+        expect(parsePastedImageLink('')).toBe(null);
+    });
+});
+
+describe('findPastedImageLinks', () => {
+    it('finds fake links in markdown image syntax, deduplicated', () => {
+        const content = [
+            '# Notes',
+            '',
+            '![image](cojudge://image/abc-1)',
+            '',
+            '![diagram](cojudge://image/def-2 "title")',
+            '',
+            'Reused: ![image](cojudge://image/abc-1)',
+            '',
+            '[link](https://example.com) ![remote](https://example.com/a.png)'
+        ].join('\n');
+        expect(findPastedImageLinks(content).sort()).toEqual(['cojudge://image/abc-1', 'cojudge://image/def-2']);
+    });
+
+    it('returns nothing for plain markdown', () => {
+        expect(findPastedImageLinks('hello **world** [x](https://example.com)')).toEqual([]);
+        expect(findPastedImageLinks('')).toEqual([]);
+    });
+});
+
+describe('extractPastedImages', () => {
+    it('returns null when the key is absent', () => {
+        expect(extractPastedImages({ files: '{}' })).toBe(null);
+    });
+
+    it('normalizes valid payloads to id → dataUrl records', () => {
+        const record = extractPastedImages({
+            [PASTED_IMAGES_KEY]: {
+                'abc-1': 'data:image/png;base64,AAA=',
+                'def-2': 'data:image/png;base64,BBB=',
+                bad: 42
+            }
+        });
+        expect(record).toEqual({
+            'abc-1': 'data:image/png;base64,AAA=',
+            'def-2': 'data:image/png;base64,BBB='
+        });
+    });
+
+    it('returns null for malformed payloads', () => {
+        expect(extractPastedImages({ [PASTED_IMAGES_KEY]: 'not-an-object' })).toBe(null);
+        expect(extractPastedImages({ [PASTED_IMAGES_KEY]: null })).toBe(null);
+        expect(extractPastedImages({ [PASTED_IMAGES_KEY]: [1, 2] })).toBe(null);
+    });
+});

--- a/src/lib/utils/imageStore.ts
+++ b/src/lib/utils/imageStore.ts
@@ -1,0 +1,195 @@
+// IndexedDB-backed store for images pasted into markdown documents.
+// The markdown source keeps a fake link (cojudge://image/<id>) instead of the
+// base64 payload, so the document text stays small and diffable. Renderers
+// resolve the fake link back to the stored data URL via resolvePastedImages
+// (see markdown.ts).
+
+const DB_NAME = 'cojudge-images';
+const STORE_NAME = 'images';
+const DB_VERSION = 1;
+
+export const PASTED_IMAGE_SCHEME = 'cojudge://image/';
+
+// Progress-data key used to carry pasted images inside cloud snapshots and
+// local backup exports. Images are only included when referenced by a markdown
+// file (cloud) or as a full snapshot (backup export).
+export const PASTED_IMAGES_KEY = 'pasted-images';
+
+export function pastedImageLink(id: string): string {
+    return PASTED_IMAGE_SCHEME + id;
+}
+
+export function parsePastedImageLink(href: string): string | null {
+    if (!href.startsWith(PASTED_IMAGE_SCHEME)) return null;
+    const id = href.slice(PASTED_IMAGE_SCHEME.length);
+    return id || null;
+}
+
+// Finds every fake image link embedded in markdown image syntax.
+export function findPastedImageLinks(content: string): string[] {
+    const links = new Set<string>();
+    const regex = /!\[[^\]]*\]\(\s*(cojudge:\/\/image\/[^\s)]+)/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(content)) !== null) {
+        links.add(match[1]);
+    }
+    return [...links];
+}
+
+// Validates a PASTED_IMAGES_KEY payload from a cloud snapshot or backup file:
+// { [id]: dataUrl }. Returns null when the key is absent or malformed.
+export function extractPastedImages(data: Record<string, unknown>): Record<string, string> | null {
+    if (!(PASTED_IMAGES_KEY in data)) return null;
+    const value = data[PASTED_IMAGES_KEY];
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+    const record: Record<string, string> = {};
+    for (const [id, dataUrl] of Object.entries(value)) {
+        if (typeof dataUrl === 'string') record[id] = dataUrl;
+    }
+    return record;
+}
+
+type ImageRecord = { id: string; dataUrl: string; createdAt: number };
+
+// In-memory cache so re-renders (every preview keystroke) don't hit IndexedDB.
+const cache = new Map<string, string>();
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function openDb(): Promise<IDBDatabase> {
+    if (dbPromise) return dbPromise;
+    const promise = new Promise<IDBDatabase>((resolve, reject) => {
+        if (typeof indexedDB === 'undefined') {
+            reject(new Error('IndexedDB is not available'));
+            return;
+        }
+        const request = indexedDB.open(DB_NAME, DB_VERSION);
+        request.onupgradeneeded = () => {
+            const db = request.result;
+            if (!db.objectStoreNames.contains(STORE_NAME)) {
+                db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+            }
+        };
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error ?? new Error('IndexedDB open failed'));
+    });
+    dbPromise = promise;
+    // Reset the cached promise on failure so a later call retries the open.
+    promise.catch(() => { dbPromise = null; });
+    return promise;
+}
+
+function withStore<T>(mode: IDBTransactionMode, fn: (store: IDBObjectStore) => IDBRequest<T>): Promise<T> {
+    return openDb().then((db) =>
+        new Promise<T>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, mode);
+            const request = fn(tx.objectStore(STORE_NAME));
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        })
+    );
+}
+
+function generateId(): string {
+    try {
+        if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+            return crypto.randomUUID();
+        }
+    } catch {
+        // fall through
+    }
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// Stores the pasted image payload and returns the fake link to embed in the
+// markdown source.
+export async function storePastedImage(dataUrl: string): Promise<string> {
+    const id = generateId();
+    const record: ImageRecord = { id, dataUrl, createdAt: Date.now() };
+    await withStore('readwrite', (store) => store.put(record));
+    cache.set(id, dataUrl);
+    return pastedImageLink(id);
+}
+
+// Resolves a fake link to the stored data URL (null when unknown).
+export async function getPastedImage(href: string): Promise<string | null> {
+    const id = parsePastedImageLink(href);
+    if (!id) return null;
+    const cached = cache.get(id);
+    if (cached !== undefined) return cached;
+    try {
+        const record = await withStore<ImageRecord | undefined>('readonly', (store) => store.get(id));
+        if (!record) return null;
+        cache.set(id, record.dataUrl);
+        return record.dataUrl;
+    } catch {
+        return null;
+    }
+}
+
+// Removes a stored image. No-op for unknown links (e.g. IndexedDB unavailable).
+export async function deletePastedImage(href: string): Promise<void> {
+    const id = parsePastedImageLink(href);
+    if (!id) return;
+    cache.delete(id);
+    try {
+        await withStore('readwrite', (store) => store.delete(id));
+    } catch {
+        // ignore
+    }
+}
+
+// Returns every stored image as { [id]: dataUrl } (empty when IndexedDB is
+// unavailable). Used for cloud snapshots and backup exports.
+export async function getAllPastedImages(): Promise<Record<string, string>> {
+    try {
+        const records = await withStore<ImageRecord[]>('readonly', (store) => store.getAll());
+        const result: Record<string, string> = {};
+        for (const record of records) {
+            if (typeof record?.id === 'string' && typeof record.dataUrl === 'string') {
+                result[record.id] = record.dataUrl;
+                cache.set(record.id, record.dataUrl);
+            }
+        }
+        return result;
+    } catch {
+        return {};
+    }
+}
+
+// Writes records ({ [id]: dataUrl }) from a cloud snapshot or backup import
+// into the store. Missing entries are left untouched; existing ones are
+// overwritten.
+export async function importPastedImages(records: Record<string, string>): Promise<void> {
+    const entries = Object.entries(records);
+    if (entries.length === 0) return;
+    try {
+        const db = await openDb();
+        await new Promise<void>((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            const store = tx.objectStore(STORE_NAME);
+            for (const [id, dataUrl] of entries) {
+                cache.set(id, dataUrl);
+                store.put({ id, dataUrl, createdAt: Date.now() } as ImageRecord);
+            }
+            tx.oncomplete = () => resolve();
+            tx.onerror = () => reject(tx.error);
+            tx.onabort = () => reject(tx.error);
+        });
+    } catch {
+        // ignore
+    }
+}
+
+// Replaces fake image links in markdown with their stored data URLs. Links
+// that cannot be resolved are left as-is.
+export async function inlinePastedImageLinks(content: string): Promise<string> {
+    const links = findPastedImageLinks(content);
+    if (links.length === 0) return content;
+    let result = content;
+    for (const link of links) {
+        const dataUrl = await getPastedImage(link);
+        if (dataUrl) result = result.replaceAll(link, dataUrl);
+    }
+    return result;
+}

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -118,6 +118,23 @@ describe('markdown utils', () => {
         expect(htmlToMarkdown(html)).toContain(`![image](${dataUrl})`);
     });
 
+    it('round-trips pasted-image fake links (IndexedDB) back to markdown', () => {
+        const fake = 'cojudge://image/abc-123';
+        const html = renderMarkdownPlain(`![image](${fake})`);
+        expect(html).toContain(`src="${fake}"`);
+        expect(htmlToMarkdown(html)).toBe(`![image](${fake})`);
+        // Round-trip stays stable
+        expect(htmlToMarkdown(renderMarkdownPlain(`![image](${fake})`))).toBe(`![image](${fake})`);
+    });
+
+    it('resolved pasted images serialize back to the fake link, not the payload', () => {
+        const dataUrl = 'data:image/png;base64,iVBORw0KGgo=';
+        const fake = 'cojudge://image/abc-123';
+        const html = `<p><img src="${dataUrl}" alt="image" data-cojudge-img="${fake}"></p>`;
+        expect(htmlToMarkdown(html)).toBe(`![image](${fake})`);
+        expect(htmlToMarkdown(html)).not.toContain(dataUrl);
+    });
+
     it('renders images as thumbnails with a delete button when imageThumbnails is enabled', () => {
         const dataUrl = 'data:image/png;base64,iVBORw0KGgo=';
         const html = renderMarkdown(`![image](${dataUrl})`, { imageThumbnails: true }) as string;

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -2,6 +2,7 @@ import { marked, Renderer } from 'marked';
 import TurndownService from 'turndown';
 import { gfm } from 'turndown-plugin-gfm';
 import { languageIconSvg } from './languageIcon';
+import { PASTED_IMAGE_SCHEME, parsePastedImageLink, getPastedImage } from './imageStore';
 
 function simpleHash(str: string): string {
     let hash = 0;
@@ -282,6 +283,24 @@ export function wrapImageThumbnails(root: HTMLElement) {
 // they get a copy button (see wrapCodeBlocksWithCopy). Stripped again by
 // htmlToMarkdown so only the <pre> round-trips back to markdown.
 export const CODE_COPY_WRAPPER_CLASS = 'md-code-copy';
+
+// Images pasted into markdown documents are stored in IndexedDB and referenced
+// by a fake link (cojudge://image/<id>). While the payload is being resolved,
+// <img> elements whose src is still the fake link stay hidden (see app.css).
+// Once resolved, the data URL lives in src and the fake link is kept in the
+// data-cojudge-img attribute so htmlToMarkdown round-trips it back to the fake
+// link instead of the (potentially huge) base64 payload.
+export async function resolvePastedImages(root: HTMLElement): Promise<void> {
+    if (typeof indexedDB === 'undefined') return;
+    const imgs = Array.from(root.querySelectorAll('img'));
+    for (const img of imgs) {
+        const fakeLink = img.getAttribute('data-cojudge-img') || img.getAttribute('src') || '';
+        if (!parsePastedImageLink(fakeLink)) continue;
+        img.dataset.cojudgeImg = fakeLink;
+        const dataUrl = await getPastedImage(fakeLink);
+        if (dataUrl && img.isConnected) img.src = dataUrl;
+    }
+}
 
 // GFM task-list checkboxes are rendered disabled by marked. In the WYSIWYG
 // editor we enable them so users can click to toggle, and mark them non-editable
@@ -582,6 +601,19 @@ function getTurndownService(): TurndownService {
                 const labelEl = node.querySelector(`.${FILE_MENTION_LABEL_CLASS}`);
                 const label = (labelEl?.textContent || node.textContent || href).trim();
                 return `[${label}](${href})`;
+            }
+        });
+        // Pasted images resolve to a data URL in src but keep the IndexedDB
+        // fake link in data-cojudge-img; serialize the fake link back to
+        // markdown so the document stays small and stable.
+        turndownService.addRule('pastedImage', {
+            filter: (node: HTMLElement) =>
+                node.nodeName === 'IMG' &&
+                (node.getAttribute('data-cojudge-img') || node.getAttribute('src') || '').startsWith(PASTED_IMAGE_SCHEME),
+            replacement: (_content: string, node: HTMLElement) => {
+                const fakeLink = node.getAttribute('data-cojudge-img') || node.getAttribute('src') || '';
+                const alt = (node.getAttribute('alt') || '').replace(/(\n+\s*)+/g, '\n').replace(/[[\]]/g, '\\$&');
+                return `![${alt}](${fakeLink})`;
             }
         });
         // Custom taskListItems rule that matches ANY checkbox input, even if

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,7 +20,14 @@
     } from '$lib/cloudSync';
     import { activeDialog } from '$lib/dialogs';
     import { collectProgressData, writeProgressStorageItem } from '$lib/progressBackup';
+
     import { applyProgressData } from '$lib/progressBackupClient';
+    import {
+        PASTED_IMAGES_KEY,
+        getAllPastedImages,
+        importPastedImages,
+        extractPastedImages
+    } from '$lib/utils/imageStore';
     import {
         clearFirebaseSettings,
         emptyFirebaseSettings,
@@ -425,6 +432,10 @@
     async function exportLocalStorage() {
         if (!browser) return;
         const data = collectProgressData(localStorage);
+        // Pasted images live in IndexedDB, outside localStorage; carry them in
+        // the backup so a restore keeps markdown images working.
+        const pastedImages = await getAllPastedImages();
+        if (Object.keys(pastedImages).length > 0) data[PASTED_IMAGES_KEY] = pastedImages;
 
         if (isDesktopMode) {
             try {
@@ -481,9 +492,16 @@
         }
     }
 
-    function confirmImport() {
+    async function confirmImport() {
         if (!pendingImport) return;
         try {
+            const pastedImages = extractPastedImages(pendingImport);
+            if (pastedImages) {
+                // Images are stored in IndexedDB, not localStorage; write them
+                // there and keep the key out of the localStorage payload.
+                await importPastedImages(pastedImages);
+                delete pendingImport[PASTED_IMAGES_KEY];
+            }
             applyProgressData(pendingImport);
             firebaseConfigured = isFirebaseConfigured();
             firebaseSettingsSaved = hasSavedFirebaseSettings();

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -17,7 +17,8 @@
     import fileStore, { isDotFileName, type FileEntry, fileSyncVersion } from '$lib/stores/fileStore.js';
     import userSettingsStorage, { type ThemeChoice, type ActivePanel } from '$lib/stores/userSettingsStorage';
     import { type ProgrammingLanguage } from '$lib/utils/util.js';
-    import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, wrapImageThumbnails, wrapCodeBlocksWithCopy, ensureTrailingEmptyLine, ensureFileMentionCarets, prepareTaskListCheckboxes, isTaskListItem, isEmptyTaskListItem, createTaskCheckbox, ensureTaskCheckbox, ensureTaskItemCaretAnchor, removeTaskCheckbox, inlineCodeSpanHtml, INLINE_CODE_STYLE_MARKER, THUMB_WRAPPER_CLASS, THUMB_DELETE_CLASS, isUrlLike, normalizeUrl, linkHtml, parsePlaygroundFileId, playgroundFileHref, fileMentionHtml, FILE_MENTION_CLASS } from '$lib/utils/markdown';
+    import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, wrapImageThumbnails, wrapCodeBlocksWithCopy, ensureTrailingEmptyLine, ensureFileMentionCarets, prepareTaskListCheckboxes, isTaskListItem, isEmptyTaskListItem, createTaskCheckbox, ensureTaskCheckbox, ensureTaskItemCaretAnchor, removeTaskCheckbox, inlineCodeSpanHtml, INLINE_CODE_STYLE_MARKER, THUMB_WRAPPER_CLASS, THUMB_DELETE_CLASS, resolvePastedImages, isUrlLike, normalizeUrl, linkHtml, parsePlaygroundFileId, playgroundFileHref, fileMentionHtml, FILE_MENTION_CLASS } from '$lib/utils/markdown';
+    import { storePastedImage, deletePastedImage, inlinePastedImageLinks } from '$lib/utils/imageStore';
     import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
     import QRCode from 'qrcode';
     import { browser } from '$app/environment';
@@ -830,11 +831,27 @@ func main() {
         }
     }
 
+    // Replaces IndexedDB fake image links in markdown with their data URLs so
+    // downloaded folders are self-contained outside the app.
+    async function inlineExportNodeImages(node: ExportNode): Promise<ExportNode> {
+        if (node.type === 'folder') {
+            return { ...node, children: await Promise.all(node.children.map(inlineExportNodeImages)) };
+        }
+        const languages = await Promise.all(
+            node.languages.map(async (lang) =>
+                lang.language === 'markdown'
+                    ? { ...lang, content: await inlinePastedImageLinks(lang.content) }
+                    : lang
+            )
+        );
+        return { ...node, languages };
+    }
+
     async function downloadFolder(folderId: string) {
         const files = getFiles();
         const node = buildExportNode(folderId, files);
         if (!node || node.type !== 'folder') return;
-        const textData = JSON.stringify(node, null, 2);
+        const textData = JSON.stringify(await inlineExportNodeImages(node), null, 2);
         const filename = `${node.name || 'folder'}.json`;
 
         if (isDesktopMode) {
@@ -2096,9 +2113,12 @@ func main() {
     }
 
     // Builds the markdown snippet inserted when an image is pasted into a
-    // markdown file (base64 data URL).
-    function markdownImageSnippet(dataUrl: string): string {
-        return `![image](${dataUrl})`;
+    // markdown file. The base64 payload is stored in IndexedDB and the source
+    // gets a fake link (cojudge://image/<id>) that previews resolve back to
+    // the payload (see resolvePastedImages).
+    async function markdownImageSnippet(dataUrl: string): Promise<string> {
+        const link = await storePastedImage(dataUrl);
+        return `![image](${link})`;
     }
 
     // --- Image lightbox (full-size view opened from thumbnails) ---
@@ -2166,6 +2186,7 @@ func main() {
             ensureFileMentionCarets(wysiwygEl);
             prepareTaskListCheckboxes(wysiwygEl);
             ensureTrailingEmptyLine(wysiwygEl);
+            resolvePastedImages(wysiwygEl);
             wysiwygEl.focus();
         }
     }
@@ -2923,6 +2944,9 @@ func main() {
         const deleteBtn = target.closest(`.${THUMB_DELETE_CLASS}`) as HTMLElement | null;
         if (deleteBtn && wysiwygEl?.contains(deleteBtn)) {
             event.preventDefault();
+            const img = deleteBtn.closest(`.${THUMB_WRAPPER_CLASS}`)?.querySelector('img');
+            const fakeLink = img?.dataset.cojudgeImg;
+            if (fakeLink) deletePastedImage(fakeLink);
             deleteBtn.closest(`.${THUMB_WRAPPER_CLASS}`)?.remove();
             ensureTrailingEmptyLine(wysiwygEl);
             commitWysiwygEdits();
@@ -2944,8 +2968,11 @@ func main() {
         if (deleteBtn && container.contains(deleteBtn)) {
             event.preventDefault();
             const img = deleteBtn.closest(`.${THUMB_WRAPPER_CLASS}`)?.querySelector('img');
-            const src = img?.getAttribute('src');
-            if (src) deletePreviewImage(src);
+            const fakeLink = img?.dataset.cojudgeImg;
+            const src = fakeLink || img?.getAttribute('src');
+            if (!src) return;
+            if (fakeLink) deletePastedImage(fakeLink);
+            deletePreviewImage(src);
             return;
         }
         const img = target.closest(`.${THUMB_WRAPPER_CLASS} img`) as HTMLImageElement | null;
@@ -3014,8 +3041,10 @@ func main() {
         }
     }
 
-    // Paste images into the WYSIWYG area as base64 <img> elements.
-    // Plain URL strings are inserted as clickable links (new tab).
+    // Paste images into the WYSIWYG area as <img> elements backed by IndexedDB
+    // (the source keeps a fake cojudge://image/<id> link; resolvePastedImages
+    // swaps it for the payload). Plain URL strings are inserted as clickable
+    // links (new tab).
     function handleWysiwygPaste(event: ClipboardEvent) {
         const items = event.clipboardData?.items;
         if (items) {
@@ -3025,14 +3054,16 @@ func main() {
                 if (!file) continue;
                 event.preventDefault();
                 const reader = new FileReader();
-                reader.onload = () => {
-                    document.execCommand('insertImage', false, reader.result as string);
+                reader.onload = async () => {
+                    const link = await storePastedImage(reader.result as string);
+                    document.execCommand('insertImage', false, link);
                     if (wysiwygEl) {
                         wrapImageThumbnails(wysiwygEl);
                         wrapCodeBlocksWithCopy(wysiwygEl);
                         // Keep an empty line after the pasted image so the caret
                         // can move past the contenteditable="false" thumbnail
                         ensureTrailingEmptyLine(wysiwygEl);
+                        resolvePastedImages(wysiwygEl);
                     }
                 };
                 reader.readAsDataURL(file);
@@ -4083,6 +4114,14 @@ func main() {
             resolveFileLanguage: (fileId) => getLanguageForTab(fileId)
         });
     })();
+    let previewEl: HTMLDivElement | null = null;
+    // Pasted images render as fake links (cojudge://image/<id>); swap them for
+    // the IndexedDB payload once the HTML has been painted.
+    $: if (previewHtml) {
+        tick().then(() => {
+            if (previewEl) resolvePastedImages(previewEl);
+        });
+    }
     $: shareDirty = (() => {
         if (activeTab?.type === 'preview' && activeTab.sourceFileId) {
             const fkey = fileKey();
@@ -4946,7 +4985,7 @@ func main() {
                 {:else}
                     <!-- svelte-ignore a11y-click-events-have-key-events -->
                     <!-- svelte-ignore a11y-no-static-element-interactions -->
-                    <div class="markdown-preview markdown-body" on:click={handlePreviewClick}>
+                    <div class="markdown-preview markdown-body" bind:this={previewEl} on:click={handlePreviewClick}>
                         {@html previewHtml}
                     </div>
                 {/if}


### PR DESCRIPTION
## What
Pasting an image into the markdown editor now stores the base64 payload in IndexedDB (`cojudge-images` / `images`) and inserts a `cojudge://image/<id>` link into the source, which the preview and WYSIWYG editor resolve against the store. Images referenced by markdown files are also carried through cloud sync and backup export/import.

## Changes
- `src/lib/utils/imageStore.ts`: IndexedDB store + helpers (`storePastedImage`, `getPastedImage`, `deletePastedImage`, `getAllPastedImages`, `importPastedImages`, `inlinePastedImageLinks`, link parsing/extraction)
- `src/lib/utils/markdown.ts`: turndown rule round-trips the fake link; `resolvePastedImages()` swaps it for a data URL in previews
- `src/lib/cloudSync.ts`: `readLocalSnapshot` attaches referenced image payloads as a `pasted-images` key; restore and discard-local-changes import them back into IndexedDB
- `src/routes/playground/+page.svelte`: async paste → store, preview resolution, WYSIWYG paste/render/delete with IndexedDB cleanup, folder download inlines images as data URLs
- `src/routes/+page.svelte`: backup export attaches all images; import extracts to IndexedDB then strips the key
- `src/lib/components/CodeEditor.svelte`: `onPasteImage` supports async handlers
- Tests: link parsing/extraction + markdown round-trip (107 passing, 0 new type errors)

## Fix included
Restore ("Local progress changed during sync") could fail deterministically when the document contained a pasted image: the pre-apply integrity check compared a localStorage-only serialization against a snapshot serialization that included the `pasted-images` key. `LocalSnapshot` now keeps a separate `storageSerialized` for that check.