### PR TITLE
feat: playground MCP server with image and open-tab tools for agents

### DIFF
--- a/e2e/mcp-active-tab.test.ts
+++ b/e2e/mcp-active-tab.test.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const MCP_URL = 'http://localhost:4173/mcp';
+
+async function seedPlayground(page) {
+    const now = Date.now();
+    const files = [
+        {
+            fileId: 'file-a',
+            fileName: 'FileA.java',
+            language: 'java',
+            lastLanguage: 'java',
+            content: 'public class FileA {\n    public static void main(String[] args) {\n        System.out.println("hi");\n    }\n}\n',
+            viewState: null,
+            output: '',
+            logs: '',
+            isActive: false,
+            order: 0,
+            isOpen: true,
+            lastUpdated: now
+        }
+    ];
+    await page.evaluate(
+        ([files, now]) => {
+            localStorage.removeItem('user-settings');
+            localStorage.setItem('files', JSON.stringify({ playground: JSON.stringify(files) }));
+            localStorage.setItem(
+                'mcp-server-settings',
+                JSON.stringify({
+                    running: true,
+                    permissions: { read: true, write: true, create: true, delete: false, includeHidden: false }
+                })
+            );
+        },
+        [files, now]
+    );
+}
+
+test('agent edit_file updates the active tab', async ({ page }) => {
+    await page.goto('/playground');
+    await seedPlayground(page);
+    await page.reload();
+    await expect(page.locator('.monaco-editor')).toBeVisible();
+    await expect(page.locator('.monaco-editor .view-lines')).toContainText('println("hi")');
+
+    // Wait until the page pushed its snapshot to the MCP server. The file map
+    // is shared across browser tabs, so check for this test's own file.
+    let fileCount = 0;
+    await expect
+        .poll(async () => {
+            const res = await fetch('http://localhost:4173/api/mcp/files');
+            const snapshot = await res.json();
+            fileCount = snapshot.entries.length;
+            return snapshot.entries.some((e) => e.fileName === 'FileA.java');
+        })
+        .toBe(true);
+
+    // Agent surgically edits the file the user has open as the active tab.
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const result = await client.callTool({
+        name: 'edit_file',
+        arguments: {
+            path: 'FileA.java',
+            edits: [{ oldText: 'println("hi")', newText: 'println("edited by agent")' }]
+        }
+    });
+    expect(result.isError).toBeFalsy();
+    await client.close();
+
+    // The SSE push must flow through to the visible editor of the active tab.
+    await expect(page.locator('.monaco-editor .view-lines')).toContainText('edited by agent');
+    await expect(page.locator('.monaco-editor .view-lines')).not.toContainText('println("hi")');
+});

--- a/e2e/mcp-open-tabs.test.ts
+++ b/e2e/mcp-open-tabs.test.ts
@@ -1,0 +1,203 @@
+import { expect, test } from '@playwright/test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const MCP_URL = 'http://localhost:4173/mcp';
+
+type OpenTabsResult = {
+    active: { path: string | null; name: string; type: string } | null;
+    open: { path: string | null; name: string; type: string }[];
+};
+
+async function startMcpServer(): Promise<void> {
+    const res = await fetch('http://localhost:4173/api/mcp/state', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'start' })
+    });
+    expect(res.ok).toBeTruthy();
+}
+
+async function getOpenTabs(client: Client): Promise<OpenTabsResult> {
+    const result = await client.callTool({ name: 'get_open_tabs', arguments: {} });
+    expect(result.isError).toBeFalsy();
+    return JSON.parse(result.content[0].text) as OpenTabsResult;
+}
+
+test('get_open_tabs reports the active tab, open tabs, previews and hidden-file gating', async () => {
+    await startMcpServer();
+
+    const now = Date.now();
+    const seed = await fetch('http://localhost:4173/api/mcp/files', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            entries: [
+                {
+                    fileId: 'note-a',
+                    fileName: 'a.md',
+                    content: '# A',
+                    language: 'markdown',
+                    parentId: null,
+                    type: 'editor',
+                    lastUpdated: now
+                },
+                {
+                    fileId: 'file-b',
+                    fileName: 'b.txt',
+                    content: 'b',
+                    language: 'plaintext',
+                    parentId: null,
+                    type: 'editor',
+                    lastUpdated: now
+                },
+                {
+                    fileId: 'file-c',
+                    fileName: '.secret.md',
+                    content: 's',
+                    language: 'markdown',
+                    parentId: null,
+                    type: 'editor',
+                    lastUpdated: now
+                }
+            ],
+            tombstones: []
+        })
+    });
+    expect(seed.ok).toBeTruthy();
+
+    const tabs = await fetch('http://localhost:4173/api/mcp/tabs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            activeTabId: 'note-a',
+            openTabs: [
+                { fileId: 'note-a', fileName: 'a.md', type: 'editor', sourceFileId: null, lastUpdated: now + 2000 },
+                { fileId: 'preview-1', fileName: 'a.md', type: 'preview', sourceFileId: 'note-a', lastUpdated: now + 1500 },
+                { fileId: 'file-b', fileName: 'b.txt', type: 'editor', sourceFileId: null, lastUpdated: now + 1000 },
+                { fileId: 'file-c', fileName: '.secret.md', type: 'editor', sourceFileId: null, lastUpdated: now },
+                { fileId: 'wb-1', fileName: 'Whiteboard', type: 'whiteboard', sourceFileId: null, lastUpdated: now }
+            ]
+        })
+    });
+    expect(tabs.ok).toBeTruthy();
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const result = await getOpenTabs(client);
+    await client.close();
+
+    expect(result.active).toEqual({ path: 'a.md', name: 'a.md', type: 'editor' });
+    const paths = result.open.map((tab) => tab.path);
+    expect(paths).toEqual(['a.md', 'b.txt', null]);
+    const whiteboard = result.open.find((tab) => tab.path === null);
+    expect(whiteboard).toEqual({ path: null, name: 'Whiteboard', type: 'whiteboard' });
+    expect(result.open.some((tab) => tab.name === '.secret.md')).toBeFalsy();
+});
+
+test('the playground pushes tab state and tab switches update the active tab', async ({ page, request }) => {
+    const now = Date.now();
+    // Clear the shared server's state from the previous test so the page's
+    // MCP file sync has nothing to pull or open as tabs. The server merges
+    // by mtime, so existing files need tombstones to be deleted.
+    const snapshot = await (await fetch('http://localhost:4173/api/mcp/files')).json();
+    const resetFiles = await request.post('http://localhost:4173/api/mcp/files', {
+        data: {
+            entries: [],
+            tombstones: (snapshot.entries ?? []).map((e: { fileId: string }) => ({
+                fileId: e.fileId,
+                time: Date.now() + 1000
+            }))
+        }
+    });
+    expect(resetFiles.ok()).toBeTruthy();
+    const resetTabs = await request.post('http://localhost:4173/api/mcp/tabs', {
+        data: { activeTabId: null, openTabs: [] }
+    });
+    expect(resetTabs.ok()).toBeTruthy();
+
+    // Seed storage before the page loads (applies to every navigation, so
+    // there is no unseeded first load that persists a stray default tab).
+    await page.addInitScript(
+        ([now]) => {
+            localStorage.setItem(
+                'files',
+                JSON.stringify({
+                    playground: JSON.stringify([
+                        {
+                            fileId: 'ui-a',
+                            fileName: 'a.md',
+                            type: 'editor',
+                            language: 'markdown',
+                            content: '# A',
+                            order: 0,
+                            isOpen: true,
+                            lastUpdated: now + 2000
+                        },
+                        {
+                            fileId: 'ui-b',
+                            fileName: 'b.txt',
+                            type: 'editor',
+                            language: 'plaintext',
+                            content: 'b',
+                            order: 1,
+                            isOpen: true,
+                            lastUpdated: now + 1000
+                        },
+                        {
+                            fileId: 'ui-c',
+                            fileName: 'c.txt',
+                            type: 'editor',
+                            language: 'plaintext',
+                            content: 'c',
+                            order: 2,
+                            isOpen: false,
+                            lastUpdated: now
+                        }
+                    ])
+                })
+            );
+            localStorage.setItem(
+                'mcp-server-settings',
+                JSON.stringify({
+                    running: true,
+                    permissions: { read: true, write: true, create: true, delete: false, includeHidden: false }
+                })
+            );
+        },
+        [now]
+    );
+
+    await page.goto('/playground');
+    // The playground page starts the MCP server from onMount, which runs
+    // after the load event; wait for it so the SDK connect below does not
+    // race a stopped server.
+    await expect
+        .poll(async () => {
+            const res = await fetch('http://localhost:4173/api/mcp/state');
+            return (await res.json()).running;
+        })
+        .toBe(true);
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    try {
+        await expect
+            .poll(async () => {
+                const result = await getOpenTabs(client);
+                const paths = result.open.map((tab) => tab.path).sort();
+                return result.active?.path === 'a.md' && JSON.stringify(paths) === JSON.stringify(['a.md', 'b.txt']);
+            })
+            .toBe(true);
+
+        await page.getByRole('tab', { name: /b\.txt/ }).click();
+        await expect
+            .poll(async () => {
+                const result = await getOpenTabs(client);
+                return result.active?.path === 'b.txt';
+            })
+            .toBe(true);
+    } finally {
+        await client.close();
+    }
+});

--- a/e2e/mcp-read-image.test.ts
+++ b/e2e/mcp-read-image.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from '@playwright/test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const MCP_URL = 'http://localhost:4173/mcp';
+
+const IMAGE_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+const IMAGE_LINK = 'cojudge://image/img-1';
+const IMAGE_DATA_URL = `data:image/png;base64,${IMAGE_BASE64}`;
+
+async function seedServerWithImage(): Promise<void> {
+    const stateRes = await fetch('http://localhost:4173/api/mcp/state', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'start' })
+    });
+    expect(stateRes.ok).toBeTruthy();
+
+    const now = Date.now();
+    const pushRes = await fetch('http://localhost:4173/api/mcp/files', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            entries: [
+                {
+                    fileId: 'note-a',
+                    fileName: 'note.md',
+                    content: `# Design\n\n![diagram](${IMAGE_LINK})\n`,
+                    language: 'markdown',
+                    parentId: null,
+                    type: 'editor',
+                    lastUpdated: now
+                }
+            ],
+            tombstones: [],
+            images: { [IMAGE_LINK]: IMAGE_DATA_URL }
+        })
+    });
+    expect(pushRes.ok).toBeTruthy();
+}
+
+test('read_image returns the pasted image for a known reference', async () => {
+    await seedServerWithImage();
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const result = await client.callTool({
+        name: 'read_image',
+        arguments: { link: IMAGE_LINK }
+    });
+    await client.close();
+
+    expect(result.isError).toBeFalsy();
+    const textBlock = result.content.find((block) => block.type === 'text');
+    expect(textBlock).toBeDefined();
+    const metadata = JSON.parse(textBlock.text) as { link: string; mimeType: string; size: number };
+    expect(metadata.link).toBe(IMAGE_LINK);
+    expect(metadata.mimeType).toBe('image/png');
+    expect(metadata.size).toBe(IMAGE_BASE64.length);
+
+    const imageBlock = result.content.find((block) => block.type === 'image');
+    expect(imageBlock).toBeDefined();
+    expect(imageBlock.mimeType).toBe('image/png');
+    expect(imageBlock.data).toBe(IMAGE_BASE64);
+});
+
+test('read_image fails cleanly for an unknown reference', async () => {
+    await seedServerWithImage();
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const result = await client.callTool({
+        name: 'read_image',
+        arguments: { link: 'cojudge://image/does-not-exist' }
+    });
+    await client.close();
+
+    expect(result.isError).toBeTruthy();
+    const textBlock = result.content.find((block) => block.type === 'text');
+    expect(textBlock).toBeDefined();
+    expect(textBlock.text).toContain('not available');
+});

--- a/e2e/mcp-upload-image.test.ts
+++ b/e2e/mcp-upload-image.test.ts
@@ -1,0 +1,188 @@
+import { expect, test } from '@playwright/test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const MCP_URL = 'http://localhost:4173/mcp';
+
+const IMAGE_BASE64 =
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+const IMAGE_DATA_URL = `data:image/png;base64,${IMAGE_BASE64}`;
+
+async function startMcpServer(): Promise<void> {
+    const res = await fetch('http://localhost:4173/api/mcp/state', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'start' })
+    });
+    expect(res.ok).toBeTruthy();
+}
+
+test('upload_image with a data URL returns a link that read_image can fetch back', async () => {
+    await startMcpServer();
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const upload = await client.callTool({
+        name: 'upload_image',
+        arguments: { data: IMAGE_DATA_URL }
+    });
+    expect(upload.isError).toBeFalsy();
+    const uploadMeta = JSON.parse(upload.content[0].text) as { id: string; link: string; mimeType: string };
+    expect(uploadMeta.link).toBe(`cojudge://image/${uploadMeta.id}`);
+    expect(uploadMeta.mimeType).toBe('image/png');
+
+    const read = await client.callTool({
+        name: 'read_image',
+        arguments: { link: uploadMeta.link }
+    });
+    expect(read.isError).toBeFalsy();
+    const imageBlock = read.content.find((block) => block.type === 'image');
+    expect(imageBlock).toBeDefined();
+    expect(imageBlock.data).toBe(IMAGE_BASE64);
+    expect(imageBlock.mimeType).toBe('image/png');
+    await client.close();
+
+    const imagesRes = await fetch(`http://localhost:4173/api/mcp/images?since=0`);
+    expect(imagesRes.ok).toBeTruthy();
+    const imagesPayload = (await imagesRes.json()) as { revision: number; images: Record<string, string> };
+    expect(imagesPayload.images[uploadMeta.id]).toBe(IMAGE_DATA_URL);
+
+    const noChangeRes = await fetch(`http://localhost:4173/api/mcp/images?since=${imagesPayload.revision}`);
+    const noChangePayload = (await noChangeRes.json()) as { revision: number; images?: Record<string, string> };
+    expect(noChangePayload.images).toBeUndefined();
+});
+
+test('upload_image accepts raw base64 with a mimeType', async () => {
+    await startMcpServer();
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const upload = await client.callTool({
+        name: 'upload_image',
+        arguments: { data: IMAGE_BASE64, mimeType: 'image/png' }
+    });
+    await client.close();
+
+    expect(upload.isError).toBeFalsy();
+    const uploadMeta = JSON.parse(upload.content[0].text) as { link: string; size: number };
+    expect(uploadMeta.link.startsWith('cojudge://image/')).toBeTruthy();
+    expect(uploadMeta.size).toBe(70);
+});
+
+test('upload_image reads base64 from a playground file', async () => {
+    await startMcpServer();
+
+    const now = Date.now();
+    const seed = await fetch('http://localhost:4173/api/mcp/files', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+            entries: [
+                {
+                    fileId: 'b64-file',
+                    fileName: 'diagram.txt',
+                    content: IMAGE_BASE64,
+                    language: 'plaintext',
+                    parentId: null,
+                    type: 'editor',
+                    lastUpdated: now
+                }
+            ],
+            tombstones: []
+        })
+    });
+    expect(seed.ok).toBeTruthy();
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const upload = await client.callTool({
+        name: 'upload_image',
+        arguments: { path: 'diagram.txt' }
+    });
+    expect(upload.isError).toBeFalsy();
+    const uploadMeta = JSON.parse(upload.content[0].text) as { link: string; mimeType: string };
+    expect(uploadMeta.link.startsWith('cojudge://image/')).toBeTruthy();
+
+    const read = await client.callTool({
+        name: 'read_image',
+        arguments: { link: uploadMeta.link }
+    });
+    expect(read.isError).toBeFalsy();
+    const imageBlock = read.content.find((block) => block.type === 'image');
+    expect(imageBlock.data).toBe(IMAGE_BASE64);
+    await client.close();
+});
+
+test('upload_image rejects garbage payloads and unknown paths', async () => {
+    await startMcpServer();
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const garbage = await client.callTool({
+        name: 'upload_image',
+        arguments: { data: 'not base64 at all!' }
+    });
+    expect(garbage.isError).toBeTruthy();
+
+    const missingPath = await client.callTool({
+        name: 'upload_image',
+        arguments: { path: 'nope.txt' }
+    });
+    expect(missingPath.isError).toBeTruthy();
+
+    const neither = await client.callTool({
+        name: 'upload_image',
+        arguments: {}
+    });
+    expect(neither.isError).toBeTruthy();
+    await client.close();
+});
+
+test('an uploaded image renders in the user\'s open note', async ({ page }) => {
+    await page.goto('/playground');
+    await page.evaluate(() => {
+        localStorage.removeItem('user-settings');
+        localStorage.setItem('files', JSON.stringify({ playground: JSON.stringify([]) }));
+        localStorage.setItem(
+            'mcp-server-settings',
+            JSON.stringify({
+                running: true,
+                permissions: { read: true, write: true, create: true, delete: false, includeHidden: false }
+            })
+        );
+    });
+    await page.reload();
+
+    await expect
+        .poll(async () => {
+            const res = await fetch('http://localhost:4173/api/mcp/state');
+            return (await res.json()).running;
+        })
+        .toBe(true);
+
+    // Agent uploads the image and writes a note that references it.
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const upload = await client.callTool({
+        name: 'upload_image',
+        arguments: { data: IMAGE_DATA_URL }
+    });
+    expect(upload.isError).toBeFalsy();
+    const link = (JSON.parse(upload.content[0].text) as { link: string }).link;
+    const write = await client.callTool({
+        name: 'write_file',
+        arguments: { path: 'note.md', content: `# Note\n\n![diagram](${link})\n` }
+    });
+    expect(write.isError).toBeFalsy();
+    await client.close();
+
+    // The note opens as a tab; activate it so the WYSIWYG renders, then the
+    // pasted image resolves to the data URL once the browser pulls the
+    // uploaded image into IndexedDB.
+    const noteTab = page.getByRole('tab', { name: /note\.md/ });
+    await expect(noteTab).toBeVisible({ timeout: 20000 });
+    await noteTab.click();
+    await expect(page.locator('img[data-cojudge-img]')).toHaveAttribute('src', /^data:image\/png/, {
+        timeout: 20000
+    });
+});

