### PR TITLE
fix: tab open/close and reorder no longer create cloud changes

### DIFF
--- a/src/lib/cloudFileChange.test.ts
+++ b/src/lib/cloudFileChange.test.ts
@@ -18,6 +18,24 @@ import {
 	type FileStore,
 	type ProgressStore
 } from './cloudFileChange';
+import { collectProgressData, type ProgressData } from './progressBackup';
+
+// Mirrors production: local and cloud data are cloud-sanitized (editor-only
+// fields like `order` stripped) before any workspace-level comparison, see
+// fileChangesAgainstCloud in cloudSync.ts.
+function sanitized(data: ProgressStore): ProgressData {
+	const keys = Object.keys(data);
+	const storage = {
+		length: keys.length,
+		key: (index: number) => keys[index] ?? null,
+		getItem: (key: string) => {
+			if (!(key in data)) return null;
+			const value = data[key];
+			return typeof value === 'string' ? value : JSON.stringify(value);
+		}
+	};
+	return collectProgressData(storage, { cloud: true });
+}
 
 function store(files: Array<{ fileId: string; fileName?: string; language: string; content: string }>): FileStore {
 	return {
@@ -155,7 +173,7 @@ describe('discardFile', () => {
 		expect(entries[0].lastUpdated).toBe(200);
 	});
 
-	it('restores cloud order instead of keeping the local order field', () => {
+	it('keeps the local order field when discarding', () => {
 		const localStore: FileStore = {
 			playground: JSON.stringify([
 				{ fileId: '1', fileName: 'Solution', language: 'python', content: 'print(2)', order: 5, isOpen: true }
@@ -170,7 +188,7 @@ describe('discardFile', () => {
 		const updated = discardFile(localStore, '1', cloudStore);
 		const entries = JSON.parse(updated.playground) as Array<Record<string, unknown>>;
 		expect(entries[0].content).toBe('print(1)');
-		expect(entries[0].order).toBe(1);
+		expect(entries[0].order).toBe(5);
 		expect(entries[0].isOpen).toBe(true);
 	});
 
@@ -301,7 +319,7 @@ describe('computeWorkspaceChanges', () => {
 		const cloud: ProgressStore = {
 			files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Original', language: 'python', content: 'x=1' }]) }
 		};
-		const changes = computeWorkspaceChanges(local, cloud, new Set());
+		const changes = computeWorkspaceChanges(sanitized(local), sanitized(cloud), new Set());
 		expect(changes).toHaveLength(1);
 		expect(changes[0].fileId).toBe(`${WORKSPACE_FILE_ID_PREFIX}playground`);
 	});
@@ -313,12 +331,33 @@ describe('computeWorkspaceChanges', () => {
 		const cloud: ProgressStore = {
 			files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Original', language: 'python', content: 'x=1' }]) }
 		};
-		expect(computeWorkspaceChanges(local, cloud, new Set(['playground']))).toEqual([]);
+		expect(computeWorkspaceChanges(sanitized(local), sanitized(cloud), new Set(['playground']))).toEqual([]);
 	});
 
 	it('ignores identical workspaces', () => {
 		const files = { playground: JSON.stringify([{ fileId: '1', fileName: 'A', language: 'python', content: 'x=1' }]) };
-		expect(computeWorkspaceChanges({ files }, { files }, new Set())).toEqual([]);
+		expect(computeWorkspaceChanges(sanitized({ files }), sanitized({ files }), new Set())).toEqual([]);
+	});
+
+	it('ignores order-only differences (tab reorder/close is not a cloud change)', () => {
+		const local: ProgressStore = {
+			files: {
+				playground: JSON.stringify([
+					{ fileId: '1', fileName: 'A', language: 'python', content: 'x', order: 0 },
+					{ fileId: '2', fileName: 'B', language: 'python', content: 'y', order: 1 }
+				])
+			}
+		};
+		const cloud: ProgressStore = {
+			files: {
+				playground: JSON.stringify([
+					{ fileId: '1', fileName: 'A', language: 'python', content: 'x', order: 1 },
+					{ fileId: '2', fileName: 'B', language: 'python', content: 'y', order: 0 }
+				])
+			}
+		};
+		expect(computeWorkspaceChanges(sanitized(local), sanitized(cloud), new Set())).toEqual([]);
+		expect(computeFileChanges(local.files as FileStore, cloud.files as FileStore)).toEqual([]);
 	});
 });
 
@@ -366,9 +405,11 @@ describe('discardChange', () => {
 
 describe('discard residual workspace noise', () => {
 	it('does not leave a workspace change after discarding matching content in place', () => {
-		// Mirrors cloud-sanitized entries (no editor-only fields). Previously,
-		// discardFile appended restored entries and kept local `order`, which
-		// made a phantom "Files (names or order)" change appear after discard.
+		// Mirrors cloud-sanitized comparison (production sanitizes before
+		// comparing). Previously, discardFile appended restored entries and kept
+		// local `order`, which made a phantom "Files (names or order)" change
+		// appear after discard. `order` is local-only UI state now, so the
+		// sanitized comparison must stay clean.
 		const localStore: FileStore = {
 			playground: JSON.stringify([
 				{ fileId: '1', fileName: 'A', language: 'python', content: 'local', order: 2 },
@@ -385,7 +426,11 @@ describe('discard residual workspace noise', () => {
 		const updated = discardFile(localStore, '1', cloudStore);
 		expect(computeFileChanges(updated, cloudStore)).toEqual([]);
 		expect(
-			computeWorkspaceChanges({ files: updated }, { files: cloudStore }, new Set())
+			computeWorkspaceChanges(
+				sanitized({ files: updated }),
+				sanitized({ files: cloudStore }),
+				new Set()
+			)
 		).toEqual([]);
 	});
 });

--- a/src/lib/cloudFileChange.ts
+++ b/src/lib/cloudFileChange.ts
@@ -59,9 +59,8 @@ export const OTHER_CHANGE_FILE_ID_PREFIXES = [
 
 // UI/runtime fields that belong to the editor, not to the file itself. They are
 // carried over when a local file is discarded back to its cloud version.
-// Note: `order` is intentionally excluded — it is a cloud-synced field, so
-// discarding must restore the cloud order or a residual "Files (names or order)"
-// change appears after every content discard.
+// `order` is tab-list placement: local-only UI state, so discarding must keep
+// the local order or the tab arrangement jumps after every content discard.
 const UI_FIELDS = [
 	'isOpen',
 	'isActive',
@@ -69,7 +68,8 @@ const UI_FIELDS = [
 	'viewState',
 	'output',
 	'logs',
-	'lastSharedContent'
+	'lastSharedContent',
+	'order'
 ] as const;
 
 function parseEntries(store: FileStore, slug: string): Array<Record<string, unknown>> {
@@ -417,8 +417,8 @@ export function computeOtherChanges(localData: ProgressStore, cloudData: Progres
 }
 
 // Catch-all for `files` store differences that produce no content diff (file
-// renames, reorders, or other metadata edits): one blob change per workspace
-// slug, skipped when a content-level change already covers that workspace.
+// renames or other metadata edits): one blob change per workspace slug, skipped
+// when a content-level change already covers that workspace.
 export function computeWorkspaceChanges(
 	localData: ProgressStore,
 	cloudData: ProgressStore,
@@ -538,9 +538,10 @@ export function computeWhiteboardChange(localBoard: unknown, cloudBoard: unknown
 
 // Reverts a single file to its cloud version: locals that only exist locally are
 // removed, and entries the file still owns in the cloud are restored while
-// carrying over editor UI state. Restored entries replace matching local slots
-// in place so sibling files (and array order) stay put — otherwise discarding
-// content leaves a residual "Files (names or order)" workspace change.
+// carrying over editor UI state (including the local tab order). Restored
+// entries replace matching local slots in place so sibling files (and array
+// order) stay put — otherwise discarding content leaves a residual "Files
+// (names or order)" workspace change.
 export function discardFile(
 	localStore: FileStore,
 	fileId: string,

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -39,6 +39,7 @@ import {
 	isCloudRestoreInProgress,
 	isMeaningfulProgress,
 	resumeProgressStorageWrites,
+	sanitizeCloudFiles,
 	serializeProgressData,
 	type ProgressData
 } from '$lib/progressBackup';
@@ -1142,7 +1143,10 @@ function readLocalFilesStore(): FileStore {
 
 function fileChangesAgainstCloud(local: ProgressData, cloud: ProgressData): FileChange[] {
 	const localFiles = (local.files as FileStore | undefined) ?? {};
-	const cloudFiles = (cloud.files as FileStore | undefined) ?? {};
+	// Re-sanitize the cloud side: snapshots uploaded by older builds may still
+	// carry fields that are local-only today (e.g. `order`), which would
+	// otherwise surface as phantom "Files (names or order)" changes.
+	const cloudFiles = (sanitizeCloudFiles(cloud).files as FileStore | undefined) ?? {};
 	const localBoard = local[WHITEBOARD_BOARD_KEY];
 	const cloudBoard = cloud[WHITEBOARD_BOARD_KEY];
 

--- a/src/lib/progressBackup.test.ts
+++ b/src/lib/progressBackup.test.ts
@@ -298,6 +298,7 @@ describe('progress backups', () => {
 						language: 'python',
 						isOpen: true,
 						isActive: true,
+						order: 0,
 						lastUpdated: 100,
 						viewState: '1:5'
 					}
@@ -316,6 +317,7 @@ describe('progress backups', () => {
 						language: 'python',
 						isOpen: false,
 						isActive: false,
+						order: 4,
 						lastUpdated: 200,
 						viewState: '2:10'
 					}

--- a/src/lib/progressBackup.ts
+++ b/src/lib/progressBackup.ts
@@ -104,9 +104,9 @@ function parseStoredValue(value: string): unknown {
 }
 
 // Only these FileEntry fields represent the file itself. Editor/runtime state
-// like the open/active tab, cursors, run output, or touch timestamps must not
-// affect the cloud data or its change checksum.
-const CLOUD_FILE_FIELDS = ['fileName', 'content', 'language', 'fileId', 'order', 'type', 'sourceFileId', 'shareId', 'parentId'];
+// like the open/active tab, tab order, cursors, run output, or touch timestamps
+// must not affect the cloud data or its change checksum.
+const CLOUD_FILE_FIELDS = ['fileName', 'content', 'language', 'fileId', 'type', 'sourceFileId', 'shareId', 'parentId'];
 
 function cloudFileEntry(entry: unknown): unknown {
 	if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return entry;
@@ -118,7 +118,7 @@ function cloudFileEntry(entry: unknown): unknown {
 	return result;
 }
 
-function sanitizeCloudFiles(data: ProgressData): ProgressData {
+export function sanitizeCloudFiles(data: ProgressData): ProgressData {
 	if (!('files' in data)) return data;
 	const store = data.files;
 	if (!store || typeof store !== 'object' || Array.isArray(store)) return data;

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -1595,7 +1595,7 @@ func main() {
 
     function closeTab(fileId: string) {
         const tabToClose = tabs.find(t => t.fileId === fileId);
-        if (isSpecialTabType(tabToClose?.type)) {
+        if (tabToClose?.type === 'preview') {
             const closedIdx = tabs.findIndex(t => t.fileId === fileId);
             tabs = tabs.filter(t => t.fileId !== fileId);
             if (!tabs[activeTabId]?.isOpen) {
@@ -1617,6 +1617,9 @@ func main() {
             return;
         }
 
+        // Editor and whiteboard tabs close the same way: the entry stays in the
+        // workspace and only the open/active state (local-only) changes, so
+        // closing a tab never becomes a cloud change.
         tabs = tabs.map(t => t.fileId === fileId ? { ...t, isOpen: false } : t);
 
         const fkey = fileKey();


### PR DESCRIPTION
## Problem

Closing a preview or whiteboard tab (and WYSIWYG preview toggles / tab drag-reorder) surfaced a phantom **"WORKSPACE Binary or generated content — diff hidden."** change in the Cojudge Cloud modal, even though open/close tab status was supposed to be excluded from syncing.

## Root cause

`order` (tab position) was in `CLOUD_FILE_FIELDS`, i.e. cloud-synced. `persistTabOrder()` renumbers `order` for every file whenever the tab list changes, so closing a preview/whiteboard tab shifted every later file's `order`, changed the sanitized cloud checksum, and produced a "Files (names or order)" workspace-level change with no content diff. Verified empirically: closing a preview tab between two editor tabs yields zero content changes and exactly one workspace change.

## Fix

- **`progressBackup.ts`**: remove `order` from `CLOUD_FILE_FIELDS` — tab order becomes local-only UI state like `isOpen`/`isActive`
- **`cloudFileChange.ts`**: move `order` into `UI_FIELDS` so discarding a file keeps the local tab order
- **`cloudSync.ts`**: re-sanitize the cloud side when diffing, so snapshots uploaded by older builds (which still contain `order`) don't show a one-time phantom change after upgrade
- **`playground/+page.svelte`**: closing a whiteboard tab now behaves like closing an editor tab (flips `isOpen`, keeps the entry) — closing any tab is sync-neutral

## Result

Closing any tab, toggling WYSIWYG previews, and drag-reordering tabs produce **zero** cloud changes. File content, renames, solutions, test cases, etc. still sync normally. Tab/file order still persists locally across sessions; it just no longer syncs across devices.

## Tests

- 109/109 unit tests pass, including new coverage: order-only differences produce no checksum or workspace change; discarding keeps the local order
- e2e: no new failures (3 clipboard-image tests fail on baseline too, environment-related)