### PR TITLE
fix: Esc no longer exits fullscreen when closing file search on macOS

### DIFF
--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -4403,6 +4403,7 @@ func main() {
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.defaultPrevented) return;
             if (e.key === 'Escape') {
+                e.preventDefault();
                 showSettings = false;
                 closeSearch();
                 closeLightbox();
@@ -5364,7 +5365,10 @@ func main() {
                     placeholder="Search files by name..."
                     class="search-file-input"
                     on:keydown={(e) => {
-                        if (e.key === 'Escape') closeSearch();
+                        if (e.key === 'Escape') {
+                            e.preventDefault();
+                            closeSearch();
+                        }
                         if (e.key === 'ArrowDown') {
                             e.preventDefault();
                             selectedIndex = (selectedIndex + 1) % filteredFiles.length;


### PR DESCRIPTION
## Problem

On macOS, pressing **Esc** to close the "Search files by name..." prompt also exited the app from fullscreen mode.

## Cause

The search input's Escape keydown handler (`src/routes/playground/+page.svelte`) closed the search overlay but never called `e.preventDefault()`. The unconsumed Escape key event propagated to the native window layer, where macOS interprets it as the "exit fullscreen" shortcut.

## Fix

- Search input handler: `e.preventDefault()` before `closeSearch()`
- Global Escape handler (covers closing search when the input isn't focused): `e.preventDefault()`

This matches the existing convention in the same file (mention popup, rename input, link input handlers already preventDefault on Escape).

## Verification

- `npm run check` — no new errors (18 pre-existing errors on main are unrelated)
- `npm run desktop:dev` — builds and launches successfully