--- a/e2e/mcp-wysiwyg.test.ts
+++ b/e2e/mcp-wysiwyg.test.ts
@@ -1,0 +1,88 @@
+import { expect, test } from '@playwright/test';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+
+const MCP_URL = 'http://localhost:4173/mcp';
+
+async function seedPreviewWysiwyg(page) {
+    const now = Date.now();
+    const files = [
+        {
+            fileId: 'doc-1',
+            fileName: 'doc.md',
+            language: 'markdown',
+            lastLanguage: 'markdown',
+            content: '# My Document\n\nSome body text.\n',
+            viewState: null,
+            output: '',
+            logs: '',
+            isActive: false,
+            order: 0,
+            isOpen: true,
+            lastUpdated: now
+        },
+        {
+            fileId: 'preview-1',
+            fileName: 'Preview: doc.md',
+            language: 'markdown',
+            content: '',
+            viewState: null,
+            output: '',
+            logs: '',
+            isActive: false,
+            order: 1,
+            isOpen: true,
+            type: 'preview',
+            sourceFileId: 'doc-1',
+            lastUpdated: now
+        }
+    ];
+    await page.evaluate(
+        ([files]) => {
+            localStorage.removeItem('user-settings');
+            localStorage.setItem('files', JSON.stringify({ playground: JSON.stringify(files) }));
+            localStorage.setItem('playground-markdown-mode', 'wysiwyg');
+            localStorage.setItem(
+                'mcp-server-settings',
+                JSON.stringify({
+                    running: true,
+                    permissions: { read: true, write: true, create: true, delete: false, includeHidden: false }
+                })
+            );
+        },
+        [files]
+    );
+}
+
+test('agent edit_file re-renders the WYSIWYG view of the active tab', async ({ page }) => {
+    await page.goto('/playground');
+    await seedPreviewWysiwyg(page);
+    await page.reload();
+
+    const wysiwyg = page.locator('.wysiwyg-editing');
+    await expect(wysiwyg).toBeVisible();
+    await expect(wysiwyg).toContainText('Some body text');
+
+    await expect
+        .poll(async () => {
+            const res = await fetch('http://localhost:4173/api/mcp/files');
+            const snapshot = await res.json();
+            return snapshot.entries.some((e) => e.fileName === 'doc.md');
+        })
+        .toBe(true);
+
+    const client = new Client({ name: 'e2e', version: '1.0.0' });
+    await client.connect(new StreamableHTTPClientTransport(new URL(MCP_URL)));
+    const result = await client.callTool({
+        name: 'edit_file',
+        arguments: {
+            path: 'doc.md',
+            edits: [{ oldText: 'Some body text', newText: 'Edited by the agent' }]
+        }
+    });
+    expect(result.isError).toBeFalsy();
+    await client.close();
+
+    await expect(wysiwyg).toContainText('Edited by the agent');
+    await expect(wysiwyg).not.toContainText('Some body text');
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
+				"@modelcontextprotocol/sdk": "^1.30.0",
 				"@tauri-apps/api": "^2.11.1",
 				"dockerode": "^5.0.1",
 				"tar-stream": "^3.1.7",
@@ -1207,6 +1208,18 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/@hono/node-server": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+			"integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"hono": "^4"
+			}
+		},
 		"node_modules/@jest/schemas": {
 			"version": "29.6.3",
 			"resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1285,6 +1298,46 @@
 			"resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
 			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
 			"license": "BSD-2-Clause"
+		},
+		"node_modules/@modelcontextprotocol/sdk": {
+			"version": "1.30.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+			"integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+			"license": "MIT",
+			"dependencies": {
+				"@hono/node-server": "^1.19.9 || ^2.0.5",
+				"ajv": "^8.17.1",
+				"ajv-formats": "^3.0.1",
+				"content-type": "^1.0.5",
+				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.5",
+				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
+				"express": "^5.2.1",
+				"express-rate-limit": "^8.2.1",
+				"hono": "^4.11.4",
+				"jose": "^6.1.3",
+				"json-schema-typed": "^8.0.2",
+				"pkce-challenge": "^5.0.0",
+				"raw-body": "^3.0.0",
+				"zod": "^3.25 || ^4.0",
+				"zod-to-json-schema": "^3.25.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@cfworker/json-schema": "^4.1.1",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"@cfworker/json-schema": {
+					"optional": true
+				},
+				"zod": {
+					"optional": false
+				}
+			}
 		},
 		"node_modules/@playwright/test": {
 			"version": "1.57.0",
@@ -2403,6 +2456,19 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2427,6 +2493,39 @@
 			},
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+			"integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ajv-formats": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+			"license": "MIT",
+			"dependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependencies": {
+				"ajv": "^8.0.0"
+			},
+			"peerDependenciesMeta": {
+				"ajv": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/ansi-regex": {
@@ -2608,6 +2707,43 @@
 				"readable-stream": "^3.4.0"
 			}
 		},
+		"node_modules/body-parser": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^2.0.0",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
+				"on-finished": "^2.4.1",
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/browserslist": {
 			"version": "4.26.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
@@ -2675,6 +2811,15 @@
 				"node": ">=10.0.0"
 			}
 		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/cac": {
 			"version": "6.7.14",
 			"resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -2683,6 +2828,35 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/camelcase": {
@@ -2826,6 +3000,28 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
@@ -2834,6 +3030,32 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"node_modules/cors": {
+			"version": "2.8.6",
+			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+			"license": "MIT",
+			"dependencies": {
+				"object-assign": "^4",
+				"vary": "^1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/cpu-features": {
@@ -2854,7 +3076,6 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -2913,6 +3134,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/devalue": {
@@ -2978,6 +3208,26 @@
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)"
 		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.235",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.235.tgz",
@@ -2991,6 +3241,15 @@
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
 			"license": "MIT"
 		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -3000,12 +3259,32 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/es-errors": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+			"integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -3061,6 +3340,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
@@ -3088,6 +3373,15 @@
 				"@types/estree": "^1.0.0"
 			}
 		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/events-universal": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
@@ -3095,6 +3389,27 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"bare-events": "^2.7.0"
+			}
+		},
+		"node_modules/eventsource": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+			"license": "MIT",
+			"dependencies": {
+				"eventsource-parser": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/eventsource-parser": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/execa": {
@@ -3121,11 +3436,104 @@
 				"url": "https://github.com/sindresorhus/execa?sponsor=1"
 			}
 		},
+		"node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/express-rate-limit": {
+			"version": "8.6.2",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+			"integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"ip-address": "^10.2.0"
+			},
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/express-rate-limit"
+			},
+			"peerDependencies": {
+				"express": ">= 4.11"
+			}
+		},
+		"node_modules/express/node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
 		"node_modules/fast-fifo": {
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
 			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
 			"license": "MIT"
+		},
+		"node_modules/fast-uri": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fastify"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/fastify"
+				}
+			],
+			"license": "BSD-3-Clause"
 		},
 		"node_modules/faye-websocket": {
 			"version": "0.11.4",
@@ -3156,6 +3564,27 @@
 				"picomatch": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/find-up": {
@@ -3209,6 +3638,15 @@
 				"@firebase/util": "1.13.0"
 			}
 		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/fraction.js": {
 			"version": "4.3.7",
 			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -3221,6 +3659,15 @@
 			"funding": {
 				"type": "patreon",
 				"url": "https://github.com/sponsors/rawify"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/fs-constants": {
@@ -3248,7 +3695,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -3273,6 +3719,43 @@
 				"node": "*"
 			}
 		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/get-stream": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
@@ -3286,17 +3769,69 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/hasown": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
 			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/hono": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+			"integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.9.0"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/http-parser-js": {
@@ -3314,6 +3849,22 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+			"integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/idb": {
@@ -3349,6 +3900,24 @@
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"license": "ISC"
 		},
+		"node_modules/ip-address": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+			"integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/is-core-module": {
 			"version": "2.16.2",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
@@ -3381,6 +3950,12 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/is-promise": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+			"license": "MIT"
+		},
 		"node_modules/is-reference": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -3408,8 +3983,16 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/jose": {
+			"version": "6.2.8",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+			"integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
+			}
 		},
 		"node_modules/js-tokens": {
 			"version": "9.0.1",
@@ -3417,6 +4000,18 @@
 			"integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/json-schema-typed": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/kleur": {
 			"version": "4.1.5",
@@ -3510,12 +4105,71 @@
 				"node": ">= 20"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+			"integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/mimic-fn": {
 			"version": "4.0.0",
@@ -3642,6 +4296,15 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.23",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
@@ -3686,6 +4349,39 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/once": {
@@ -3768,6 +4464,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3782,7 +4487,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -3794,6 +4498,16 @@
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/path-to-regexp": {
+			"version": "8.4.2",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
 		},
 		"node_modules/pathe": {
 			"version": "1.1.2",
@@ -3830,6 +4544,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/pkce-challenge": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/pkg-types": {
@@ -3995,6 +4718,19 @@
 				"node": ">=12.0.0"
 			}
 		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/pump": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
@@ -4094,6 +4830,50 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/qs": {
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+			"integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
 		"node_modules/react-is": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -4133,6 +4913,15 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
 			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4212,6 +5001,22 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"is-promise": "^4.0.0",
+				"parseurl": "^1.3.3",
+				"path-to-regexp": "^8.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
 		"node_modules/sade": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
@@ -4251,6 +5056,51 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"license": "MIT"
 		},
+		"node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -4265,11 +5115,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -4282,10 +5137,81 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.4"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/siginfo": {
@@ -4362,6 +5288,15 @@
 			"integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/std-env": {
 			"version": "3.10.0",
@@ -4653,6 +5588,15 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/totalist": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -4705,6 +5649,37 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/type-is": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^2.0.0",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4731,6 +5706,15 @@
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
 			"integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
 			"license": "MIT"
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.3",
@@ -4781,6 +5765,15 @@
 			"license": "MIT",
 			"bin": {
 				"uuid": "dist-node/bin/uuid"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/vite": {
@@ -5983,7 +6976,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -6097,6 +7089,24 @@
 			"integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/zod": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"vitest": "^1.1.5"
 	},
 	"dependencies": {
+		"@modelcontextprotocol/sdk": "^1.30.0",
 		"@tauri-apps/api": "^2.11.1",
 		"dockerode": "^5.0.1",
 		"tar-stream": "^3.1.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
 		reuseExistingServer: !process.env.CI
 	},
 	testDir: 'e2e',
+	// The MCP manager is a server singleton, so browser contexts share its
+	// file snapshot and revision. Serialize tests to avoid cross-test races.
+	workers: 1,
 	use: {
 		baseURL: 'http://localhost:4173'
 	}

--- a/src-tauri/backend/desktop-server.mjs
+++ b/src-tauri/backend/desktop-server.mjs
@@ -49,9 +49,12 @@ const server = createServer((request, response) => {
 		return;
 	}
 
-	const authenticated = (request.headers.cookie ?? '')
-		.split(';')
-		.some((value) => value.trim() === cookie);
+	const authenticated =
+		(request.headers.cookie ?? '')
+			.split(';')
+			.some((value) => value.trim() === cookie) ||
+		request.headers.authorization === `Bearer ${token}` ||
+		requestUrl.searchParams.get('token') === token;
 	if (!authenticated) {
 		response.writeHead(403, { connection: 'close', 'content-type': 'text/plain' });
 		response.end('Forbidden');
@@ -120,7 +123,7 @@ async function main() {
 	});
 
 	process.env.ORIGIN = origin;
-	process.env.BODY_SIZE_LIMIT = '10M';
+	process.env.BODY_SIZE_LIMIT = '100M';
 	delete process.env.PROTOCOL_HEADER;
 	delete process.env.HOST_HEADER;
 	delete process.env.PORT_HEADER;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -22,7 +22,10 @@ use std::{
 };
 
 #[cfg(all(not(debug_assertions), unix))]
-use std::{os::unix::net::UnixStream, path::PathBuf};
+use std::os::unix::net::UnixStream;
+
+#[cfg(not(debug_assertions))]
+use std::path::PathBuf;
 
 #[cfg(all(not(debug_assertions), windows))]
 use std::os::windows::process::CommandExt;
@@ -552,6 +555,27 @@ async fn google_oauth_access_token(
         .map_err(|_| "Google sign-in stopped unexpectedly.".to_string())?
 }
 
+/**
+ * Generate a new desktop MCP token, persist it, and restart the backend so
+ * the new token takes effect. The webview re-bootstraps with the returned
+ * token to keep its session cookie valid. Errors in debug builds: rotation
+ * only exists in the packaged desktop app.
+ */
+#[tauri::command]
+async fn rotate_desktop_token(app: tauri::AppHandle) -> Result<String, String> {
+    #[cfg(not(debug_assertions))]
+    {
+        tauri::async_runtime::spawn_blocking(move || rotate_desktop_token_blocking(&app))
+            .await
+            .map_err(|_| "Token rotation stopped unexpectedly.".to_string())?
+    }
+    #[cfg(debug_assertions)]
+    {
+        let _ = app;
+        Err("Token rotation is only available in the packaged desktop app.".to_string())
+    }
+}
+
 #[cfg(not(debug_assertions))]
 fn show_startup_error(app: &tauri::AppHandle) {
     if app
@@ -583,6 +607,61 @@ fn random_token() -> std::io::Result<String> {
     let mut token = String::with_capacity(bytes.len() * 2);
     for byte in bytes {
         write!(token, "{byte:02x}").unwrap();
+    }
+    Ok(token)
+}
+
+#[cfg(not(debug_assertions))]
+fn desktop_token_path(app: &tauri::AppHandle) -> std::io::Result<PathBuf> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| std::io::Error::other(error.to_string()))?;
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir.join("desktop-mcp-token"))
+}
+
+#[cfg(not(debug_assertions))]
+fn write_desktop_token(path: &PathBuf, token: &str) -> std::io::Result<()> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    file.write_all(token.as_bytes())
+}
+
+/**
+ * The desktop MCP token persists across restarts so the URL users copy into
+ * their agent configuration stays valid. The first launch writes a fresh
+ * 64-hex token to the app data directory; later launches reuse it.
+ */
+#[cfg(not(debug_assertions))]
+fn load_or_create_desktop_token(app: &tauri::AppHandle) -> std::io::Result<String> {
+    let path = desktop_token_path(app)?;
+    if let Ok(existing) = std::fs::read_to_string(&path) {
+        let existing = existing.trim();
+        if existing.len() == 64 && existing.chars().all(|c| c.is_ascii_hexdigit()) {
+            return Ok(existing.to_owned());
+        }
+    }
+    let token = random_token()?;
+    write_desktop_token(&path, &token)?;
+    Ok(token)
+}
+
+#[cfg(not(debug_assertions))]
+fn rotate_desktop_token_blocking(app: &tauri::AppHandle) -> Result<String, String> {
+    let token = random_token().map_err(|error| error.to_string())?;
+    let path = desktop_token_path(app).map_err(|error| error.to_string())?;
+    write_desktop_token(&path, &token).map_err(|error| error.to_string())?;
+    stop_backend_child(app);
+    if let Err(error) = start_backend(app) {
+        show_startup_error(app);
+        return Err(format!("Failed to restart the backend: {error}"));
     }
     Ok(token)
 }
@@ -653,7 +732,7 @@ fn start_backend(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Error
         .parent()
         .ok_or("application executable has no parent directory")?
         .join(format!("cojudge-node{}", std::env::consts::EXE_SUFFIX));
-    let token = random_token()?;
+    let token = load_or_create_desktop_token(app)?;
     let session_id = random_token()?;
 
     let mut command = Command::new(node);
@@ -762,11 +841,8 @@ fn start_backend(app: &tauri::AppHandle) -> Result<(), Box<dyn std::error::Error
     Ok(())
 }
 
-fn shutdown_backend(app: &tauri::AppHandle) {
+fn stop_backend_child(app: &tauri::AppHandle) {
     let state = app.state::<Backend>();
-    if state.shutting_down.swap(true, Ordering::AcqRel) {
-        return;
-    }
 
     let Some(mut child) = state.child.lock().unwrap().take() else {
         return;
@@ -789,13 +865,22 @@ fn shutdown_backend(app: &tauri::AppHandle) {
     let _ = child.wait();
 }
 
+fn shutdown_backend(app: &tauri::AppHandle) {
+    let state = app.state::<Backend>();
+    if state.shutting_down.swap(true, Ordering::AcqRel) {
+        return;
+    }
+    stop_backend_child(app);
+}
+
 fn main() {
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .manage(Backend::default())
         .invoke_handler(tauri::generate_handler![
             new_window,
-            google_oauth_access_token
+            google_oauth_access_token,
+            rotate_desktop_token
         ])
         .on_menu_event(|app, event| {
             if event.id().0.as_str() == NEW_WINDOW_MENU_ID {

--- a/src/lib/components/McpServerModal.svelte
+++ b/src/lib/components/McpServerModal.svelte
@@ -1,0 +1,575 @@
+<script lang="ts">
+    import { onDestroy, tick } from 'svelte';
+    import { browser } from '$app/environment';
+    import {
+        desktopMcpToken,
+        getMcpUrl,
+        mcpClientState,
+        pullMcpFilesNow,
+        refreshMcpState,
+        restartMcpServer,
+        rotateDesktopMcpToken,
+        startMcpServer,
+        stopMcpServer,
+        syncMcpFilesNow,
+        updateMcpPermissions
+    } from '$lib/mcp/client';
+    import { mcpSettings } from '$lib/mcp/settings';
+    import type { McpPermissions } from '$lib/mcp/types';
+
+    export let open = false;
+    export let onClose: () => void = () => {};
+
+    let mcpModalCard: HTMLElement | null = null;
+    let copied = false;
+    let copyTimer: ReturnType<typeof setTimeout> | undefined;
+    let armRotation = false;
+    let armTimer: ReturnType<typeof setTimeout> | undefined;
+    let rotateError = '';
+    let draftPermissions: McpPermissions = $mcpSettings.permissions;
+    const permissionItems: { key: 'read' | 'write' | 'create' | 'delete'; label: string; hint: string }[] = [
+        { key: 'read', label: 'READ', hint: 'Search and view files' },
+        { key: 'write', label: 'WRITE', hint: 'Edit, move and rename files and folders' },
+        { key: 'create', label: 'CREATE', hint: 'Create files and notes' },
+        { key: 'delete', label: 'DELETE', hint: 'Delete files and folders' }
+    ];
+
+    function close() {
+        onClose();
+    }
+
+    async function openModal() {
+        copied = false;
+        draftPermissions = $mcpSettings.permissions;
+        await refreshMcpState();
+        if ($mcpSettings.running && !$mcpClientState.running) {
+            await startMcpServer();
+        }
+        void syncMcpFilesNow();
+        void pullMcpFilesNow();
+        await tick();
+        mcpModalCard?.focus();
+    }
+
+    async function handleStart() {
+        await startMcpServer();
+        void syncMcpFilesNow();
+    }
+
+    async function handleRestart() {
+        await restartMcpServer();
+        void syncMcpFilesNow();
+    }
+
+    async function handleRefresh() {
+        void syncMcpFilesNow();
+        void pullMcpFilesNow();
+        await refreshMcpState();
+    }
+
+    async function handleRotate() {
+        rotateError = '';
+        if (!armRotation) {
+            armRotation = true;
+            if (armTimer) clearTimeout(armTimer);
+            armTimer = setTimeout(() => (armRotation = false), 4000);
+            return;
+        }
+        if (armTimer) clearTimeout(armTimer);
+        armRotation = false;
+        try {
+            // Navigates through the bootstrap endpoint; the app reloads with
+            // the new token and a fresh session cookie.
+            await rotateDesktopMcpToken();
+        } catch (error) {
+            rotateError = error instanceof Error ? error.message : 'Token rotation failed.';
+        }
+    }
+
+    $: if (open) void openModal();
+
+    $: if (browser) {
+        if (open) {
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.overflow = '';
+        }
+    }
+
+    onDestroy(() => {
+        if (browser) document.body.style.overflow = '';
+        if (copyTimer) clearTimeout(copyTimer);
+        if (armTimer) clearTimeout(armTimer);
+    });
+
+    async function copyUrl() {
+        if (!browser) return;
+        try {
+            await navigator.clipboard.writeText(getMcpUrl());
+        } catch {
+            // Clipboard API can be blocked; try a fallback selection.
+            const input = document.querySelector<HTMLInputElement>('.mcp-url-input');
+            input?.select();
+        }
+        copied = true;
+        if (copyTimer) clearTimeout(copyTimer);
+        copyTimer = setTimeout(() => (copied = false), 2000);
+    }
+
+    async function setPermission(key: keyof McpPermissions, value: boolean) {
+        draftPermissions = { ...draftPermissions, [key]: value };
+        await updateMcpPermissions(draftPermissions);
+    }
+
+    function trapModalFocus(event: KeyboardEvent, modal: HTMLElement) {
+        const focusable = Array.from(
+            modal.querySelectorAll<HTMLElement>('button:not(:disabled), input:not(:disabled)')
+        );
+        if (!focusable.length) return;
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey && document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+            event.preventDefault();
+            first.focus();
+        }
+    }
+
+    function handleModalKeydown(event: KeyboardEvent) {
+        if (!open) return;
+        if (event.defaultPrevented) return;
+        if (!mcpModalCard) return;
+        if (event.key === 'Escape') {
+            event.preventDefault();
+            close();
+            return;
+        }
+        if (event.key === 'Tab') trapModalFocus(event, mcpModalCard);
+    }
+</script>
+
+<svelte:window onkeydown={handleModalKeydown} />
+
+{#if open}
+    <div class="home-modal-shell">
+        <button class="home-modal-backdrop" aria-label="Close MCP Server settings" tabindex="-1" onclick={close}></button>
+        <div
+            bind:this={mcpModalCard}
+            class="home-modal-card mcp-settings-card"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="mcp-settings-title"
+            tabindex="-1"
+        >
+            <div class="modal-heading-row">
+                <div>
+                    <span class="modal-eyebrow">Agent access</span>
+                    <h2 id="mcp-settings-title">MCP Server</h2>
+                </div>
+                <div class="modal-heading-right">
+                    <span class:running={$mcpClientState.running} class="mcp-status-pill">
+                        <span></span>{$mcpClientState.running ? 'Running' : 'Stopped'}
+                    </span>
+                    <button class="modal-close-btn" type="button" onclick={close} aria-label="Close">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                            <line x1="18" y1="6" x2="6" y2="18"></line>
+                            <line x1="6" y1="6" x2="18" y2="18"></line>
+                        </svg>
+                    </button>
+                </div>
+            </div>
+
+            <p>Agents connect to Cojudge over the Model Context Protocol to search, view, edit, and create notes on your playground files. Copy the URL into your agent as an MCP server, then control exactly what it may do below.</p>
+
+            <div class="mcp-url-row">
+                <input class="mcp-url-input" readonly value={getMcpUrl()} spellcheck="false" onfocus={(e) => e.currentTarget.select()} />
+                <button class="btn mcp-copy-btn" type="button" onclick={copyUrl}>
+                    {copied ? 'Copied' : 'Copy'}
+                </button>
+            </div>
+            {#if $desktopMcpToken}
+                <div class="mcp-rotate-row">
+                    <button
+                        class="btn mcp-rotate-btn"
+                        type="button"
+                        onclick={handleRotate}
+                        disabled={armRotation}
+                    >
+                        {armRotation ? 'Click again to confirm' : 'Rotate token'}
+                    </button>
+                    <span class="mcp-rotate-hint">Generate a new token. Agents with the old URL lose access.</span>
+                </div>
+            {/if}
+            {#if rotateError}
+                <p class="modal-error" role="alert">{rotateError}</p>
+            {/if}
+
+            <div class="mcp-section">
+                <strong class="mcp-section-title">Permissions</strong>
+                <div class="mcp-permission-list">
+                    {#each permissionItems as item}
+                        <div class="mcp-permission-row">
+                            <div class="mcp-permission-label">
+                                <strong>{item.label}</strong>
+                                <span>{item.hint}</span>
+                            </div>
+                            <button
+                                class="mcp-toggle"
+                                class:on={draftPermissions[item.key]}
+                                type="button"
+                                role="switch"
+                                aria-checked={draftPermissions[item.key]}
+                                aria-label={item.label}
+                                onclick={() => setPermission(item.key, !draftPermissions[item.key])}
+                                disabled={$mcpClientState.loading}
+                            >
+                                <span></span>
+                            </button>
+                        </div>
+                    {/each}
+                    <div class="mcp-permission-row">
+                        <div class="mcp-permission-label">
+                            <strong>Hidden files</strong>
+                            <span>Also expose dotfiles (names starting with <code>.</code>, like <code>.env</code>)</span>
+                        </div>
+                        <button
+                            class="mcp-toggle"
+                            class:on={draftPermissions.includeHidden}
+                            type="button"
+                            role="switch"
+                            aria-checked={draftPermissions.includeHidden}
+                            aria-label="Include hidden files"
+                            onclick={() => setPermission('includeHidden', !draftPermissions.includeHidden)}
+                            disabled={$mcpClientState.loading}
+                        >
+                            <span></span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <div class="mcp-section">
+                <div class="mcp-section-heading">
+                    <strong class="mcp-section-title">Server</strong>
+                    <span class="mcp-file-count">{$mcpClientState.fileCount} { $mcpClientState.fileCount === 1 ? 'file' : 'files'} available</span>
+                </div>
+                <div class="mcp-server-actions">
+                    <button class="btn" type="button" onclick={handleStart} disabled={$mcpClientState.loading || $mcpClientState.running}>
+                        Start
+                    </button>
+                    <button class="btn" type="button" onclick={stopMcpServer} disabled={$mcpClientState.loading || !$mcpClientState.running}>
+                        Stop
+                    </button>
+                    <button class="btn" type="button" onclick={handleRestart} disabled={$mcpClientState.loading || !$mcpClientState.running}>
+                        Restart
+                    </button>
+                    <button class="btn mcp-refresh-btn" type="button" onclick={handleRefresh} disabled={$mcpClientState.loading}>
+                        Refresh
+                    </button>
+                </div>
+            </div>
+
+            {#if $mcpClientState.error}
+                <p class="modal-error" role="alert">{$mcpClientState.error}</p>
+            {/if}
+
+            <p class="mcp-offline-note">Everything runs locally on this device. The server only listens while Cojudge is open, and only serves the playground files synced from this browser. File changes sync live over a local event stream, so agent edits appear in the playground and the file count here as they happen.</p>
+
+            <div class="home-modal-actions">
+                <div class="modal-actions-right">
+                    <button class="btn" type="button" onclick={close}>Close</button>
+                </div>
+            </div>
+        </div>
+    </div>
+{/if}
+
+<style>
+    .btn {
+        appearance: none;
+        border: 1px solid var(--color-border);
+        padding: 0.35rem 0.75rem;
+        border-radius: 0.375rem;
+        background: var(--color-btn);
+        cursor: pointer;
+        font-size: 0.9rem;
+        color: inherit;
+    }
+    .btn:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+    .home-modal-shell {
+        position: fixed;
+        inset: 0;
+        z-index: 1000;
+        display: grid;
+        place-items: center;
+        padding: 1.25rem;
+        overflow-y: auto;
+    }
+    .home-modal-backdrop {
+        position: absolute;
+        inset: 0;
+        border: 0;
+        background: rgba(0, 0, 0, 0.52);
+        cursor: default;
+    }
+    .home-modal-card {
+        position: relative;
+        width: min(430px, 100%);
+        max-height: calc(100vh - 2.5rem);
+        max-height: calc(100dvh - 2.5rem);
+        overflow-y: auto;
+        padding: 1.5rem;
+        border: 1px solid var(--color-border);
+        border-radius: 0.875rem;
+        background: var(--color-bg);
+        box-shadow: 0 24px 70px rgba(0, 0, 0, 0.3);
+    }
+    .home-modal-card p {
+        margin: 0;
+        color: var(--color-text-secondary);
+        line-height: 1.55;
+    }
+    .home-modal-actions {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+        margin-top: 1.5rem;
+        flex-wrap: wrap;
+    }
+    .modal-actions-right {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-left: auto;
+    }
+    .modal-heading-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-bottom: 0.5rem;
+    }
+    .modal-heading-right {
+        display: flex;
+        align-items: center;
+        gap: 0.6rem;
+    }
+    .modal-close-btn {
+        background: none;
+        border: none;
+        padding: 0.25rem;
+        cursor: pointer;
+        color: var(--color-text-secondary);
+        display: grid;
+        place-items: center;
+        border-radius: 0.375rem;
+        transition: background 0.15s ease, color 0.15s ease;
+    }
+    .modal-close-btn:hover {
+        background: var(--color-surface, rgba(255, 255, 255, 0.08));
+        color: var(--color-text);
+    }
+    .modal-eyebrow {
+        display: block;
+        margin-top: 0.35rem;
+        color: var(--color-highlight);
+        font-size: 0.7rem;
+        font-weight: 750;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+    .modal-error {
+        margin-top: 0.75rem !important;
+        color: var(--color-hard) !important;
+        font-size: 0.8rem;
+        font-weight: 600;
+    }
+    .mcp-settings-card {
+        width: min(520px, 100%);
+    }
+    .mcp-status-pill {
+        display: inline-flex;
+        align-items: center;
+        flex: 0 0 auto;
+        gap: 0.4rem;
+        padding: 0.3rem 0.55rem;
+        border: 1px solid var(--color-border);
+        border-radius: 999px;
+        color: var(--color-text-secondary);
+        font-size: 0.72rem;
+        font-weight: 650;
+    }
+    .mcp-status-pill span {
+        width: 0.45rem;
+        height: 0.45rem;
+        border-radius: 50%;
+        background: var(--color-text-secondary);
+    }
+    .mcp-status-pill.running {
+        color: var(--color-easy);
+    }
+    .mcp-status-pill.running span {
+        background: var(--color-easy);
+        box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-easy) 16%, transparent);
+    }
+    .mcp-url-row {
+        display: flex;
+        gap: 0.5rem;
+        margin-top: 1rem;
+    }
+    .mcp-url-input {
+        flex: 1;
+        min-width: 0;
+        padding: 0.4rem 0.6rem;
+        border: 1px solid var(--color-border);
+        border-radius: 0.375rem;
+        background: var(--color-second-bg);
+        color: var(--color-text);
+        font-family: var(--font-mono);
+        font-size: 0.76rem;
+        outline: none;
+    }
+    .mcp-url-input:focus-visible {
+        outline: 2px solid var(--color-highlight);
+        outline-offset: 1px;
+    }
+    .mcp-copy-btn {
+        flex: 0 0 auto;
+        font-size: 0.8rem;
+    }
+    .mcp-rotate-row {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin-top: 0.5rem;
+        flex-wrap: wrap;
+    }
+    .mcp-rotate-btn {
+        flex: 0 0 auto;
+        font-size: 0.8rem;
+    }
+    .mcp-rotate-hint {
+        color: var(--color-text-secondary);
+        font-size: 0.72rem;
+    }
+    .mcp-section {
+        display: grid;
+        gap: 0.5rem;
+        margin-top: 1rem;
+        padding: 0.85rem;
+        border: 1px solid var(--color-border);
+        border-radius: 0.65rem;
+        background: var(--color-surface);
+    }
+    .mcp-section-heading {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem;
+    }
+    .mcp-section-title {
+        color: var(--color-text);
+        font-size: 0.78rem;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+    }
+    .mcp-file-count {
+        color: var(--color-text-secondary);
+        font-size: 0.72rem;
+    }
+    .mcp-permission-list {
+        display: grid;
+        gap: 0.25rem;
+    }
+    .mcp-permission-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 0.45rem 0.1rem;
+    }
+    .mcp-permission-row + .mcp-permission-row {
+        border-top: 1px solid var(--color-border);
+    }
+    .mcp-permission-label {
+        display: grid;
+        gap: 0.1rem;
+        min-width: 0;
+    }
+    .mcp-permission-label strong {
+        color: var(--color-text);
+        font-size: 0.8rem;
+        letter-spacing: 0.02em;
+    }
+    .mcp-permission-label span {
+        overflow: hidden;
+        color: var(--color-text-secondary);
+        font-size: 0.72rem;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+    .mcp-permission-label code {
+        font-family: var(--font-mono);
+        font-size: 0.68rem;
+    }
+    .mcp-toggle {
+        position: relative;
+        flex: 0 0 auto;
+        width: 2.2rem;
+        height: 1.25rem;
+        padding: 0;
+        border: 1px solid var(--color-border);
+        border-radius: 999px;
+        background: color-mix(in srgb, var(--color-text) 16%, transparent);
+        cursor: pointer;
+        transition: background 0.15s ease, border-color 0.15s ease;
+    }
+    .mcp-toggle:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+    .mcp-toggle span {
+        position: absolute;
+        top: 50%;
+        left: 0.15rem;
+        width: 0.85rem;
+        height: 0.85rem;
+        border-radius: 50%;
+        background: #fff;
+        transform: translateY(-50%);
+        transition: left 0.15s ease;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+    }
+    .mcp-toggle.on {
+        background: var(--color-highlight);
+        border-color: var(--color-highlight);
+    }
+    .mcp-toggle.on span {
+        left: calc(100% - 1rem);
+    }
+    .mcp-toggle:focus-visible {
+        outline: 2px solid var(--color-highlight);
+        outline-offset: 2px;
+    }
+    .mcp-server-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+    .mcp-refresh-btn {
+        margin-left: auto;
+    }
+    .mcp-offline-note {
+        margin-top: 1rem !important;
+        padding: 0.75rem;
+        border-radius: 0.5rem;
+        background: var(--color-second-bg);
+        font-size: 0.76rem;
+    }
+</style>

--- a/src/lib/mcp/client.ts
+++ b/src/lib/mcp/client.ts
@@ -1,0 +1,596 @@
+import { browser } from '$app/environment';
+import { get, writable } from 'svelte/store';
+import fileStore, { fileSyncVersion, type FileEntry } from '$lib/stores/fileStore';
+import { findPastedImageLinks, getAllPastedImages, importPastedImages, parsePastedImageLink } from '$lib/utils/imageStore';
+import { mcpSettings } from './settings';
+import type { McpFileEntry, McpFilePush, McpFileSnapshot, McpPermissions, McpServerState, McpTabState } from './types';
+
+export type McpClientState = McpServerState & {
+    loading: boolean;
+    error: string;
+};
+
+const initialState: McpClientState = {
+    running: false,
+    permissions: { read: true, write: true, create: true, delete: false, includeHidden: false },
+    revision: 0,
+    fileCount: 0,
+    loading: false,
+    error: ''
+};
+
+export const mcpClientState = writable<McpClientState>(initialState);
+
+/** The playground key in the file store that the MCP server exposes. */
+export const MCP_FILE_KEY = 'playground';
+
+/**
+ * Per-launch token of the packaged desktop backend (set by the root layout).
+ * Persists across app restarts so copied MCP URLs stay valid; agents
+ * authenticate with it through the MCP URL query string. Null in dev mode.
+ */
+export const desktopMcpToken = writable<string | null>(null);
+
+export function setDesktopMcpToken(token: string | null): void {
+	desktopMcpToken.set(token);
+}
+
+/** The URL agents use to connect (Streamable HTTP MCP endpoint). */
+export function getMcpUrl(): string {
+	if (!browser) return '/mcp';
+	const base = `${window.location.origin}/mcp`;
+	const token = get(desktopMcpToken);
+	return token ? `${base}?token=${token}` : base;
+}
+
+/**
+ * Rotate the desktop MCP token (packaged app only): the backend regenerates
+ * the token, restarts, and this function redirects through the bootstrap
+ * endpoint so the webview's session cookie stays valid.
+ */
+export async function rotateDesktopMcpToken(): Promise<void> {
+	if (!browser) throw new Error('Token rotation is only available in the packaged desktop app.');
+	if (!get(desktopMcpToken)) {
+		throw new Error('Token rotation is only available in the packaged desktop app.');
+	}
+	const tauriInternals = (window as Window & {
+		__TAURI_INTERNALS__?: {
+			invoke: <T>(command: string, args?: Record<string, unknown>) => Promise<T>;
+		};
+	}).__TAURI_INTERNALS__;
+	if (!tauriInternals) throw new Error('The desktop bridge is unavailable.');
+	const token = await tauriInternals.invoke<string>('rotate_desktop_token');
+	window.location.href = `/__cojudge_bootstrap?token=${encodeURIComponent(token)}`;
+}
+
+async function requestState(): Promise<McpServerState> {
+    const response = await fetch('/api/mcp/state');
+    if (!response.ok) throw new Error(`MCP state request failed (${response.status}).`);
+    return (await response.json()) as McpServerState;
+}
+
+export async function refreshMcpState(): Promise<void> {
+    if (!browser) return;
+    mcpClientState.update((s) => ({ ...s, loading: true, error: '' }));
+    try {
+        const state = await requestState();
+        mcpClientState.set({ ...state, loading: false, error: '' });
+    } catch (error) {
+        mcpClientState.update((s) => ({
+            ...s,
+            loading: false,
+            error: error instanceof Error ? error.message : 'Could not reach the MCP server.'
+        }));
+    }
+}
+
+async function runAction(action: 'start' | 'stop' | 'restart' | 'setPermissions', permissions?: McpPermissions): Promise<void> {
+    if (!browser) return;
+    mcpClientState.update((s) => ({ ...s, loading: true, error: '' }));
+    try {
+        const response = await fetch('/api/mcp/state', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(permissions ? { action, permissions } : { action })
+        });
+        if (!response.ok) {
+            const payload = await response.json().catch(() => null);
+            throw new Error(payload?.error ?? `MCP action failed (${response.status}).`);
+        }
+        const state = (await response.json()) as McpServerState;
+        mcpClientState.set({ ...state, loading: false, error: '' });
+        mcpSettings.update((s) => ({ ...s, running: state.running, permissions: state.permissions }));
+    } catch (error) {
+        mcpClientState.update((s) => ({
+            ...s,
+            loading: false,
+            error: error instanceof Error ? error.message : 'MCP action failed.'
+        }));
+    }
+}
+
+export function startMcpServer(): Promise<void> {
+    return runAction('start');
+}
+
+export function stopMcpServer(): Promise<void> {
+    return runAction('stop');
+}
+
+export function restartMcpServer(): Promise<void> {
+    return runAction('restart');
+}
+
+export function updateMcpPermissions(permissions: McpPermissions): Promise<void> {
+    return runAction('setPermissions', permissions);
+}
+
+/** Start the server automatically when the user previously left it running. */
+export async function ensureMcpServerRunning(): Promise<void> {
+    if (!browser) return;
+    await refreshMcpState();
+    const settings = get(mcpSettings);
+    const state = get(mcpClientState);
+    if (settings.running && !state.running) {
+        await startMcpServer();
+    }
+}
+
+/** Convert playground FileEntry rows into the slim entries the MCP server stores. */
+export function toMcpEntries(entries: FileEntry[]): McpFileEntry[] {
+    const byId = new Map<string, FileEntry>();
+    for (const entry of entries) {
+        if (entry.type === 'preview' || entry.type === 'whiteboard') continue;
+        const existing = byId.get(entry.fileId);
+        if (!existing || (entry.lastUpdated ?? 0) > (existing.lastUpdated ?? 0)) {
+            byId.set(entry.fileId, entry);
+        }
+    }
+    return Array.from(byId.values()).map((entry) => ({
+        fileId: entry.fileId,
+        fileName: entry.fileName,
+        content: entry.content ?? '',
+        language: entry.language ?? 'plaintext',
+        parentId: entry.parentId ?? null,
+        type: entry.type === 'folder' ? 'folder' : 'editor',
+        order: entry.order,
+        lastUpdated: entry.lastUpdated ?? 0
+    }));
+}
+
+/** Build a FileEntry row the playground can ingest from an MCP snapshot row. */
+export function fromMcpEntry(entry: McpFileEntry): FileEntry {
+    return {
+        fileId: entry.fileId,
+        fileName: entry.fileName,
+        content: entry.content,
+        language: entry.language,
+        parentId: entry.parentId ?? null,
+        type: entry.type === 'folder' ? 'folder' : 'editor',
+        order: entry.order,
+        lastUpdated: entry.lastUpdated,
+        isActive: false,
+        isOpen: entry.type !== 'folder',
+        output: '',
+        logs: '',
+        viewState: null
+    } as FileEntry;
+}
+
+/** Shape of the playground's tab metadata, passed structurally. */
+export type McpClientTab = {
+    fileId: string;
+    fileName: string;
+    isOpen: boolean;
+    lastUpdated?: number;
+    type?: 'editor' | 'preview' | 'whiteboard';
+    sourceFileId?: string;
+};
+
+/** Convert playground tabs into the state pushed to the MCP server. */
+export function toMcpTabState(tabs: McpClientTab[], activeIndex: number): McpTabState {
+    const openTabs = tabs
+        .filter((tab) => tab.isOpen)
+        .map((tab) => ({
+            fileId: tab.fileId,
+            fileName: tab.fileName,
+            type: tab.type ?? 'editor',
+            sourceFileId: tab.sourceFileId ?? null,
+            lastUpdated: tab.lastUpdated ?? 0
+        }));
+    const active = activeIndex >= 0 && activeIndex < tabs.length ? tabs[activeIndex] : null;
+    const activeTabId = active
+        ? active.type === 'preview' && active.sourceFileId
+            ? active.sourceFileId
+            : active.fileId
+        : null;
+    return { activeTabId, openTabs };
+}
+
+/** Push the current tab state (open tabs + active tab) to the MCP server. */
+export async function pushMcpTabs(state: McpTabState): Promise<void> {
+    if (!browser) return;
+    if (!get(mcpClientState).running) return;
+    const response = await fetch('/api/mcp/tabs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(state)
+    });
+    if (!response.ok && response.status === 503) {
+        mcpClientState.update((s) => ({ ...s, running: false }));
+    }
+}
+
+/**
+ * Collect data URLs for every pasted image referenced by the given entries'
+ * markdown content, keyed by fake link (`cojudge://image/<id>`). Returns an
+ * empty map when nothing is referenced or IndexedDB is unavailable.
+ */
+async function collectReferencedImages(entries: McpFileEntry[]): Promise<Record<string, string>> {
+    const links = new Set<string>();
+    for (const entry of entries) {
+        if (entry.type === 'folder') continue;
+        for (const link of findPastedImageLinks(entry.content)) links.add(link);
+    }
+    if (links.size === 0) return {};
+    const all = await getAllPastedImages();
+    const images: Record<string, string> = {};
+    for (const link of links) {
+        const id = parsePastedImageLink(link);
+        if (id && all[id]) images[link] = all[id];
+    }
+    return images;
+}
+
+/** Revision of the image map this tab has imported into IndexedDB so far. */
+let knownImagesRevision = -1;
+
+/**
+ * Pull agent-uploaded images from the MCP server into IndexedDB so notes
+ * referencing them render. Uses `?since=` so the server only sends the full
+ * image map when it actually changed; only images missing locally are
+ * imported, and a fileSyncVersion bump re-renders open notes.
+ */
+export async function syncMcpImages(): Promise<void> {
+    if (!browser) return;
+    if (!get(mcpClientState).running) return;
+    try {
+        const response = await fetch(`/api/mcp/images?since=${knownImagesRevision}`);
+        if (!response.ok) return;
+        const payload = (await response.json()) as { revision?: number; images?: Record<string, string> };
+        if (typeof payload.revision !== 'number') return;
+        knownImagesRevision = payload.revision;
+        if (!payload.images) return;
+        const have = await getAllPastedImages();
+        const missing: Record<string, string> = {};
+        for (const [id, dataUrl] of Object.entries(payload.images)) {
+            if (typeof dataUrl !== 'string') continue;
+            if (!(id in have)) missing[id] = dataUrl;
+        }
+        if (Object.keys(missing).length === 0) return;
+        await importPastedImages(missing);
+        fileSyncVersion.update((version) => version + 1);
+    } catch {
+        // Server unreachable or IndexedDB unavailable; the next poll retries.
+    }
+}
+
+export async function pushMcpFiles(entries: FileEntry[], tombstones: { fileId: string; time: number }[]): Promise<void> {
+    if (!browser) return;
+    const state = get(mcpClientState);
+    if (!state.running) return;
+    const mcpEntries = toMcpEntries(entries);
+    const push: McpFilePush = {
+        entries: mcpEntries,
+        tombstones,
+        images: await collectReferencedImages(mcpEntries)
+    };
+    const response = await fetch('/api/mcp/files', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(push)
+    });
+    if (!response.ok) {
+        if (response.status === 503) {
+            mcpClientState.update((s) => ({ ...s, running: false }));
+        }
+        return;
+    }
+    const stateAfter = (await response.json()) as McpServerState;
+    mcpClientState.update((s) => ({ ...s, revision: stateAfter.revision, fileCount: stateAfter.fileCount }));
+}
+
+export async function pullMcpFiles(): Promise<McpFileSnapshot | null> {
+    if (!browser) return null;
+    const state = get(mcpClientState);
+    if (!state.running) return null;
+    const response = await fetch('/api/mcp/files');
+    if (!response.ok) {
+        if (response.status === 503) {
+            mcpClientState.update((s) => ({ ...s, running: false }));
+        }
+        return null;
+    }
+    return (await response.json()) as McpFileSnapshot;
+}
+
+/**
+ * Immediately push the current playground snapshot to the MCP server.
+ * Unlike the store subscription, this works from any page (the file store
+ * is read straight from localStorage) and bypasses the change-detection gate,
+ * so the popup can kick a sync on open / start / restart.
+ */
+export async function syncMcpFilesNow(): Promise<void> {
+    if (!browser) return;
+    if (!get(mcpClientState).running) return;
+    const store = get(fileStore);
+    let entries: FileEntry[] = [];
+    try {
+        entries = JSON.parse(store[MCP_FILE_KEY] ?? '[]') as FileEntry[];
+    } catch {
+        return;
+    }
+    await pushMcpFiles(entries, []);
+    await syncMcpImages();
+}
+
+export type PullApplied = {
+    added: { fileId: string; fileName: string; lastUpdated: number }[];
+    changed: number;
+    removed: number;
+};
+
+/**
+ * Merge a server snapshot into the file store. Entries the agent last touched
+ * (newer lastUpdated) win; entries the user last touched are kept; tombstones
+ * remove files the agent deleted. Only writes the store when something
+ * actually changed, so the playground only reloads its editor for real edits.
+ *
+ * When `prevKnownIds` is provided (the sync loop's deletion tracker), it is
+ * kept in sync with the merged result so later pushes emit correct tombstones.
+ */
+function mergeSnapshotIntoStore(snapshot: McpFileSnapshot, prevKnownIds: Set<string> | null): PullApplied {
+    const localEntries = entriesOfStore();
+    const localById = new Map(localEntries.map((entry) => [entry.fileId, entry]));
+    const localPrev = new Set(localEntries.map((entry) => entry.fileId));
+    const next: FileEntry[] = [];
+    const added: { fileId: string; fileName: string; lastUpdated: number }[] = [];
+    let changed = 0;
+
+    for (const entry of snapshot.entries) {
+        const local = localById.get(entry.fileId);
+        if (!local) {
+            next.push(fromMcpEntry(entry));
+            added.push({ fileId: entry.fileId, fileName: entry.fileName, lastUpdated: entry.lastUpdated });
+        } else if ((entry.lastUpdated ?? 0) > (local.lastUpdated ?? 0)) {
+            next.push({
+                ...fromMcpEntry(entry),
+                output: local.output,
+                logs: local.logs,
+                viewState: local.viewState,
+                isOpen: local.isOpen
+            });
+            changed++;
+        } else {
+            next.push(local);
+        }
+    }
+
+    let removed = 0;
+    const tombstoneTimes = new Map(snapshot.tombstones.map((t) => [t.fileId, t.time]));
+    for (const entry of localEntries) {
+        const tombstoneTime = tombstoneTimes.get(entry.fileId);
+        if (tombstoneTime !== undefined && (entry.lastUpdated ?? 0) <= tombstoneTime) {
+            removed++;
+            continue;
+        }
+        if (!next.some((candidate) => candidate.fileId === entry.fileId)) {
+            next.push(entry);
+        }
+    }
+
+    if (prevKnownIds) {
+        for (const id of localPrev) {
+            if (!next.some((candidate) => candidate.fileId === id)) prevKnownIds.delete(id);
+        }
+        const nextIds = new Set(next.map((entry) => entry.fileId));
+        for (const id of nextIds) prevKnownIds.add(id);
+    }
+
+    const applied: PullApplied = { added, changed, removed };
+    const changedSomething = added.length > 0 || changed > 0 || removed > 0;
+    if (changedSomething) {
+        fileStore.update((store) => ({ ...store, [MCP_FILE_KEY]: JSON.stringify(next) }));
+        fileSyncVersion.update((version) => version + 1);
+    }
+    return applied;
+}
+
+/** Registered by the playground sync loop; falls back to a standalone pull. */
+let pullHandler: (() => void) | null = null;
+
+function setMcpPullHandler(handler: (() => void) | null): void {
+    pullHandler = handler;
+}
+
+function requestMcpPull(): void {
+    if (pullHandler) {
+        pullHandler();
+        return;
+    }
+    void pullMcpFilesStandalone();
+}
+
+/** Pull the server snapshot and merge it, without the sync loop's bookkeeping. */
+async function pullMcpFilesStandalone(): Promise<void> {
+    if (!browser) return;
+    const snapshot = await pullMcpFiles();
+    if (!snapshot) return;
+    mergeSnapshotIntoStore(snapshot, null);
+    mcpClientState.update((s) => ({ ...s, revision: snapshot.revision, fileCount: snapshot.entries.length }));
+    void syncMcpImages();
+}
+
+/**
+ * Pull agent-made changes from the MCP server and merge them into the store.
+ * Works from any page; on the playground page it routes through the sync loop
+ * so new agent files also appear as tabs.
+ */
+export async function pullMcpFilesNow(): Promise<void> {
+    if (!browser) return;
+    if (pullHandler) {
+        pullHandler();
+        return;
+    }
+    await pullMcpFilesStandalone();
+}
+
+let eventSource: EventSource | null = null;
+let eventSourceRefCount = 0;
+
+/**
+ * Open the SSE event stream from the MCP server. The browser reconnects
+ * automatically on drops; events trigger an instant pull instead of waiting
+ * for the polling interval. Refcounted: pages call it in onMount and dispose
+ * in onDestroy; the last page to leave closes the connection.
+ */
+export function startMcpEventSync(): () => void {
+    if (!browser) return () => {};
+    eventSourceRefCount++;
+    if (!eventSource) {
+        eventSource = new EventSource('/api/mcp/events');
+        eventSource.addEventListener('files-changed', (event) => {
+            try {
+                const data = JSON.parse((event as MessageEvent).data) as { revision?: number };
+                if (typeof data.revision !== 'number') return;
+                const known = get(mcpClientState).revision;
+                if (known > 0 && data.revision <= known) return;
+                requestMcpPull();
+            } catch {
+                // Ignore malformed events.
+            }
+        });
+        eventSource.addEventListener('images-changed', () => {
+            void syncMcpImages();
+        });
+        eventSource.addEventListener('state-changed', () => {
+            void refreshMcpState();
+        });
+        eventSource.addEventListener('hello', () => {
+            void refreshMcpState();
+        });
+    }
+    return () => {
+        eventSourceRefCount--;
+        if (eventSourceRefCount <= 0 && eventSource) {
+            eventSource.close();
+            eventSource = null;
+        }
+    };
+}
+
+/** Read the current playground rows straight from the file store. */
+export function entriesOfStore(): FileEntry[] {
+    if (!browser) return [];
+    const store = get(fileStore);
+    const raw = store[MCP_FILE_KEY] ?? '[]';
+    try {
+        return JSON.parse(raw) as FileEntry[];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Subscribe to the file store, push it to the MCP server while running, and
+ * pull agent-made changes back into the store instantly over the SSE stream
+ * (with a polling interval as a fallback).
+ *
+ * Returns a cleanup function.
+ */
+export function setupMcpFileSync(options: {
+    pushDebounceMs?: number;
+    pullIntervalMs?: number;
+    onApplied?: (applied: PullApplied) => void;
+} = {}): () => void {
+    if (!browser) return () => {};
+    const pushDebounceMs = options.pushDebounceMs ?? 600;
+    const pullIntervalMs = options.pullIntervalMs ?? 4000;
+
+    let lastPushSignature = '';
+    let prevKnownIds = new Set<string>();
+    let reportedDeletions = new Set<string>();
+    let pushTimer: ReturnType<typeof setTimeout> | undefined;
+    let pullTimer: ReturnType<typeof setInterval> | undefined;
+    let disposed = false;
+
+    function schedulePush() {
+        if (disposed) return;
+        if (pushTimer) clearTimeout(pushTimer);
+        pushTimer = setTimeout(() => void pushNow(), pushDebounceMs);
+    }
+
+    async function pushNow() {
+        if (disposed) return;
+        const entries = entriesOfStore();
+        const signature = JSON.stringify(toMcpEntries(entries));
+        if (signature === lastPushSignature) return;
+        lastPushSignature = signature;
+
+        const currentIds = new Set(entries.map((entry) => entry.fileId));
+        const tombstones: { fileId: string; time: number }[] = [];
+        const now = Date.now();
+        for (const id of prevKnownIds) {
+            if (!currentIds.has(id) && !reportedDeletions.has(id)) {
+                tombstones.push({ fileId: id, time: now });
+                reportedDeletions.add(id);
+            }
+        }
+        for (const id of currentIds) {
+            reportedDeletions.delete(id);
+        }
+        prevKnownIds = currentIds;
+        await pushMcpFiles(entries, tombstones);
+    }
+
+    async function pullNow() {
+        if (disposed) return;
+        const snapshot = await pullMcpFiles();
+        if (!snapshot || disposed) return;
+        const applied = mergeSnapshotIntoStore(snapshot, prevKnownIds);
+        if (applied.added.length > 0 || applied.changed > 0 || applied.removed > 0) {
+            options.onApplied?.(applied);
+        }
+        mcpClientState.update((s) => ({ ...s, revision: snapshot.revision, fileCount: snapshot.entries.length }));
+        void syncMcpImages();
+    }
+
+    const unsubStore = fileStore.subscribe(() => schedulePush());
+    let wasRunning = false;
+    const unsubClientState = mcpClientState.subscribe((state) => {
+        if (state.running && !wasRunning) {
+            // The server just came up: push the current snapshot immediately,
+            // otherwise files stay empty until the next store change.
+            lastPushSignature = '';
+            schedulePush();
+            void pullNow();
+        }
+        if (!state.running) {
+            lastPushSignature = '';
+            reportedDeletions.clear();
+        }
+        wasRunning = state.running;
+    });
+    pullTimer = setInterval(() => void pullNow(), pullIntervalMs);
+    void pullNow();
+    setMcpPullHandler(() => void pullNow());
+
+    return () => {
+        disposed = true;
+        setMcpPullHandler(null);
+        unsubStore();
+        unsubClientState();
+        if (pushTimer) clearTimeout(pushTimer);
+        if (pullTimer) clearInterval(pullTimer);
+    };
+}

--- a/src/lib/mcp/settings.ts
+++ b/src/lib/mcp/settings.ts
@@ -1,0 +1,35 @@
+import { browser } from '$app/environment';
+import { writable } from 'svelte/store';
+import { writeProgressStorageItem } from '$lib/progressBackup';
+import { DEFAULT_MCP_SETTINGS, type McpSettings } from './types';
+
+const STORAGE_KEY = 'mcp-server-settings';
+
+function normalizeSettings(input: any): McpSettings {
+    const permissions = input?.permissions ?? {};
+    return {
+        running: typeof input?.running === 'boolean' ? input.running : DEFAULT_MCP_SETTINGS.running,
+        permissions: {
+            read: typeof permissions.read === 'boolean' ? permissions.read : DEFAULT_MCP_SETTINGS.permissions.read,
+            write: typeof permissions.write === 'boolean' ? permissions.write : DEFAULT_MCP_SETTINGS.permissions.write,
+            create: typeof permissions.create === 'boolean' ? permissions.create : DEFAULT_MCP_SETTINGS.permissions.create,
+            delete: typeof permissions.delete === 'boolean' ? permissions.delete : DEFAULT_MCP_SETTINGS.permissions.delete,
+            includeHidden: typeof permissions.includeHidden === 'boolean'
+                ? permissions.includeHidden
+                : DEFAULT_MCP_SETTINGS.permissions.includeHidden
+        }
+    };
+}
+
+const initialSettings: McpSettings = browser
+    ? normalizeSettings(JSON.parse(localStorage.getItem(STORAGE_KEY) || 'null'))
+    : DEFAULT_MCP_SETTINGS;
+
+/** Persisted client-side MCP server configuration. */
+export const mcpSettings = writable<McpSettings>(initialSettings);
+
+if (browser) {
+    mcpSettings.subscribe((value) => {
+        writeProgressStorageItem(localStorage, STORAGE_KEY, JSON.stringify(value));
+    });
+}

--- a/src/lib/mcp/types.ts
+++ b/src/lib/mcp/types.ts
@@ -1,0 +1,95 @@
+// Shared types for the Cojudge MCP server (used by both client and server code).
+
+export type McpPermission = 'read' | 'write' | 'create' | 'delete';
+
+export type McpPermissions = {
+    read: boolean;
+    write: boolean;
+    create: boolean;
+    delete: boolean;
+    /** Whether agents may access hidden files (names starting with `.`). */
+    includeHidden: boolean;
+};
+
+export const DEFAULT_MCP_PERMISSIONS: McpPermissions = {
+    read: true,
+    write: true,
+    create: true,
+    delete: false,
+    includeHidden: false
+};
+
+/** Slim view of a playground file exposed to MCP agents. */
+export type McpFileEntry = {
+    fileId: string;
+    fileName: string;
+    content: string;
+    language: string;
+    parentId: string | null;
+    type?: 'editor' | 'folder';
+    order?: number;
+    /** Last write time in ms since epoch; used for last-writer-wins merges. */
+    lastUpdated: number;
+};
+
+/** One tab currently open in the playground, as seen by MCP agents. */
+export type McpTabEntry = {
+    fileId: string;
+    fileName: string;
+    type: 'editor' | 'preview' | 'whiteboard';
+    /** Note id a preview tab renders (resolved to its path by the tool layer). */
+    sourceFileId: string | null;
+    lastUpdated: number;
+};
+
+/** Client push payload for /api/mcp/tabs. */
+export type McpTabState = {
+    /** fileId of the active tab (preview tabs resolve to their source note). */
+    activeTabId: string | null;
+    openTabs: McpTabEntry[];
+};
+
+/** Client push payload for /api/mcp/files. */
+export type McpFilePush = {
+    entries: McpFileEntry[];
+    tombstones: { fileId: string; time: number }[];
+    /**
+     * Data URLs for pasted images referenced by playground markdown files,
+     * keyed by their fake link (e.g. `cojudge://image/<id>`). Immutable once
+     * pushed; used by the read_image tool.
+     */
+    images?: Record<string, string>;
+};
+
+/** Server snapshot payload for the client (GET /api/mcp/files). */
+export type McpFileSnapshot = {
+    revision: number;
+    entries: McpFileEntry[];
+    tombstones: { fileId: string; time: number }[];
+};
+
+/** Full state returned by GET /api/mcp/state. */
+export type McpServerState = {
+    running: boolean;
+    permissions: McpPermissions;
+    revision: number;
+    fileCount: number;
+};
+
+/** Actions accepted by POST /api/mcp/state. */
+export type McpStateAction =
+    | { action: 'start' }
+    | { action: 'stop' }
+    | { action: 'restart' }
+    | { action: 'setPermissions'; permissions: McpPermissions };
+
+/** Persisted client-side MCP settings (localStorage). */
+export type McpSettings = {
+    running: boolean;
+    permissions: McpPermissions;
+};
+
+export const DEFAULT_MCP_SETTINGS: McpSettings = {
+    running: false,
+    permissions: DEFAULT_MCP_PERMISSIONS
+};

--- a/src/lib/server/mcp/manager.ts
+++ b/src/lib/server/mcp/manager.ts
@@ -1,0 +1,312 @@
+import { randomUUID } from 'node:crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import type { McpFileEntry, McpFilePush, McpFileSnapshot, McpPermissions, McpServerState, McpTabState } from '$lib/mcp/types';
+import { parsePastedImageLink } from '$lib/utils/imageStore';
+import { registerTools } from './tools';
+
+type ManagedFile = {
+    entry: McpFileEntry;
+    /** Last write time in ms since epoch (client save or agent tool call). */
+    mtime: number;
+};
+
+type Session = {
+    transport: WebStandardStreamableHTTPServerTransport;
+    server: McpServer;
+};
+
+const CORS_HEADERS: Record<string, string> = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID, Accept',
+    'Access-Control-Expose-Headers': 'Mcp-Session-Id, Last-Event-ID'
+};
+
+/**
+ * Server-side singleton holding the MCP server lifecycle, permission
+ * configuration, and the playground file snapshot synced from the client.
+ *
+ * The MCP protocol endpoint lives at /mcp and speaks the Streamable HTTP
+ * transport; start/stop/restart and permission changes go through the
+ * /api/mcp/state and /api/mcp/files control endpoints.
+ */
+export class McpManager {    private running = false;
+    private permissions: McpPermissions = {
+        read: true,
+        write: true,
+        create: true,
+        delete: false,
+        includeHidden: false
+    };
+    private files = new Map<string, ManagedFile>();
+    private tombstones = new Map<string, number>();
+    /** Pasted-image payloads keyed by image id (the `cojudge://image/<id>` id). */
+    private images = new Map<string, string>();
+    private imagesRevision = 0;
+    /** Last tab state pushed by a playground page (active tab + open tabs). */
+    private tabState: McpTabState = { activeTabId: null, openTabs: [] };
+    private revision = 0;
+    private sessions = new Map<string, Session>();
+
+    isRunning(): boolean {
+        return this.running;
+    }
+
+    getPermissions(): McpPermissions {
+        return { ...this.permissions };
+    }
+
+    getFileCount(): number {
+        return this.files.size;
+    }
+
+    getState(): McpServerState {
+        return {
+            running: this.running,
+            permissions: this.getPermissions(),
+            revision: this.revision,
+            fileCount: this.files.size
+        };
+    }
+
+    async start(): Promise<void> {
+        this.running = true;
+    }
+
+    async stop(): Promise<void> {
+        this.running = false;
+        await this.closeSessions();
+    }
+
+    async restart(): Promise<void> {
+        await this.closeSessions();
+        this.running = true;
+    }
+
+    setPermissions(permissions: McpPermissions): void {
+        this.permissions = {
+            read: Boolean(permissions.read),
+            write: Boolean(permissions.write),
+            create: Boolean(permissions.create),
+            delete: Boolean(permissions.delete),
+            includeHidden: Boolean(permissions.includeHidden)
+        };
+    }
+
+    /** Entry lookup used by the tool layer. */
+    getFile(fileId: string): McpFileEntry | undefined {
+        return this.files.get(fileId)?.entry;
+    }
+
+    /** All live entries (folders included), as stored. */
+    listFiles(): McpFileEntry[] {
+        return Array.from(this.files.values()).map((f) => ({ ...f.entry }));
+    }
+
+    /**
+     * Data URL of a pasted image, looked up by its fake link
+     * (`cojudge://image/<id>`) or bare id.
+     */
+    getImage(linkOrId: string): string | undefined {
+        const id = parsePastedImageLink(linkOrId) ?? linkOrId;
+        return this.images.get(id);
+    }
+
+    /** Store an image payload (agent upload) under a fresh id. */
+    setImage(id: string, dataUrl: string): void {
+        this.images.set(id, dataUrl);
+        this.imagesRevision++;
+    }
+
+    /** Every image payload keyed by id ({ [id]: dataUrl }). */
+    getImages(): Record<string, string> {
+        return Object.fromEntries(this.images);
+    }
+
+    /** Bumped on every agent image upload; drives the images-changed SSE event. */
+    getImagesRevision(): number {
+        return this.imagesRevision;
+    }
+
+    /** Remember the tab state pushed by a playground page (last writer wins). */
+    setTabState(state: McpTabState): void {
+        this.tabState = {
+            activeTabId: state.activeTabId ?? null,
+            openTabs: Array.isArray(state.openTabs) ? state.openTabs : []
+        };
+    }
+
+    /** The current tab state (active tab + open tabs). */
+    getTabState(): McpTabState {
+        return {
+            activeTabId: this.tabState.activeTabId,
+            openTabs: this.tabState.openTabs.map((tab) => ({ ...tab }))
+        };
+    }
+
+    /** Called by tools after an agent creates/edits a file. */
+    applyAgentWrite(entry: McpFileEntry): void {
+        const mtime = Date.now();
+        this.files.set(entry.fileId, { entry: { ...entry }, mtime });
+        this.tombstones.delete(entry.fileId);
+        this.revision++;
+    }
+
+    /** Called by tools after an agent deletes a file. */
+    applyAgentDelete(fileId: string): void {
+        const time = Date.now();
+        this.files.delete(fileId);
+        this.tombstones.set(fileId, Math.max(this.tombstones.get(fileId) ?? 0, time));
+        this.revision++;
+    }
+
+    /**
+     * Re-parent an entry and every entry beneath it (used for folder moves).
+     * Each moved entry gets a fresh mtime/lastUpdated so the browser's
+     * last-writer-wins merge picks the move up. Returns the number of entries
+     * moved.
+     */
+    applyAgentMove(fileId: string, newParentId: string | null): number {
+        const children = Array.from(this.files.values())
+            .filter((f) => f.entry.parentId === fileId)
+            .map((f) => f.entry);
+        let moved = 0;
+        for (const child of children) {
+            moved += this.applyAgentMove(child.fileId, fileId);
+        }
+        const existing = this.files.get(fileId);
+        if (!existing) return moved;
+        const mtime = Date.now();
+        this.files.set(fileId, {
+            entry: { ...existing.entry, parentId: newParentId, lastUpdated: mtime },
+            mtime
+        });
+        this.revision++;
+        return moved + 1;
+    }
+
+    /**
+     * Merge a client-pushed snapshot. The client is authoritative for files it
+     * last touched; the server keeps its own (agent-written) version when its
+     * mtime is newer, so agent edits are not clobbered by stale client pushes.
+     */
+    syncClientFiles(push: McpFilePush): void {
+        for (const entry of push.entries) {
+            if (!entry || typeof entry.fileId !== 'string') continue;
+            const existing = this.files.get(entry.fileId);
+            const mtime = typeof entry.lastUpdated === 'number' ? entry.lastUpdated : 0;
+            if (!existing || mtime >= existing.mtime) {
+                this.files.set(entry.fileId, { entry, mtime });
+                this.tombstones.delete(entry.fileId);
+            }
+        }
+        for (const tombstone of push.tombstones ?? []) {
+            const existing = this.files.get(tombstone.fileId);
+            if (existing && existing.mtime <= tombstone.time) {
+                this.files.delete(tombstone.fileId);
+            }
+            this.tombstones.set(
+                tombstone.fileId,
+                Math.max(this.tombstones.get(tombstone.fileId) ?? 0, tombstone.time)
+            );
+        }
+        for (const [link, dataUrl] of Object.entries(push.images ?? {})) {
+            if (typeof link === 'string' && typeof dataUrl === 'string') {
+                const id = parsePastedImageLink(link) ?? link;
+                this.images.set(id, dataUrl);
+            }
+        }
+        this.revision++;
+    }
+
+    getSnapshot(): McpFileSnapshot {
+        return {
+            revision: this.revision,
+            entries: this.listFiles(),
+            tombstones: Array.from(this.tombstones.entries()).map(([fileId, time]) => ({ fileId, time }))
+        };
+    }
+
+    /** True when the client should consider `fileId` deleted (per tombstones). */
+    getTombstoneTime(fileId: string): number {
+        return this.tombstones.get(fileId) ?? 0;
+    }
+
+    /**
+     * Route an HTTP request for the /mcp protocol endpoint. Serves the
+     * Streamable HTTP transport; requests that carry an unknown session id
+     * receive a 404 per the specification.
+     */
+    async handleProtocolRequest(request: Request): Promise<Response> {
+        if (!this.running) {
+            return this.withCors(new Response('MCP server is stopped', { status: 503 }));
+        }
+
+        const sessionId = request.headers.get('mcp-session-id');
+        if (sessionId) {
+            const session = this.sessions.get(sessionId);
+            if (!session) {
+                return this.withCors(new Response('Session not found', { status: 404 }));
+            }
+            return this.withCors(await session.transport.handleRequest(request));
+        }
+
+        const transport = new WebStandardStreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID()
+        });
+        const server = new McpServer({ name: 'cojudge-playground', version: '0.1.0' });
+        registerTools(server, this);
+        await server.connect(transport);
+        try {
+            const response = await transport.handleRequest(request);
+            const assigned = transport.sessionId;
+            if (assigned && !this.sessions.has(assigned)) {
+                this.sessions.set(assigned, { transport, server });
+                transport.onclose = () => {
+                    this.sessions.delete(assigned);
+                    void server.close();
+                };
+            } else {
+                void server.close();
+            }
+            return this.withCors(response);
+        } catch (error) {
+            void server.close();
+            throw error;
+        }
+    }
+
+    private async closeSessions(): Promise<void> {
+        const sessions = Array.from(this.sessions.values());
+        this.sessions.clear();
+        await Promise.allSettled(
+            sessions.map(async (session) => {
+                try {
+                    await session.transport.close();
+                } catch {
+                    // transport is already closed
+                }
+                try {
+                    await session.server.close();
+                } catch {
+                    // server is already closed
+                }
+            })
+        );
+    }
+
+    private withCors(response: Response): Response {
+        const headers = new Headers(response.headers);
+        for (const [name, value] of Object.entries(CORS_HEADERS)) {
+            headers.set(name, value);
+        }
+        return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers
+        });
+    }
+}
+
+export const mcpManager = new McpManager();

--- a/src/lib/server/mcp/tools.ts
+++ b/src/lib/server/mcp/tools.ts
@@ -1,0 +1,713 @@
+import { v4 as uuidv4 } from 'uuid';
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { ImageContent } from '@modelcontextprotocol/sdk/types.js';
+import type { McpFileEntry, McpPermissions } from '$lib/mcp/types';
+import { pastedImageLink } from '$lib/utils/imageStore';
+import type { McpManager } from './manager';
+import {
+    buildTree,
+    childrenOf,
+    isDotFileName,
+    isSelfOrDescendant,
+    languageFromFileName,
+    normalizeSegments,
+    pathOf,
+    resolvePath
+} from './virtualFs';
+
+type ToolResult = { content: [{ type: 'text'; text: string }] };
+
+const SEARCH_RESULT_LIMIT = 50;
+const SNIPPET_LENGTH = 160;
+
+function text(text: string): ToolResult {
+    return { content: [{ type: 'text', text }] };
+}
+
+function jsonText(value: unknown): ToolResult {
+    return text(JSON.stringify(value, null, 2));
+}
+
+function requirePermission(permissions: McpPermissions, name: 'read' | 'write' | 'create' | 'delete'): void {
+    if (!permissions[name]) {
+        throw new McpError(
+            ErrorCode.InvalidRequest,
+            `Permission denied: ${name.toUpperCase()} is turned off for this MCP server. Enable it in the MCP Server settings popup.`
+        );
+    }
+}
+
+function assertVisible(entry: McpFileEntry, permissions: McpPermissions): void {
+    if (!permissions.includeHidden && isDotFileName(entry.fileName)) {
+        throw new McpError(
+            ErrorCode.InvalidRequest,
+            `Hidden file "${entry.fileName}" is not accessible while "include hidden files" is off.`
+        );
+    }
+}
+
+function visibleEntry(entry: McpFileEntry | null, permissions: McpPermissions): McpFileEntry | null {
+    if (!entry) return null;
+    assertVisible(entry, permissions);
+    return entry;
+}
+
+/** Resolve a path, enforcing hidden-file visibility on every matched segment. */
+function resolveVisiblePath(manager: McpManager, rawPath: string): McpFileEntry | null {
+    const permissions = manager.getPermissions();
+    const segments = normalizeSegments(rawPath);
+    if (segments.length === 0) return null;
+    const entries = manager.listFiles();
+    const byId = new Map(entries.map((e) => [e.fileId, e]));
+    let level = entries.filter((e) => e.parentId == null);
+    let current: McpFileEntry | null = null;
+    for (let i = 0; i < segments.length; i++) {
+        current = level.find((entry) => entry.fileName === segments[i]) ?? null;
+        if (!current) return null;
+        assertVisible(current, permissions);
+        if (i < segments.length - 1) {
+            level = entries.filter((e) => e.parentId === current!.fileId);
+        }
+    }
+    return current;
+}
+
+function parentFolder(manager: McpManager, rawPath: string): McpFileEntry | null {
+    const segments = normalizeSegments(rawPath);
+    if (segments.length <= 1) return null;
+    const parentPath = segments.slice(0, -1).join('/');
+    return resolveVisiblePath(manager, parentPath);
+}
+
+/** Auto-create missing parent folders for a new file path. */
+function ensureParentFolders(manager: McpManager, rawPath: string): void {
+    const segments = normalizeSegments(rawPath);
+    if (segments.length <= 1) return;
+    const entries = manager.listFiles();
+    const byId = new Map(entries.map((e) => [e.fileId, e]));
+    let parentId: string | null = null;
+    for (let i = 0; i < segments.length - 1; i++) {
+        const name = segments[i];
+        const siblings = entries.filter((e) => e.parentId === parentId);
+        let folder = siblings.find((e) => e.fileName === name);
+        if (!folder) {
+            folder = {
+                fileId: uuidv4(),
+                fileName: name,
+                content: '',
+                language: 'plaintext',
+                parentId,
+                type: 'folder',
+                lastUpdated: Date.now()
+            };
+            manager.applyAgentWrite(folder);
+        }
+        parentId = folder.fileId;
+    }
+}
+
+function findParentFolder(manager: McpManager, rawPath: string): string | null {
+    const parent = parentFolder(manager, rawPath);
+    if (!parent) return null;
+    if (parent.type !== 'folder') {
+        throw new McpError(ErrorCode.InvalidRequest, `"${parent.fileName}" is not a folder.`);
+    }
+    return parent.fileId;
+}
+
+function entrySummary(manager: McpManager, entry: McpFileEntry, withSize = false): Record<string, unknown> {
+    const summary: Record<string, unknown> = {
+        path: pathOf(manager.listFiles(), entry),
+        name: entry.fileName,
+        type: entry.type === 'folder' ? 'folder' : 'file',
+        language: entry.type === 'folder' ? undefined : entry.language,
+        lastUpdated: entry.lastUpdated
+    };
+    if (withSize && entry.type !== 'folder') {
+        summary.size = entry.content.length;
+    }
+    return summary;
+}
+
+export function registerTools(server: McpServer, manager: McpManager): void {
+    const permissions = () => manager.getPermissions();
+
+    server.registerTool(
+        'list_files',
+        {
+            title: 'List files',
+            description:
+                'List the files and folders in the Cojudge playground. Use this to discover what is available before reading or editing. Pass a folder path to list its contents; pass a file path to get that file alone. Hidden files (starting with ".") are only shown when "include hidden files" is enabled.',
+            inputSchema: z.object({
+                path: z
+                    .string()
+                    .optional()
+                    .describe('Optional folder or file path. Defaults to the playground root.')
+            })
+        },
+        async ({ path }) => {
+            requirePermission(permissions(), 'read');
+            const perms = permissions();
+            if (path) {
+                const entry = visibleEntry(resolveVisiblePath(manager, path), perms);
+                if (!entry) {
+                    throw new McpError(ErrorCode.InvalidRequest, `Path "${path}" does not exist.`);
+                }
+                if (entry.type !== 'folder') {
+                    return jsonText({ files: [entrySummary(manager, entry)] });
+                }
+            }
+            const tree = buildTree(manager.listFiles());
+            const children = childrenOf(tree, path || undefined);
+            const files = children
+                .filter((entry) => perms.includeHidden || !isDotFileName(entry.fileName))
+                .map((entry) => entrySummary(manager, entry, true));
+            return jsonText({ path: path ?? '', files });
+        }
+    );
+
+    server.registerTool(
+        'search_files',
+        {
+            title: 'Search files',
+            description:
+                'Search playground file names and contents for a query string. Returns up to 50 matches with a snippet of the surrounding text for each.',
+            inputSchema: z.object({
+                query: z.string().min(1).describe('Text to search for in file names and contents.'),
+                path: z
+                    .string()
+                    .optional()
+                    .describe('Restrict the search to a folder path. Defaults to the whole playground.')
+            })
+        },
+        async ({ query, path }) => {
+            requirePermission(permissions(), 'read');
+            const perms = permissions();
+            const all = manager.listFiles();
+            const tree = buildTree(all);
+            const restrictEntry = path ? visibleEntry(resolveVisiblePath(manager, path), perms) : null;
+            if (path && !restrictEntry) {
+                throw new McpError(ErrorCode.InvalidRequest, `Path "${path}" does not exist.`);
+            }
+            const inScope = (entry: McpFileEntry): boolean => {
+                if (entry.type === 'folder') return false;
+                if (!perms.includeHidden && isDotFileName(entry.fileName)) return false;
+                if (restrictEntry) {
+                    return (
+                        entry.fileId === restrictEntry.fileId ||
+                        isSelfOrDescendant(all, entry.fileId, restrictEntry.fileId)
+                    );
+                }
+                return true;
+            };
+            const needle = query.toLowerCase();
+            const results: Record<string, unknown>[] = [];
+            for (const entry of all) {
+                if (!inScope(entry)) continue;
+                const nameHit = entry.fileName.toLowerCase().includes(needle);
+                const contentIndex = entry.content.toLowerCase().indexOf(needle);
+                const filePath = pathOf(all, entry);
+                if (nameHit || contentIndex >= 0) {
+                    results.push({
+                        path: filePath,
+                        name: entry.fileName,
+                        language: entry.language,
+                        snippet: contentIndex >= 0 ? snippetAround(entry.content, contentIndex) : undefined,
+                        matched: contentIndex >= 0 ? 'content' : 'name'
+                    });
+                    if (results.length >= SEARCH_RESULT_LIMIT) break;
+                }
+            }
+            return jsonText({ query, path: path ?? '', count: results.length, results });
+        }
+    );
+
+    server.registerTool(
+        'read_file',
+        {
+            title: 'Read file',
+            description:
+                'Read the full contents of a playground file. The returned content can be used as the basis for edits, reviews, or writing a solution note.',
+            inputSchema: z.object({
+                path: z.string().describe('Path of the file to read, e.g. "notes/todo.md".')
+            })
+        },
+        async ({ path }) => {
+            requirePermission(permissions(), 'read');
+            const entry = visibleEntry(resolveVisiblePath(manager, path), permissions());
+            if (!entry) {
+                throw new McpError(ErrorCode.InvalidRequest, `File "${path}" does not exist.`);
+            }
+            if (entry.type === 'folder') {
+                throw new McpError(ErrorCode.InvalidRequest, `"${path}" is a folder, not a file.`);
+            }
+            return jsonText({
+                path: pathOf(manager.listFiles(), entry),
+                name: entry.fileName,
+                language: entry.language,
+                lastUpdated: entry.lastUpdated,
+                size: entry.content.length,
+                content: entry.content
+            });
+        }
+    );
+
+    server.registerTool(
+        'read_image',
+        {
+            title: 'Read image',
+            description:
+                'Read an image that is pasted into a playground markdown note. Note contents reference pasted images as cojudge://image/<id>; pass the exact reference as it appears (read_file returns these inline). The image is returned as an image content block with its MIME type, plus a text block with metadata. Requires the READ permission.',
+            inputSchema: z.object({
+                link: z
+                    .string()
+                    .describe('The image reference exactly as it appears in the markdown, e.g. "cojudge://image/1f0a3b2c-4d5e".')
+            })
+        },
+        async ({ link }) => {
+            requirePermission(permissions(), 'read');
+            const dataUrl = manager.getImage(link);
+            if (!dataUrl) {
+                throw new McpError(
+                    ErrorCode.InvalidRequest,
+                    `Image "${link}" is not available on the MCP server. It is only synced after the note containing it has been opened and saved in the playground.`
+                );
+            }
+            const parsed = parseDataUrl(dataUrl);
+            if (!parsed) {
+                throw new McpError(ErrorCode.InvalidRequest, `Image "${link}" has an unsupported data URL.`);
+            }
+            const imageBlock: ImageContent = { type: 'image', data: parsed.base64, mimeType: parsed.mimeType };
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: JSON.stringify(
+                            {
+                                link,
+                                mimeType: parsed.mimeType,
+                                size: parsed.base64.length
+                            },
+                            null,
+                            2
+                        )
+                    },
+                    imageBlock
+                ]
+            };
+        }
+    );
+
+    server.registerTool(
+        'upload_image',
+        {
+            title: 'Upload image',
+            description:
+                'Upload an image to the playground and get back a cojudge://image/<id> link you can embed in markdown notes as ![alt](link). Pass the image either as data (a data URL like data:image/png;base64,... or raw base64, with mimeType for raw base64) or as path to a playground file whose contents are the image as base64 text. Uploaded images become visible in the user\'s notes within a few seconds. Requires the WRITE permission.',
+            inputSchema: z.object({
+                data: z
+                    .string()
+                    .optional()
+                    .describe('The image as a data URL (e.g. "data:image/png;base64,...") or raw base64. Provide mimeType when passing raw base64 without a data URL prefix.'),
+                mimeType: z
+                    .string()
+                    .optional()
+                    .describe('MIME type of the image, e.g. "image/png". Required when data is raw base64; defaults to "image/png".'),
+                path: z
+                    .string()
+                    .optional()
+                    .describe('Path of a playground file whose contents are the image as base64 text (with or without a data URL prefix). Alternative to data.')
+            })
+        },
+        async ({ data, mimeType, path }) => {
+            requirePermission(permissions(), 'write');
+            let payload: string | null = null;
+            if (path) {
+                const entry = visibleEntry(resolveVisiblePath(manager, path), permissions());
+                if (!entry) {
+                    throw new McpError(ErrorCode.InvalidRequest, `File "${path}" does not exist.`);
+                }
+                if (entry.type === 'folder') {
+                    throw new McpError(ErrorCode.InvalidRequest, `"${path}" is a folder, not a file.`);
+                }
+                payload = entry.content;
+            } else if (typeof data === 'string' && data.length > 0) {
+                payload = data;
+            }
+            if (!payload) {
+                throw new McpError(ErrorCode.InvalidRequest, 'Provide either "data" or "path" with the image payload.');
+            }
+            const parsed = parseImagePayload(payload, mimeType);
+            if (!parsed) {
+                throw new McpError(
+                    ErrorCode.InvalidRequest,
+                    'The image payload is neither a data URL nor valid base64 text.'
+                );
+            }
+            if (parsed.size > MAX_IMAGE_UPLOAD_BYTES) {
+                throw new McpError(
+                    ErrorCode.InvalidRequest,
+                    `Image payload is ${parsed.size} bytes; the upload limit is ${MAX_IMAGE_UPLOAD_BYTES} bytes.`
+                );
+            }
+            const id = uuidv4();
+            manager.setImage(id, parsed.dataUrl);
+            const link = pastedImageLink(id);
+            return jsonText({ id, link, mimeType: parsed.mimeType, size: parsed.size });
+        }
+    );
+
+    server.registerTool(
+        'get_open_tabs',
+        {
+            title: 'Get open tabs',
+            description:
+                'See which playground files are currently open as tabs and which one is active. Returns the active tab (if any) and every open tab with its file path; preview tabs resolve to their source note. Use this to know what the user is looking at before reading or editing. Requires the READ permission.',
+            inputSchema: z.object({})
+        },
+        async () => {
+            requirePermission(permissions(), 'read');
+            const perms = permissions();
+            const all = manager.listFiles();
+            const byId = new Map(all.map((entry) => [entry.fileId, entry]));
+            const { activeTabId, openTabs } = manager.getTabState();
+
+            const resolveTab = (tab: { fileId: string; fileName: string; type: string; sourceFileId: string | null; lastUpdated: number }) => {
+                const sourceId = tab.type === 'preview' && tab.sourceFileId ? tab.sourceFileId : tab.fileId;
+                const entry = sourceId ? byId.get(sourceId) : undefined;
+                if (!entry) {
+                    return { path: null, name: tab.fileName, type: tab.type };
+                }
+                if (!perms.includeHidden && isDotFileName(entry.fileName)) return null;
+                return {
+                    path: pathOf(all, entry),
+                    name: tab.type === 'editor' ? entry.fileName : tab.fileName,
+                    type: tab.type
+                };
+            };
+
+            const seen = new Set<string>();
+            const open: Record<string, unknown>[] = [];
+            let active: Record<string, unknown> | null = null;
+            for (const tab of openTabs) {
+                const resolved = resolveTab(tab);
+                if (!resolved) continue;
+                // A preview tab and its source editor tab share the same
+                // resolved path; the first occurrence wins for both the open
+                // list and the active tab.
+                if (active === null && activeTabId !== null && (tab.type === 'preview' ? tab.sourceFileId : tab.fileId) === activeTabId) {
+                    active = resolved;
+                }
+                const key = resolved.path ?? resolved.name;
+                if (seen.has(key)) continue;
+                seen.add(key);
+                open.push(resolved);
+            }
+            return jsonText({ active, open });
+        }
+    );
+
+    server.registerTool(
+        'write_file',
+        {
+            title: 'Write file',
+            description:
+                'Overwrite an existing playground file, or create a new one when the path does not exist. Parent folders are created automatically for new paths. Requires the WRITE permission for overwrites and CREATE for new files.',
+            inputSchema: z.object({
+                path: z.string().describe('Path of the file to write, e.g. "notes/idea.md".'),
+                content: z.string().describe('The full new contents of the file.')
+            })
+        },
+        async ({ path, content }) => {
+            const existing = resolveVisiblePath(manager, path);
+            let created = false;
+            if (existing) {
+                requirePermission(permissions(), 'write');
+                if (existing.type === 'folder') {
+                    throw new McpError(ErrorCode.InvalidRequest, `"${path}" is a folder, not a file.`);
+                }
+                const updated: McpFileEntry = {
+                    ...existing,
+                    content,
+                    lastUpdated: Date.now()
+                };
+                manager.applyAgentWrite(updated);
+            } else {
+                requirePermission(permissions(), 'create');
+                ensureParentFolders(manager, path);
+                const segments = normalizeSegments(path);
+                const fileName = segments[segments.length - 1];
+                const parentId = findParentFolder(manager, path);
+                manager.applyAgentWrite({
+                    fileId: uuidv4(),
+                    fileName,
+                    content,
+                    language: languageFromFileName(fileName),
+                    parentId,
+                    type: 'editor',
+                    lastUpdated: Date.now()
+                });
+                created = true;
+            }
+            return jsonText({ path, created, size: content.length });
+        }
+    );
+
+    server.registerTool(
+        'edit_file',
+        {
+            title: 'Edit file',
+            description:
+                'Make surgical edits to an existing playground file without rewriting the whole thing. Provide one or more edits; each one replaces its exact oldText with newText. Every oldText must appear exactly once in the file — include the surrounding lines so the match is unique. All edits are validated before any is applied, so a call either applies every edit or changes nothing. newText may be empty to delete text. Prefer this over write_file when only a few spots change. Requires the WRITE permission.',
+            inputSchema: z.object({
+                path: z.string().describe('Path of the file to edit, e.g. "notes/todo.md".'),
+                edits: z
+                    .array(
+                        z.object({
+                            oldText: z
+                                .string()
+                                .min(1)
+                                .describe('Exact text to replace. Must appear exactly once in the file.'),
+                            newText: z
+                                .string()
+                                .describe('Replacement text. Use an empty string to delete the matched text.')
+                        })
+                    )
+                    .describe('The edits to apply, in order.')
+            })
+        },
+        async ({ path, edits }) => {
+            requirePermission(permissions(), 'write');
+            const entry = visibleEntry(resolveVisiblePath(manager, path), permissions());
+            if (!entry) {
+                throw new McpError(ErrorCode.InvalidRequest, `File "${path}" does not exist.`);
+            }
+            if (entry.type === 'folder') {
+                throw new McpError(ErrorCode.InvalidRequest, `"${path}" is a folder, not a file.`);
+            }
+            let content = entry.content;
+            for (let index = 0; index < edits.length; index++) {
+                const { oldText, newText } = edits[index];
+                const occurrences = content.split(oldText).length - 1;
+                if (occurrences === 0) {
+                    throw new McpError(
+                        ErrorCode.InvalidRequest,
+                        `Edit ${index + 1} did not match anything in "${path}". Include more context from the file.`
+                    );
+                }
+                if (occurrences > 1) {
+                    throw new McpError(
+                        ErrorCode.InvalidRequest,
+                        `Edit ${index + 1} matched ${occurrences} places in "${path}". Include more surrounding lines to make the oldText unique.`
+                    );
+                }
+                content = content.replace(oldText, newText);
+            }
+            manager.applyAgentWrite({ ...entry, content, lastUpdated: Date.now() });
+            return jsonText({ path, edits: edits.length, size: content.length });
+        }
+    );
+
+    server.registerTool(
+        'move_file',
+        {
+            title: 'Move or rename file',
+            description:
+                'Move a playground file or folder to a new location, or rename it. The destination parent folder must already exist; the destination path itself must be free. Moving a folder moves everything inside it. Requires the WRITE permission.',
+            inputSchema: z.object({
+                path: z.string().describe('Path of the file or folder to move, e.g. "notes/todo.md".'),
+                destination: z.string().describe('New path of the file or folder, e.g. "archive/todo.md" or "todo-renamed.md".')
+            })
+        },
+        async ({ path, destination }) => {
+            requirePermission(permissions(), 'write');
+            const perms = permissions();
+            const source = visibleEntry(resolveVisiblePath(manager, path), perms);
+            if (!source) {
+                throw new McpError(ErrorCode.InvalidRequest, `Path "${path}" does not exist.`);
+            }
+            const sourceSegments = normalizeSegments(path);
+            const destSegments = normalizeSegments(destination);
+            if (sourceSegments.join('/') === destSegments.join('/')) {
+                throw new McpError(ErrorCode.InvalidRequest, 'Source and destination are the same path.');
+            }
+            if (resolveVisiblePath(manager, destination)) {
+                throw new McpError(ErrorCode.InvalidRequest, `Destination "${destination}" already exists.`);
+            }
+            let parentId: string | null = null;
+            if (destSegments.length > 1) {
+                const parentPath = destSegments.slice(0, -1).join('/');
+                const parent = resolveVisiblePath(manager, parentPath);
+                if (!parent) {
+                    throw new McpError(ErrorCode.InvalidRequest, `Destination folder "${parentPath}" does not exist.`);
+                }
+                if (parent.type !== 'folder') {
+                    throw new McpError(ErrorCode.InvalidRequest, `"${parentPath}" is not a folder.`);
+                }
+                parentId = parent.fileId;
+            }
+            if (source.type === 'folder') {
+                const all = manager.listFiles();
+                if (parentId !== null && isSelfOrDescendant(all, parentId, source.fileId)) {
+                    throw new McpError(
+                        ErrorCode.InvalidRequest,
+                        'Cannot move a folder into itself or one of its subfolders.'
+                    );
+                }
+            }
+            const moved = manager.applyAgentMove(source.fileId, parentId);
+            const destinationName = destSegments[destSegments.length - 1];
+            if (destinationName !== source.fileName) {
+                const entry = manager.getFile(source.fileId);
+                if (entry) {
+                    manager.applyAgentWrite({ ...entry, fileName: destinationName, lastUpdated: Date.now() });
+                }
+            }
+            return jsonText({ path, destination, moved });
+        }
+    );
+
+    server.registerTool(
+        'create_file',
+        {
+            title: 'Create file',
+            description:
+                'Create a new file in the playground. Fails if the path already exists. Parent folders are created automatically. Requires the CREATE permission.',
+            inputSchema: z.object({
+                path: z.string().describe('Path of the new file, e.g. "scratchpad/ideas.txt".'),
+                content: z.string().optional().describe('Optional initial contents (empty by default).')
+            })
+        },
+        async ({ path, content }) => {
+            requirePermission(permissions(), 'create');
+            if (resolveVisiblePath(manager, path)) {
+                throw new McpError(ErrorCode.InvalidRequest, `File "${path}" already exists.`);
+            }
+            ensureParentFolders(manager, path);
+            const segments = normalizeSegments(path);
+            const fileName = segments[segments.length - 1];
+            const parentId = findParentFolder(manager, path);
+            manager.applyAgentWrite({
+                fileId: uuidv4(),
+                fileName,
+                content: content ?? '',
+                language: languageFromFileName(fileName),
+                parentId,
+                type: 'editor',
+                lastUpdated: Date.now()
+            });
+            return jsonText({ path, created: true });
+        }
+    );
+
+    server.registerTool(
+        'create_note',
+        {
+            title: 'Create note',
+            description:
+                'Create a new markdown note in the playground. The path gets a ".md" extension when it does not already end in one. Notes open in the playground markdown editor so you can draft solutions, explanations, or todos. Requires the CREATE permission.',
+            inputSchema: z.object({
+                path: z
+                    .string()
+                    .describe('Path of the note, e.g. "notes/solution-approach". A .md extension is added automatically.'),
+                content: z.string().optional().describe('Optional initial markdown contents (empty by default).')
+            })
+        },
+        async ({ path, content }) => {
+            requirePermission(permissions(), 'create');
+            const notePath = /\.md$/i.test(path) ? path : `${path}.md`;
+            if (resolveVisiblePath(manager, notePath)) {
+                throw new McpError(ErrorCode.InvalidRequest, `Note "${notePath}" already exists.`);
+            }
+            ensureParentFolders(manager, notePath);
+            const segments = normalizeSegments(notePath);
+            const fileName = segments[segments.length - 1];
+            const parentId = findParentFolder(manager, notePath);
+            manager.applyAgentWrite({
+                fileId: uuidv4(),
+                fileName,
+                content: content ?? '',
+                language: 'markdown',
+                parentId,
+                type: 'editor',
+                lastUpdated: Date.now()
+            });
+            return jsonText({ path: notePath, created: true });
+        }
+    );
+
+    server.registerTool(
+        'delete_file',
+        {
+            title: 'Delete file or folder',
+            description:
+                'Delete a playground file, or a folder and everything inside it. Requires the DELETE permission.',
+            inputSchema: z.object({
+                path: z.string().describe('Path of the file or folder to delete.')
+            })
+        },
+        async ({ path }) => {
+            requirePermission(permissions(), 'delete');
+            const entry = visibleEntry(resolveVisiblePath(manager, path), permissions());
+            if (!entry) {
+                throw new McpError(ErrorCode.InvalidRequest, `Path "${path}" does not exist.`);
+            }
+            const all = manager.listFiles();
+            const targetId = entry.fileId;
+            const toRemove = all.filter(
+                (candidate) =>
+                    candidate.fileId === targetId ||
+                    (entry.type === 'folder' && isSelfOrDescendant(all, candidate.fileId, targetId))
+            );
+            for (const candidate of toRemove) {
+                manager.applyAgentDelete(candidate.fileId);
+            }
+            return jsonText({ path, deleted: toRemove.length });
+        }
+    );
+}
+
+function snippetAround(content: string, index: number): string {
+    const start = Math.max(0, index - Math.floor(SNIPPET_LENGTH / 3));
+    const end = Math.min(content.length, index + Math.floor((SNIPPET_LENGTH * 2) / 3));
+    const prefix = start > 0 ? '…' : '';
+    const suffix = end < content.length ? '…' : '';
+    return `${prefix}${content.slice(start, end).replace(/\s+/g, ' ').trim()}${suffix}`;
+}
+
+/** Split a data URL into its MIME type and base64 payload (null when not a data URL). */
+function parseDataUrl(dataUrl: string): { mimeType: string; base64: string } | null {
+    const match = /^data:([^;,]+)(?:;[^,]*)?,(.*)$/s.exec(dataUrl);
+    if (!match) return null;
+    return { mimeType: match[1] || 'application/octet-stream', base64: match[2] };
+}
+
+const MAX_IMAGE_UPLOAD_BYTES = 20 * 1024 * 1024;
+
+/**
+ * Normalize an upload payload (data URL or raw base64 text) into a data URL
+ * with its MIME type and decoded byte size. Returns null when the payload is
+ * not a data URL and not valid base64.
+ */
+function parseImagePayload(payload: string, mimeType?: string): { dataUrl: string; mimeType: string; size: number } | null {
+    const trimmed = payload.trim();
+    if (trimmed.startsWith('data:')) {
+        const parsed = parseDataUrl(trimmed);
+        if (!parsed) return null;
+        return { dataUrl: trimmed, mimeType: parsed.mimeType, size: base64ByteLength(parsed.base64) };
+    }
+    if (!/^[A-Za-z0-9+/=\s]+$/.test(trimmed)) return null;
+    const cleaned = trimmed.replace(/\s+/g, '');
+    if (cleaned.length === 0 || cleaned.length % 4 === 1) return null;
+    const type = mimeType ?? 'image/png';
+    return { dataUrl: `data:${type};base64,${cleaned}`, mimeType: type, size: base64ByteLength(cleaned) };
+}
+
+function base64ByteLength(base64: string): number {
+    let padding = 0;
+    if (base64.endsWith('==')) padding = 2;
+    else if (base64.endsWith('=')) padding = 1;
+    return Math.floor((base64.length - padding) * 3 / 4);
+}

--- a/src/lib/server/mcp/virtualFs.ts
+++ b/src/lib/server/mcp/virtualFs.ts
@@ -1,0 +1,131 @@
+import type { McpFileEntry } from '$lib/mcp/types';
+
+/** Children grouped by parentId (null = root). */
+export type FileTree = Map<string | null, McpFileEntry[]>;
+
+export function isDotFileName(fileName: string): boolean {
+    return fileName.startsWith('.') && fileName !== '.' && fileName !== '..';
+}
+
+export function buildTree(entries: McpFileEntry[]): FileTree {
+    const tree: FileTree = new Map();
+    for (const entry of entries) {
+        const parent = entry.parentId ?? null;
+        const siblings = tree.get(parent) ?? [];
+        siblings.push(entry);
+        tree.set(parent, siblings);
+    }
+    for (const siblings of tree.values()) {
+        siblings.sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER) || a.fileName.localeCompare(b.fileName));
+    }
+    return tree;
+}
+
+/**
+ * Resolve a path like `notes/todo.md` (or `/notes/todo.md`) against the tree.
+ * The final segment may be a file or a folder.
+ */
+export function resolvePath(tree: FileTree, rawPath: string): McpFileEntry | null {
+    const segments = normalizeSegments(rawPath);
+    if (segments.length === 0) return null;
+    let level = tree.get(null) ?? [];
+    let current: McpFileEntry | null = null;
+    for (let i = 0; i < segments.length; i++) {
+        const segment = segments[i];
+        current = level.find((entry) => entry.fileName === segment) ?? null;
+        if (!current) return null;
+        if (i < segments.length - 1) {
+            level = tree.get(current.fileId) ?? [];
+        }
+    }
+    return current;
+}
+
+/** Split a path into segments, rejecting dangerous or empty ones. */
+export function normalizeSegments(rawPath: string): string[] {
+    const cleaned = String(rawPath ?? '')
+        .replace(/\\/g, '/')
+        .replace(/^\/+/, '')
+        .replace(/\/+$/, '');
+    if (!cleaned || cleaned === '.') return [];
+    const segments = cleaned.split('/');
+    if (segments.some((s) => !s || s === '.' || s === '..')) {
+        throw new Error(`Invalid path "${rawPath}"`);
+    }
+    return segments;
+}
+
+/** Children of the folder at `path` (or all root entries when path is empty). */
+export function childrenOf(tree: FileTree, path: string | null | undefined): McpFileEntry[] {
+    if (!path) return tree.get(null) ?? [];
+    const entry = resolvePath(tree, path);
+    if (!entry) return [];
+    if (entry.type === 'folder') return tree.get(entry.fileId) ?? [];
+    return [];
+}
+
+/** Human-readable path for an entry, computed by walking up parents. */
+export function pathOf(entries: McpFileEntry[], entry: McpFileEntry): string {
+    const byId = new Map(entries.map((e) => [e.fileId, e]));
+    const parts: string[] = [];
+    let current: McpFileEntry | undefined = entry;
+    let guard = 0;
+    while (current && guard++ < 64) {
+        parts.unshift(current.fileName);
+        if (!current.parentId) break;
+        current = byId.get(current.parentId);
+    }
+    return parts.join('/');
+}
+
+/** Whether `fileId` is `folderId` itself or lives anywhere beneath it. */
+export function isSelfOrDescendant(entries: McpFileEntry[], fileId: string, folderId: string): boolean {
+    if (fileId === folderId) return true;
+    const byId = new Map(entries.map((e) => [e.fileId, e]));
+    let current = byId.get(fileId);
+    let guard = 0;
+    while (current && guard++ < 64) {
+        if (!current.parentId) return false;
+        if (current.parentId === folderId) return true;
+        current = byId.get(current.parentId);
+    }
+    return false;
+}
+
+const EXTENSION_LANGUAGES: Record<string, string> = {
+    java: 'java',
+    py: 'python',
+    cpp: 'cpp',
+    cc: 'cpp',
+    cxx: 'cpp',
+    h: 'cpp',
+    hpp: 'cpp',
+    cs: 'csharp',
+    rs: 'rust',
+    go: 'go',
+    ts: 'typescript',
+    tsx: 'typescript',
+    js: 'typescript',
+    mjs: 'typescript',
+    cjs: 'typescript',
+    md: 'markdown',
+    markdown: 'markdown',
+    txt: 'plaintext',
+    json: 'plaintext',
+    yml: 'plaintext',
+    yaml: 'plaintext',
+    csv: 'plaintext',
+    html: 'plaintext',
+    css: 'plaintext',
+    xml: 'plaintext',
+    ini: 'plaintext',
+    cfg: 'plaintext',
+    env: 'plaintext'
+};
+
+export function languageFromFileName(fileName: string): string {
+    const dot = fileName.lastIndexOf('.');
+    if (dot < 0 || dot === fileName.length - 1) return 'plaintext';
+    const ext = fileName.slice(dot + 1).toLowerCase();
+    return EXTENSION_LANGUAGES[ext] ?? 'plaintext';
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -3,6 +3,9 @@ import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async () => {
 	return {
-		isDemoSite: env.IS_DEMO_SITE === 'true'
+		isDemoSite: env.IS_DEMO_SITE === 'true',
+		// Per-launch token of the packaged desktop backend, used to build the
+		// copyable MCP URL for agents. Absent in dev mode.
+		desktopMcpToken: env.COJUDGE_DESKTOP_TOKEN ?? null
 	};
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,11 +3,16 @@
 	import { onMount } from 'svelte';
 	import AppDialog from '$lib/components/AppDialog.svelte';
 	import { startCloudSync, stopCloudSync } from '$lib/cloudSync';
+	import { setDesktopMcpToken } from '$lib/mcp/client';
 	import favicon from '$lib/assets/favicon.svg';
 	import DemoBanner from '$lib/components/DemoBanner.svelte';
 	import '../app.css';
 
 	let { children, data } = $props();
+
+	$effect(() => {
+		setDesktopMcpToken(data.desktopMcpToken ?? null);
+	});
 
 	onMount(() => {
 		void startCloudSync();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,6 +13,8 @@
     import GameHistoryPopup from "$lib/components/GameHistoryPopup.svelte";
     import gameResultsStore, { type GameResult } from '$lib/stores/gameResultsStore';
     import CloudSyncModal from "$lib/components/CloudSyncModal.svelte";
+    import McpServerModal from "$lib/components/McpServerModal.svelte";
+    import { ensureMcpServerRunning, mcpClientState, startMcpEventSync } from '$lib/mcp/client';
     import {
         cloudSyncState,
         refreshCloudLocalState,
@@ -51,6 +53,7 @@
     let importNoticeTimer: ReturnType<typeof setTimeout> | undefined;
     let showFirebaseSettings = false;
     let showCloudSettings = false;
+    let showMcpSettings = false;
     let showLoadCode = false;
     let firebaseForm: FirebaseSettings = emptyFirebaseSettings();
     let firebaseSettingsError = '';
@@ -194,6 +197,12 @@
 
     onMount(() => {
         window.addEventListener("click", handleClickOutside);
+        void ensureMcpServerRunning();
+        let stopMcpEventSync: (() => void) | undefined;
+        stopMcpEventSync = startMcpEventSync();
+        onDestroy(() => {
+            if (stopMcpEventSync) stopMcpEventSync();
+        });
 
         // Restore last selected course from localStorage if no course param in URL
         const url = new URL(window.location.href);
@@ -558,6 +567,16 @@
         void tick().then(() => dropdownToggleButton?.focus());
     }
 
+    function openMcpSettings() {
+        showDropdown = false;
+        showMcpSettings = true;
+    }
+
+    function closeMcpSettings() {
+        showMcpSettings = false;
+        void tick().then(() => dropdownToggleButton?.focus());
+    }
+
     async function openFirebaseSettings() {
         firebaseForm = getFirebaseSettings();
         firebaseSettingsSaved = hasSavedFirebaseSettings();
@@ -810,6 +829,26 @@
                             {cloudMenuStatus()}
                         </span>
                     </button>
+                    <button
+                        class="dropdown-item"
+                        role="menuitem"
+                        onclick={openMcpSettings}
+                        title="Configure the MCP server agents can use to access your playground files"
+                    >
+                        <span class="dropdown-item-content">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M9 2v6"></path>
+                                <path d="M15 2v6"></path>
+                                <path d="M7 8h10v4a5 5 0 0 1-10 0Z"></path>
+                                <path d="M12 17v5"></path>
+                                <path d="M8 22h8"></path>
+                            </svg>
+                            MCP Server
+                        </span>
+                        <span class:configured={$mcpClientState.running} class="firebase-menu-status">
+                            {$mcpClientState.running ? 'Running' : 'Stopped'}
+                        </span>
+                    </button>
                     <div class="dropdown-separator" role="separator"></div>
                     <button
                         class="dropdown-item"
@@ -977,6 +1016,7 @@
         </div>
     {/if}
     <CloudSyncModal open={showCloudSettings} onClose={closeCloudSettings} />
+    <McpServerModal open={showMcpSettings} onClose={closeMcpSettings} />
     {#if showFirebaseSettings}
         <div class="home-modal-shell">
             <button class="home-modal-backdrop" aria-label="Close Firebase settings" tabindex="-1" onclick={closeFirebaseSettings}></button>

--- a/src/routes/api/mcp/events/+server.ts
+++ b/src/routes/api/mcp/events/+server.ts
@@ -1,0 +1,79 @@
+import { mcpManager } from '$lib/server/mcp/manager';
+
+const POLL_INTERVAL_MS = 500;
+const HEARTBEAT_INTERVAL_MS = 15000;
+
+function send(controller: ReadableStreamDefaultController<Uint8Array>, encoder: TextEncoder, name: string, data: unknown): void {
+    try {
+        controller.enqueue(encoder.encode(`event: ${name}\ndata: ${JSON.stringify(data)}\n\n`));
+    } catch {
+        // Stream already closed; the abort handler stops the timers.
+    }
+}
+
+/**
+ * Server-Sent Events stream broadcasting MCP server changes to the UI.
+ *
+ * Emits "files-changed" whenever the file snapshot revision moves (agent
+ * writes, client pushes, deletes) and "state-changed" when the server
+ * starts/stops. The UI uses this to pull the snapshot instantly instead of
+ * waiting for its polling interval.
+ *
+ * The stream stays open while the server is stopped so start/stop transitions
+ * are always delivered; a heartbeat keeps proxies from dropping the idle
+ * connection.
+ */
+export const GET = ({ request }): Response => {
+    let lastRevision = mcpManager.getState().revision;
+    let lastImagesRevision = mcpManager.getImagesRevision();
+    let lastRunning = mcpManager.isRunning();
+    const encoder = new TextEncoder();
+
+    const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+            send(controller, encoder, 'hello', mcpManager.getState());
+
+            const poll = setInterval(() => {
+                const state = mcpManager.getState();
+                if (state.running !== lastRunning) {
+                    lastRunning = state.running;
+                    send(controller, encoder, 'state-changed', { running: state.running });
+                }
+                if (state.revision !== lastRevision) {
+                    lastRevision = state.revision;
+                    send(controller, encoder, 'files-changed', {
+                        revision: state.revision,
+                        fileCount: state.fileCount
+                    });
+                }
+                const imagesRevision = mcpManager.getImagesRevision();
+                if (imagesRevision !== lastImagesRevision) {
+                    lastImagesRevision = imagesRevision;
+                    send(controller, encoder, 'images-changed', { revision: imagesRevision });
+                }
+            }, POLL_INTERVAL_MS);
+
+            const heartbeat = setInterval(() => {
+                send(controller, encoder, 'ping', {});
+            }, HEARTBEAT_INTERVAL_MS);
+
+            request.signal.addEventListener('abort', () => {
+                clearInterval(poll);
+                clearInterval(heartbeat);
+                try {
+                    controller.close();
+                } catch {
+                    // already closed
+                }
+            });
+        }
+    });
+
+    return new Response(stream, {
+        headers: {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache, no-transform',
+            'Connection': 'keep-alive'
+        }
+    });
+};

--- a/src/routes/api/mcp/files/+server.ts
+++ b/src/routes/api/mcp/files/+server.ts
@@ -1,0 +1,32 @@
+import { json } from '@sveltejs/kit';
+import { mcpManager } from '$lib/server/mcp/manager';
+import type { McpFilePush } from '$lib/mcp/types';
+
+export const GET = async () => {
+    if (!mcpManager.isRunning()) {
+        return json({ error: 'MCP server is stopped.' }, { status: 503 });
+    }
+    return json(mcpManager.getSnapshot());
+};
+
+export const POST = async ({ request }) => {
+    if (!mcpManager.isRunning()) {
+        return json({ error: 'MCP server is stopped.' }, { status: 503 });
+    }
+    let push: McpFilePush;
+    try {
+        push = await request.json();
+    } catch {
+        return json({ error: 'Invalid JSON body.' }, { status: 400 });
+    }
+    if (!Array.isArray(push?.entries)) {
+        return json({ error: 'Missing entries array.' }, { status: 400 });
+    }
+    mcpManager.syncClientFiles({
+        entries: push.entries,
+        tombstones: Array.isArray(push.tombstones) ? push.tombstones : [],
+        images:
+            push.images && typeof push.images === 'object' && !Array.isArray(push.images) ? push.images : {}
+    });
+    return json(mcpManager.getState());
+};

--- a/src/routes/api/mcp/images/+server.ts
+++ b/src/routes/api/mcp/images/+server.ts
@@ -1,0 +1,19 @@
+import { json } from '@sveltejs/kit';
+import { mcpManager } from '$lib/server/mcp/manager';
+
+/**
+ * Pasted-image payloads the client does not have yet. The client passes the
+ * revision it already knows via `?since=`: the full image map is only
+ * returned when the revision moved, keeping the poll cheap.
+ */
+export const GET = async ({ url }) => {
+    if (!mcpManager.isRunning()) {
+        return json({ error: 'MCP server is stopped.' }, { status: 503 });
+    }
+    const since = Number(url.searchParams.get('since') ?? -1);
+    const revision = mcpManager.getImagesRevision();
+    return json({
+        revision,
+        images: revision !== since ? mcpManager.getImages() : undefined
+    });
+};

--- a/src/routes/api/mcp/state/+server.ts
+++ b/src/routes/api/mcp/state/+server.ts
@@ -1,0 +1,36 @@
+import { json } from '@sveltejs/kit';
+import { mcpManager } from '$lib/server/mcp/manager';
+import type { McpPermissions, McpStateAction } from '$lib/mcp/types';
+
+export const GET = async () => json(mcpManager.getState());
+
+export const POST = async ({ request }) => {
+    let body: McpStateAction;
+    try {
+        body = await request.json();
+    } catch {
+        return json({ error: 'Invalid JSON body.' }, { status: 400 });
+    }
+    const action = (body as { action?: string })?.action ?? '';
+    const permissions = (body as { permissions?: McpPermissions }).permissions;
+    switch (action) {
+        case 'start':
+            await mcpManager.start();
+            break;
+        case 'stop':
+            await mcpManager.stop();
+            break;
+        case 'restart':
+            await mcpManager.restart();
+            break;
+        case 'setPermissions':
+            if (!permissions) {
+                return json({ error: 'Missing permissions.' }, { status: 400 });
+            }
+            mcpManager.setPermissions(permissions);
+            break;
+        default:
+            return json({ error: `Unknown action "${action}".` }, { status: 400 });
+    }
+    return json(mcpManager.getState());
+};

--- a/src/routes/api/mcp/tabs/+server.ts
+++ b/src/routes/api/mcp/tabs/+server.ts
@@ -1,0 +1,23 @@
+import { json } from '@sveltejs/kit';
+import { mcpManager } from '$lib/server/mcp/manager';
+import type { McpTabState } from '$lib/mcp/types';
+
+export const POST = async ({ request }) => {
+    if (!mcpManager.isRunning()) {
+        return json({ error: 'MCP server is stopped.' }, { status: 503 });
+    }
+    let state: McpTabState;
+    try {
+        state = await request.json();
+    } catch {
+        return json({ error: 'Invalid JSON body.' }, { status: 400 });
+    }
+    if (!Array.isArray(state?.openTabs)) {
+        return json({ error: 'Missing openTabs array.' }, { status: 400 });
+    }
+    mcpManager.setTabState({
+        activeTabId: typeof state.activeTabId === 'string' ? state.activeTabId : null,
+        openTabs: state.openTabs
+    });
+    return json(mcpManager.getState());
+};

--- a/src/routes/mcp/[...path]/+server.ts
+++ b/src/routes/mcp/[...path]/+server.ts
@@ -1,0 +1,35 @@
+import { mcpManager } from '$lib/server/mcp/manager';
+
+const CORS_HEADERS: Record<string, string> = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type, Mcp-Session-Id, Mcp-Protocol-Version, Last-Event-ID, Accept',
+    'Access-Control-Expose-Headers': 'Mcp-Session-Id, Last-Event-ID'
+};
+
+function corsPreflight(): Response {
+    return new Response(null, {
+        status: 204,
+        headers: CORS_HEADERS
+    });
+}
+
+function addCors(response: Response): Response {
+    const headers = new Headers(response.headers);
+    for (const [name, value] of Object.entries(CORS_HEADERS)) {
+        headers.set(name, value);
+    }
+    return new Response(response.body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers
+    });
+}
+
+export const OPTIONS = () => corsPreflight();
+
+export const GET = async ({ request }) => addCors(await mcpManager.handleProtocolRequest(request));
+
+export const POST = async ({ request }) => addCors(await mcpManager.handleProtocolRequest(request));
+
+export const DELETE = async ({ request }) => addCors(await mcpManager.handleProtocolRequest(request));

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -2,6 +2,7 @@
     import { page } from '$app/stores';
     import PlaygroundExecutionPanel from '$lib/components/PlaygroundExecutionPanel.svelte';
     import CloudSyncModal from '$lib/components/CloudSyncModal.svelte';
+    import McpServerModal from '$lib/components/McpServerModal.svelte';
     import LanguageIcon from '$lib/components/LanguageIcon.svelte';
     import ShareModal from '$lib/components/ShareModal.svelte';
     import Tooltip from '$lib/components/Tooltip.svelte';
@@ -10,6 +11,7 @@
     import { consumeForkTransfer } from '$lib/forkTransfer';
     import { ensureAuthenticated, initFirebase } from '$lib/firebase';
     import { isDesktopRuntime } from '$lib/firebaseSettings';
+    import { ensureMcpServerRunning, mcpClientState, pushMcpTabs, setupMcpFileSync, startMcpEventSync, toMcpTabState } from '$lib/mcp/client';
     import { cloudSyncState } from '$lib/cloudSync';
     import { WHITEBOARD_FILE_ID } from '$lib/cloudFileChange';
     import { CLOUD_FLUSH_EVENT, isCloudRestoreInProgress, writeProgressStorageItem } from '$lib/progressBackup';
@@ -34,6 +36,8 @@
     const codeKey = () => `${problemId}:${language}`;
     let showCloudSettings = false;
     let cloudActivityButton: HTMLButtonElement | null = null;
+    let showMcpSettings = false;
+    let mcpActivityButton: HTMLButtonElement | null = null;
 
     function openCloudSettings() {
         showCloudSettings = true;
@@ -43,6 +47,16 @@
         showCloudSettings = false;
         await tick();
         cloudActivityButton?.focus();
+    }
+
+    function openMcpSettings() {
+        showMcpSettings = true;
+    }
+
+    async function closeMcpSettings() {
+        showMcpSettings = false;
+        await tick();
+        mcpActivityButton?.focus();
     }
 
     const starterCode = {
@@ -1574,10 +1588,64 @@ func main() {
         loadOrInitFile(language);
     }
 
-    // Reload code when another browser tab changes the file store
-    $: if ($fileSyncVersion > 0 && activeTabId >= 0 && activeTabId < tabs.length && !isSpecialTabType(tabs[activeTabId]?.type) && language) {
-        skipNextSave = true;
-        loadOrInitFile(language);
+    // Keep the MCP server informed of the open tabs + active tab, so agents
+    // can see what the user is looking at. Debounced; skipped while the MCP
+    // server is stopped (a subscription in onMount re-pushes when it starts).
+    let tabPushTimer: ReturnType<typeof setTimeout> | undefined;
+
+    $: scheduleTabPush(tabs, activeTabId);
+
+    function scheduleTabPush(tabList: TabMeta[], activeIndex: number): void {
+        if (tabPushTimer) clearTimeout(tabPushTimer);
+        tabPushTimer = setTimeout(() => {
+            tabPushTimer = undefined;
+            void pushMcpTabs(toMcpTabState(tabList, activeIndex));
+        }, 200);
+    }
+
+    // Reload code when another browser tab or the MCP server changes the file
+    // store. Only reload when the stored content actually differs from the
+    // editor buffer, so an in-progress edit is never clobbered by a no-op merge.
+    $: if ($fileSyncVersion > 0 && activeTabId >= 0 && activeTabId < tabs.length && language) {
+        const activeFile = tabs[activeTabId];
+        if (activeFile?.type === 'preview' && previewEditMode && wysiwygEl && activeFile.sourceFileId) {
+            // WYSIWYG renders from innerHTML, not from `code`, so re-render it
+            // from the store when the markdown source changed elsewhere (e.g. an
+            // agent edit). Skip while the user is typing there — their own edits
+            // win via last-writer-wins and a mid-keystroke re-render would jump
+            // the caret.
+            try {
+                const files = JSON.parse(get(fileStore)[fileKey()] ?? '[]') as FileEntry[];
+                const source = files.find((x) => x.fileId === activeFile.sourceFileId && x.language === 'markdown');
+                if (source) {
+                    const rendered = htmlToMarkdown(wysiwygEl.innerHTML);
+                    if (normalizeContent(source.content) !== normalizeContent(rendered) && !wysiwygDirty) {
+                        wysiwygEl.innerHTML = renderMarkdownPlain(source.content, {
+                            resolveFileLanguage: (fileId) => getLanguageForTab(fileId)
+                        });
+                        wrapImageThumbnails(wysiwygEl);
+                        wrapCodeBlocksWithCopy(wysiwygEl);
+                        ensureFileMentionCarets(wysiwygEl);
+                        prepareTaskListCheckboxes(wysiwygEl);
+                        ensureTrailingEmptyLine(wysiwygEl);
+                    }
+                }
+            } catch {
+                // Ignore malformed store content.
+            }
+        } else if (activeFile && !isSpecialTabType(activeFile.type)) {
+            let freshCode: string | undefined;
+            try {
+                const files = JSON.parse(get(fileStore)[fileKey()] ?? '[]') as FileEntry[];
+                freshCode = files.find((x) => x.fileId === activeFile.fileId && x.language === language)?.content;
+            } catch {
+                // Ignore malformed store content.
+            }
+            if (freshCode !== undefined && freshCode !== code) {
+                skipNextSave = true;
+                loadOrInitFile(language);
+            }
+        }
         $fileSyncVersion;
     }
 
@@ -2133,6 +2201,7 @@ func main() {
     // --- Markdown preview WYSIWYG editing ---
     let previewEditMode = false;
     let wysiwygEl: HTMLDivElement | null = null;
+    let wysiwygDirty = false;
     let wysiwygDebounce: ReturnType<typeof setTimeout> | null = null;
     let wysiwygSourceFileId: string | null = null;
     let lastActiveTabFileId: string | null = null;
@@ -2201,6 +2270,7 @@ func main() {
 
     function handleWysiwygInput() {
         removeOrphanCodeWrappers();
+        wysiwygDirty = true;
         healTaskListStructure();
         if (wysiwygEl?.querySelector('li input[type="checkbox"][disabled]')) {
             prepareTaskListCheckboxes(wysiwygEl);
@@ -3224,6 +3294,7 @@ func main() {
             clearTimeout(wysiwygDebounce);
             wysiwygDebounce = null;
         }
+        wysiwygDirty = false;
         if (!previewEditMode || !wysiwygEl || !wysiwygSourceFileId) return;
         removeOrphanCodeWrappers();
         healTaskListStructure();
@@ -4456,11 +4527,41 @@ func main() {
         window.addEventListener('keydown', handleKeyDown);
         window.addEventListener('beforeunload', handleUnload);
         window.addEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
+        // MCP server: auto-start when previously running and keep playground files in sync
+        void ensureMcpServerRunning();
+        const stopMcpEventSync = startMcpEventSync();
+        const stopMcpFileSync = setupMcpFileSync({
+            onApplied: ({ added }) => {
+                if (!added.length) return;
+                const existingIds = new Set(tabs.map((t) => t.fileId));
+                const additions: TabMeta[] = [];
+                for (const file of added) {
+                    if (existingIds.has(file.fileId)) continue;
+                    existingIds.add(file.fileId);
+                    additions.push({ fileId: file.fileId, fileName: file.fileName, isOpen: true, lastUpdated: file.lastUpdated });
+                }
+                if (additions.length) tabs = [...tabs, ...additions];
+            }
+        });
+        // Push the tab state when the MCP server comes up (the reactive
+        // scheduleTabPush only fires on tab changes, so the initial state
+        // would otherwise be missing until the user switches tabs).
+        let mcpWasRunning = false;
+        const stopMcpStateWatch = mcpClientState.subscribe((state) => {
+            if (state.running && !mcpWasRunning) {
+                scheduleTabPush(tabs, activeTabId);
+            }
+            mcpWasRunning = state.running;
+        });
         return () => {
             document.removeEventListener('click', handleDocClick);
             window.removeEventListener('keydown', handleKeyDown);
             window.removeEventListener('beforeunload', handleUnload);
             window.removeEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
+            stopMcpFileSync();
+            stopMcpEventSync();
+            stopMcpStateWatch();
+            if (tabPushTimer) clearTimeout(tabPushTimer);
         };
     });
 </script>
@@ -4546,6 +4647,24 @@ func main() {
                         <line x1="5" y1="5" x2="19" y2="19" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
                     </svg>
                 {/if}
+            </button>
+        </Tooltip>
+        <Tooltip text="MCP Server" pos="right">
+            <button
+                class="activity-icon"
+                on:click={openMcpSettings}
+                title={$mcpClientState.running ? 'MCP Server — Running' : 'MCP Server — Stopped'}
+                aria-label="MCP Server"
+                bind:this={mcpActivityButton}
+            >
+                <span class:mcp-running={$mcpClientState.running} class="mcp-icon-legend" aria-hidden="true"></span>
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M9 2v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M15 2v6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M7 8h10v4a5 5 0 0 1-10 0Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M12 17v5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M8 22h8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
             </button>
         </Tooltip>
         <div class="settings-wrapper activity-settings" bind:this={settingsContainer}>
@@ -5452,6 +5571,7 @@ func main() {
 </div>
 
 <CloudSyncModal open={showCloudSettings} onClose={closeCloudSettings} />
+<McpServerModal open={showMcpSettings} onClose={closeMcpSettings} />
 
 <style>
     .workspace {
@@ -5585,6 +5705,22 @@ func main() {
 
     .cloud-icon-offline {
         opacity: 0.5;
+    }
+
+    .mcp-icon-legend {
+        position: absolute;
+        top: 5px;
+        right: 6px;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: var(--color-text-secondary);
+        box-shadow: 0 0 0 2px var(--color-bg);
+    }
+
+    .mcp-icon-legend.mcp-running {
+        background: var(--color-easy);
+        box-shadow: 0 0 0 2px var(--color-bg), 0 0 6px color-mix(in srgb, var(--color-easy) 70%, transparent);
     }
 
     /* Sidebar Styles */


### PR DESCRIPTION
## Summary

Adds a local MCP server to the Cojudge playground so AI agents can read and edit the user's open files, see what the user is looking at, and work with pasted images.

- **MCP server infrastructure**: `McpServer` (streamable HTTP) served at `/mcp`, with the `@modelcontextprotocol/sdk`; a shared manager singleton handling sessions, permissions, and the file snapshot. State routes under `/api/mcp/*` (state, files, images, tabs, SSE events).
- **Settings UI**: `McpServerModal` with start/stop, permission toggles (read/write/create/delete, hidden-file visibility), and a copyable agent URL. Auto-starts when previously left running; two-way file sync between the playground and agents (agent edits re-render open notes live).
- **Tools**: `list_files`, `search_files`, `read_file`, `write_file`, `edit_file`, `move_file`, `create_file`, `create_note`, `delete_file`, plus new **`read_image`** (read a pasted image referenced as `cojudge://image/<id>`), **`upload_image`** (agent uploads an image that appears in the user's notes), and **`get_open_tabs`** (active + open tabs, resolves previews to their source file, gates hidden files).
- **Desktop auth**: persistent 64-hex token per app launch (`COJUDGE_DESKTOP_TOKEN`), accepted via `Authorization: Bearer`, `?token=`, or cookie; `rotate_desktop_token` Tauri command for the packaged app. Backend `BODY_SIZE_LIMIT` raised 10M → 100M for image payloads.
- **Tests**: 5 e2e suites (`mcp-active-tab`, `mcp-open-tabs`, `mcp-read-image`, `mcp-upload-image`, `mcp-wysiwyg`) covering API-level behavior and full UI roundtrips; `workers: 1` to serialize since the MCP manager is a server singleton.

## Verification

- `npx playwright test e2e/mcp-` — 11/11 passing
- `npx vitest run` — 108/108 passing
- `npm run check` — only pre-existing errors (none in touched files)