### PR TITLE
feat: debug console for live expression evaluation

### DIFF
--- a/bin/lib/commands/debug.js
+++ b/bin/lib/commands/debug.js
@@ -13,7 +13,8 @@ Usage:
   cojudge debug continue <jobId>          Continue execution (run until next breakpoint or end)
   cojudge debug step <jobId>              Step over to the next line
   cojudge debug stop <jobId>              Stop the debug session
-  cojudge debug eval <jobId> <variable>   Show the value of a variable in the current runtime
+  cojudge debug eval <jobId> <expr>       Evaluate an expression in the current runtime
+                                          (e.g. 'cojudge debug eval <jobId> "x + y"')
 
 Start a debug session with:
   cojudge run <file> --debug-lines 5,10,15
@@ -32,15 +33,15 @@ Start a debug session with:
     }
 
     if (subAction === 'eval') {
-        const variable = args[3];
+        const variable = args.slice(3).join(' ');
         if (!jobId) {
             console.error(`Error: Missing job ID for 'eval' action.`);
-            console.error(`Usage: cojudge debug eval <jobId> <variable>`);
+            console.error(`Usage: cojudge debug eval <jobId> <expression>`);
             process.exit(1);
         }
         if (!variable) {
-            console.error(`Error: Missing variable name for 'eval' action.`);
-            console.error(`Usage: cojudge debug eval <jobId> <variable>`);
+            console.error(`Error: Missing expression for 'eval' action.`);
+            console.error(`Usage: cojudge debug eval <jobId> <expression>`);
             process.exit(1);
         }
         await debugEval(PORT, jobId, variable);

--- a/src/lib/components/ExecutionPanel.svelte
+++ b/src/lib/components/ExecutionPanel.svelte
@@ -32,8 +32,13 @@
         | "preparing"
         | "pending"
         | "judging";
-    let activeMainTab: "testcase" | "output" | "console" | "submission" | "debugger" =
-        "testcase";
+    let activeMainTab:
+        | "testcase"
+        | "output"
+        | "console"
+        | "submission"
+        | "debugger"
+        | "debug-console" = "testcase";
     let activeTestCaseIndex = 0;
     let isLoading = false;
     let isMac = false;
@@ -817,6 +822,34 @@
     let isDebugRunning = false;
     let debugPollInterval: any = null;
     let lastSyncedBreakpoints: string = "[]";
+    let evalInput = "";
+    let evalBusy = false;
+    let evalHistory: { expr: string; result?: string; error?: string }[] = [];
+
+    async function debugEvalExpression() {
+        const expr = evalInput.trim();
+        if (!expr || !debugJobId) return;
+        if (evalBusy) return;
+        evalBusy = true;
+        evalInput = "";
+        try {
+            const res = await fetch("/api/debug", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ jobId: debugJobId, action: "eval", variable: expr }),
+            });
+            const body = await res.json();
+            if (res.ok) {
+                evalHistory = [...evalHistory, { expr, result: body.value }];
+            } else {
+                evalHistory = [...evalHistory, { expr, error: body?.error || "Evaluation failed" }];
+            }
+        } catch (err: any) {
+            evalHistory = [...evalHistory, { expr, error: err?.message || "Evaluation failed" }];
+        } finally {
+            evalBusy = false;
+        }
+    }
 
     // The currently executing test case (1-based -> 0-based index) for pill highlight.
     // Only set while debugging is actively running/paused — not when completed/error/stopped.
@@ -879,6 +912,7 @@
         submissionFailure = null;
         debugState = { status: "running" };
         activeMainTab = "debugger";
+        evalHistory = [];
         lastSyncedBreakpoints = JSON.stringify(debugBreakpoints);
 
         try {
@@ -1085,6 +1119,15 @@
                 on:click={() => (activeMainTab = "debugger")}
             >
                 Debugger
+            </button>
+        {/if}
+        {#if debugState}
+            <button
+                class="tab"
+                class:active={activeMainTab === "debug-console"}
+                on:click={() => (activeMainTab = "debug-console")}
+            >
+                Debug Console
             </button>
         {/if}
     </div>
@@ -1413,6 +1456,85 @@
                         <pre class="result-output error">{debugState.error}</pre>
                     </div>
                 {/if}
+            </div>
+        {:else if activeMainTab === "debug-console" && debugState}
+            <div class="debug-view repl-view">
+                <div class="debug-header">
+                    <span class="debug-status">
+                        {#if debugState.status === "paused"}
+                            <span class="debug-dot paused"></span> Paused at line {debugState.line}
+                        {:else}
+                            <span class="debug-dot running"></span>
+                            {debugState.status === "running"
+                                ? "Running"
+                                : debugState.status === "completed"
+                                  ? "Completed"
+                                  : "Not paused"}
+                        {/if}
+                    </span>
+                    <button
+                        class="btn btn-debug-action"
+                        on:click={() => (evalHistory = [])}
+                        disabled={evalHistory.length === 0}
+                    >
+                        Clear
+                    </button>
+                    {#if debugJobId && (debugState.status === "paused" || debugState.status === "running")}
+                        <div class="debug-actions">
+                            <button class="btn btn-debug-action" on:click={() => debugAction("step")} disabled={isDebugRunning}>
+                                Step Over
+                            </button>
+                            <button class="btn btn-debug-action" on:click={() => debugAction("continue")} disabled={isDebugRunning}>
+                                Continue
+                            </button>
+                            <button class="btn btn-debug-action" on:click={() => debugAction("stop")} disabled={isDebugRunning}>
+                                Stop
+                            </button>
+                        </div>
+                    {/if}
+                </div>
+                <div class="repl-history">
+                    {#each evalHistory as entry (entry.expr + entry.result + entry.error)}
+                        <div class="repl-entry">
+                            <div class="repl-input-line">
+                                <span class="repl-prompt">&gt;</span>
+                                <span class="repl-expr">{entry.expr}</span>
+                            </div>
+                            {#if entry.error}
+                                <div class="repl-result repl-error">{entry.error}</div>
+                            {:else}
+                                <div class="repl-result">{entry.result}</div>
+                            {/if}
+                        </div>
+                    {/each}
+                    {#if evalHistory.length === 0}
+                        <div class="debug-placeholder">
+                            {#if debugState.status === "paused"}
+                                Enter an expression to evaluate, e.g. <code>x + y</code> or
+                                <code>arr.length</code>.
+                            {:else}
+                                Waiting for the debug session to pause...
+                            {/if}
+                        </div>
+                    {/if}
+                </div>
+                <div class="repl-input-row">
+                    <span class="repl-prompt">&gt;</span>
+                    <input
+                        class="repl-input"
+                        type="text"
+                        placeholder={debugState.status === "paused"
+                            ? "Enter expression to evaluate"
+                            : "Session must be paused to evaluate"}
+                        bind:value={evalInput}
+                        disabled={debugState.status !== "paused" || evalBusy || !debugJobId}
+                        on:keydown={(e) => {
+                            if (e.key === "Enter") debugEvalExpression();
+                        }}
+                        spellcheck="false"
+                        autocomplete="off"
+                    />
+                </div>
             </div>
         {/if}
     </div>
@@ -2171,5 +2293,67 @@
         color: var(--color-text-secondary);
         font-style: italic;
         padding: var(--spacing-1) var(--spacing-2);
+    }
+    .repl-history {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-2);
+        overflow-y: auto;
+        flex: 1;
+        min-height: 0;
+    }
+    .repl-view {
+        height: 100%;
+        min-height: 0;
+    }    .repl-entry {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        font-family: var(--font-mono);
+        font-size: 0.82rem;
+    }
+    .repl-input-line {
+        color: var(--color-text-secondary);
+    }
+    .repl-prompt {
+        color: var(--color-highlight);
+        font-weight: 700;
+        margin-right: 4px;
+    }
+    .repl-expr {
+        color: var(--color-text-primary);
+    }
+    .repl-result {
+        color: var(--color-text);
+        white-space: pre-wrap;
+        word-break: break-word;
+        padding-left: 16px;
+    }
+    .repl-error {
+        color: var(--color-incorrect);
+    }
+    .repl-input-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        border-top: 1px solid var(--color-border);
+        padding-top: var(--spacing-2);
+    }
+    .repl-input {
+        flex: 1;
+        font-family: var(--font-mono);
+        font-size: 0.82rem;
+        padding: 6px 8px;
+        border: 1px solid var(--color-border);
+        border-radius: var(--border-radius-sm);
+        background: var(--color-surface);
+        color: var(--color-text);
+        outline: none;
+    }
+    .repl-input:focus {
+        border-color: var(--color-highlight);
+    }
+    .repl-input:disabled {
+        opacity: 0.5;
     }
 </style>

--- a/src/lib/components/PlaygroundExecutionPanel.svelte
+++ b/src/lib/components/PlaygroundExecutionPanel.svelte
@@ -26,6 +26,35 @@
     let isDebugRunning = false;
     let debugPollInterval: any = null;
     let lastSyncedBreakpoints: string = '[]';
+    let activeTab: "output" | "console" = "output";
+    let evalInput = "";
+    let evalBusy = false;
+    let evalHistory: { expr: string; result?: string; error?: string }[] = [];
+
+    async function debugEvalExpression() {
+        const expr = evalInput.trim();
+        if (!expr || !debugJobId) return;
+        if (evalBusy) return;
+        evalBusy = true;
+        evalInput = "";
+        try {
+            const res = await fetch("/api/debug", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ jobId: debugJobId, action: "eval", variable: expr }),
+            });
+            const body = await res.json();
+            if (res.ok) {
+                evalHistory = [...evalHistory, { expr, result: body.value }];
+            } else {
+                evalHistory = [...evalHistory, { expr, error: body?.error || "Evaluation failed" }];
+            }
+        } catch (err: any) {
+            evalHistory = [...evalHistory, { expr, error: err?.message || "Evaluation failed" }];
+        } finally {
+            evalBusy = false;
+        }
+    }
 
     $: activeDebugLine = (debugState && debugState.status === 'paused') ? debugState.line : null;
 
@@ -319,6 +348,7 @@
         hasRunOnce = true;
         debugState = { status: 'running' };
         runningMessage = "Debug starting...";
+        evalHistory = [];
         lastSyncedBreakpoints = JSON.stringify(debugBreakpoints);
 
         try {
@@ -460,14 +490,107 @@
         on:keydown={handleResizerKeydown}
     ></button>
     <div class="tabs" class:hide={$execPaneHeightStore <= 15}>
-        <button class="tab active">Output</button>
+        <button
+            class="tab"
+            class:active={activeTab === "output"}
+            on:click={() => (activeTab = "output")}
+        >
+            Output
+        </button>
+        {#if debugState}
+            <button
+                class="tab"
+                class:active={activeTab === "console"}
+                on:click={() => (activeTab = "console")}
+            >
+                Debug Console
+            </button>
+        {/if}
     </div>
 
     <div
         class="content"
         class:hide={$execPaneHeightStore <= minExecPanelHeight}
     >
-        {#if debugState}
+        {#if debugState && activeTab === "console"}
+            <div class="debug-view repl-view">
+                <div class="debug-header">
+                    <span class="debug-status">
+                        {#if debugState.status === 'paused'}
+                            <span class="debug-dot paused"></span> Paused at line {debugState.line}
+                        {:else}
+                            <span class="debug-dot running"></span>
+                            {debugState.status === 'running'
+                                ? 'Running'
+                                : debugState.status === 'completed'
+                                  ? 'Completed'
+                                  : 'Not paused'}
+                        {/if}
+                    </span>
+                    <button
+                        class="btn btn-debug-action"
+                        on:click={() => (evalHistory = [])}
+                        disabled={evalHistory.length === 0}
+                    >
+                        Clear
+                    </button>
+                    {#if debugJobId && (debugState.status === 'paused' || debugState.status === 'running')}
+                        <div class="debug-actions">
+                            <button class="btn btn-debug-action" on:click={() => debugAction('step')} disabled={isDebugRunning}>
+                                Step Over
+                            </button>
+                            <button class="btn btn-debug-action" on:click={() => debugAction('continue')} disabled={isDebugRunning}>
+                                Continue
+                            </button>
+                            <button class="btn btn-debug-action" on:click={() => debugAction('stop')} disabled={isDebugRunning}>
+                                Stop
+                            </button>
+                        </div>
+                    {/if}
+                </div>
+                <div class="repl-history">
+                    {#each evalHistory as entry (entry.expr + entry.result + entry.error)}
+                        <div class="repl-entry">
+                            <div class="repl-input-line">
+                                <span class="repl-prompt">&gt;</span>
+                                <span class="repl-expr">{entry.expr}</span>
+                            </div>
+                            {#if entry.error}
+                                <div class="repl-result repl-error">{entry.error}</div>
+                            {:else}
+                                <div class="repl-result">{entry.result}</div>
+                            {/if}
+                        </div>
+                    {/each}
+                    {#if evalHistory.length === 0}
+                        <div class="debug-placeholder">
+                            {#if debugState.status === 'paused'}
+                                Enter an expression to evaluate, e.g. <code>x + y</code>.
+                            {:else}
+                                Waiting for the debug session to pause...
+                            {/if}
+                        </div>
+                    {/if}
+                </div>
+                <div class="repl-input-row">
+                    <span class="repl-prompt">&gt;</span>
+                    <input
+                        class="repl-input"
+                        type="text"
+                        placeholder={debugState.status === 'paused'
+                            ? 'Enter expression to evaluate'
+                            : 'Session must be paused to evaluate'}
+                        bind:value={evalInput}
+                        disabled={debugState.status !== 'paused' || evalBusy || !debugJobId}
+                        on:keydown={(e) => {
+                            if (e.key === 'Enter') debugEvalExpression();
+                        }}
+                        spellcheck="false"
+                        autocomplete="off"
+                    />
+                </div>
+            </div>
+        {:else if debugState}
             <div class="debug-view">
                 <div class="debug-header">
                     <span class="debug-status">
@@ -1112,5 +1235,68 @@
         color: var(--color-text-secondary);
         font-style: italic;
         padding: var(--spacing-1) var(--spacing-2);
+    }
+    .repl-history {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-2);
+        overflow-y: auto;
+        flex: 1;
+        min-height: 0;
+    }
+    .repl-view {
+        height: 100%;
+        min-height: 0;
+    }
+    .repl-entry {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        font-family: var(--font-mono);
+        font-size: 0.82rem;
+    }
+    .repl-input-line {
+        color: var(--color-text-secondary);
+    }
+    .repl-prompt {
+        color: var(--color-highlight);
+        font-weight: 700;
+        margin-right: 4px;
+    }
+    .repl-expr {
+        color: var(--color-text-primary);
+    }
+    .repl-result {
+        color: var(--color-text);
+        white-space: pre-wrap;
+        word-break: break-word;
+        padding-left: 16px;
+    }
+    .repl-error {
+        color: var(--color-incorrect);
+    }
+    .repl-input-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        border-top: 1px solid var(--color-border);
+        padding-top: var(--spacing-2);
+    }
+    .repl-input {
+        flex: 1;
+        font-family: var(--font-mono);
+        font-size: 0.82rem;
+        padding: 6px 8px;
+        border: 1px solid var(--color-border);
+        border-radius: var(--border-radius-sm);
+        background: var(--color-surface);
+        color: var(--color-text);
+        outline: none;
+    }
+    .repl-input:focus {
+        border-color: var(--color-highlight);
+    }
+    .repl-input:disabled {
+        opacity: 0.5;
     }
 </style>

--- a/src/lib/runners/CppDebugDriver.ts
+++ b/src/lib/runners/CppDebugDriver.ts
@@ -9,6 +9,7 @@ import time
 STATE_FILE = '/tmp/cojudge_debug_state.json'
 CMD_FILE = '/tmp/cojudge_debug_cmd.json'
 STDOUT_FILE = '/tmp/cojudge_stdout.txt'
+EVAL_RESULT_FILE = '/tmp/cojudge_eval_result.json'
 
 def send_mi(gdb_proc, cmd):
     gdb_proc.stdin.write(cmd + '\n')
@@ -80,6 +81,35 @@ def collect_variables(gdb_proc):
     send_mi(gdb_proc, '-stack-list-variables --all-values')
     resp = read_mi_until(gdb_proc)
     return extract_all_vars(resp)
+
+def unescape_mi(raw):
+    return raw.replace('\\"', '"').replace('\\\\', '\\')
+
+def eval_expression(gdb_proc, expr):
+    quoted = '"' + expr.replace('\\', '\\\\').replace('"', '\\"') + '"'
+    send_mi(gdb_proc, '-data-evaluate-expression ' + quoted)
+    resp = read_mi_until(gdb_proc)
+    for record in resp:
+        if record.startswith('^error'):
+            m = re.search(r'msg="((?:[^"\\]|\\.)*)"', record)
+            msg = m.group(1) if m else 'evaluation failed'
+            return None, unescape_mi(msg)
+        m = re.match(r'\^done,value="((?:[^"\\]|\\.)*)"', record)
+        if m:
+            return unescape_mi(m.group(1)), None
+    return None, 'no result from gdb'
+
+def write_eval_result(value, error):
+    payload = {}
+    if error is not None:
+        payload['error'] = error
+    else:
+        payload['value'] = value
+    try:
+        with open(EVAL_RESULT_FILE, 'w') as f:
+            json.dump(payload, f)
+    except:
+        pass
 
 def wait_for_cmd():
     while True:
@@ -203,6 +233,10 @@ def main():
                         elif action == 'continue':
                             send_mi(gdb_proc, '-exec-continue')
                             break
+                        elif action == 'eval':
+                            expr = cmd.get('expression', '')
+                            value, err = eval_expression(gdb_proc, expr)
+                            write_eval_result(value, err)
                         elif action == 'set_breakpoints':
                             new_bps = cmd.get('breakpoints', [])
                             new_bps_int = []

--- a/src/lib/runners/CsharpDebugDriver.ts
+++ b/src/lib/runners/CsharpDebugDriver.ts
@@ -1,7 +1,10 @@
 export const CSHARP_DEBUG_SUPPORT: string = String.raw`using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 
@@ -11,6 +14,7 @@ public static class DebugSupport
     private static bool stepMode = false;
     private static string STATE_FILE = "/tmp/cojudge_debug_state.json";
     private static string CMD_FILE = "/tmp/cojudge_debug_cmd.json";
+    private static string EVAL_RESULT_FILE = "/tmp/cojudge_eval_result.json";
     private static StringWriter outputCapture = new StringWriter();
     private static TextWriter originalOut;
 
@@ -33,7 +37,7 @@ public static class DebugSupport
         WriteState("running", -1, null, null);
     }
 
-    public static void Check(int line, Dictionary<string, string> vars)
+    public static void Check(int line, Dictionary<string, object> vars)
     {
         PollCommands();
 
@@ -81,9 +85,9 @@ public static class DebugSupport
         catch { }
     }
 
-    private static void Pause(int line, Dictionary<string, string> vars)
+    private static void Pause(int line, Dictionary<string, object> vars)
     {
-        WriteState("paused", line, null, vars);
+        WriteState("paused", line, null, RenderDict(vars));
 
         while (true)
         {
@@ -126,7 +130,22 @@ public static class DebugSupport
                             }
                         }
                     }
-                    WriteState("paused", line, null, vars);
+                    WriteState("paused", line, null, RenderDict(vars));
+                    continue;
+                }
+
+                if (action == "eval")
+                {
+                    string expr = GetJsonString(content, "expression");
+                    try
+                    {
+                        object result = ExprEvaluator.Evaluate(expr, vars);
+                        WriteEvalResult(RenderValue(result), null);
+                    }
+                    catch (Exception e)
+                    {
+                        WriteEvalResult(null, e.Message);
+                    }
                     continue;
                 }
 
@@ -150,6 +169,74 @@ public static class DebugSupport
                 Thread.Sleep(100);
             }
         }
+    }
+
+    private static string GetJsonString(string json, string key)
+    {
+        int ki = json.IndexOf("\"" + key + "\"", StringComparison.Ordinal);
+        if (ki < 0) return "";
+        int ci = json.IndexOf(':', ki);
+        if (ci < 0) return "";
+        int q1 = json.IndexOf('"', ci);
+        if (q1 < 0) return "";
+        var sb = new StringBuilder();
+        int i = q1 + 1;
+        while (i < json.Length)
+        {
+            char c = json[i];
+            if (c == '\\')
+            {
+                if (i + 1 >= json.Length) break;
+                char e = json[i + 1];
+                switch (e)
+                {
+                    case '"': sb.Append('"'); break;
+                    case '\\': sb.Append('\\'); break;
+                    case 'n': sb.Append('\n'); break;
+                    case 't': sb.Append('\t'); break;
+                    case 'r': sb.Append('\r'); break;
+                    default: sb.Append(e); break;
+                }
+                i += 2;
+            }
+            else if (c == '"')
+            {
+                return sb.ToString();
+            }
+            else
+            {
+                sb.Append(c);
+                i++;
+            }
+        }
+        return sb.ToString();
+    }
+
+    private static Dictionary<string, string> RenderDict(Dictionary<string, object> vars)
+    {
+        var rendered = new Dictionary<string, string>();
+        if (vars == null) return rendered;
+        foreach (var kv in vars)
+        {
+            rendered[kv.Key] = RenderValue(kv.Value);
+        }
+        return rendered;
+    }
+
+    private static void WriteEvalResult(string value, string error)
+    {
+        var sb = new StringBuilder();
+        sb.Append("{");
+        if (error != null)
+        {
+            sb.Append("\"error\":\"").Append(EscapeJson(error)).Append("\"");
+        }
+        else
+        {
+            sb.Append("\"value\":\"").Append(EscapeJson(value ?? "null")).Append("\"");
+        }
+        sb.Append("}");
+        try { File.WriteAllText(EVAL_RESULT_FILE, sb.ToString()); } catch { }
     }
 
     private static string ParseAction(string json)
@@ -360,6 +447,504 @@ public static class DebugSupport
         WriteState("completed", -1, null, null);
     }
 }
+
+public static class ExprEvaluator
+{
+    public static object Evaluate(string expr, Dictionary<string, object> vars)
+    {
+        var p = new Parser(expr, vars);
+        object v = p.ParseExpression();
+        if (!p.AtEnd) throw new InvalidOperationException("Unexpected token at position " + p.Pos);
+        return v;
+    }
+
+    private class Parser
+    {
+        private readonly string s;
+        private readonly Dictionary<string, object> vars;
+        private int pos;
+
+        public Parser(string s, Dictionary<string, object> vars) { this.s = s; this.vars = vars; }
+
+        public int Pos { get { SkipWs(); return pos; } }
+
+        private char Cur { get { SkipWs(); return pos < s.Length ? s[pos] : '\0'; } }
+        private char Peek(int off) { return pos + off < s.Length ? s[pos + off] : '\0'; }
+
+        public bool AtEnd { get { SkipWs(); return pos >= s.Length; } }
+
+        private void SkipWs() { while (pos < s.Length && char.IsWhiteSpace(s[pos])) pos++; }
+
+        public object ParseExpression() { return ParseOr(); }
+
+        private object ParseOr()
+        {
+            object a = ParseAnd();
+            while (Cur == '|' && Peek(1) == '|')
+            {
+                pos += 2;
+                object b = ParseAnd();
+                a = (bool)a || (bool)b;
+            }
+            return a;
+        }
+
+        private object ParseAnd()
+        {
+            object a = ParseEquality();
+            while (Cur == '&' && Peek(1) == '&')
+            {
+                pos += 2;
+                object b = ParseEquality();
+                a = (bool)a && (bool)b;
+            }
+            return a;
+        }
+
+        private object ParseEquality()
+        {
+            object a = ParseRelational();
+            while (true)
+            {
+                string op = null;
+                if (Cur == '=' && Peek(1) == '=') op = "==";
+                else if (Cur == '!' && Peek(1) == '=') op = "!=";
+                if (op == null) return a;
+                pos += 2;
+                object b = ParseRelational();
+                a = Compare(a, b, op);
+            }
+        }
+
+        private object ParseRelational()
+        {
+            object a = ParseAdditive();
+            while (true)
+            {
+                string op = null;
+                char c = Cur;
+                if (c == '<' && Peek(1) == '=') op = "<=";
+                else if (c == '>' && Peek(1) == '=') op = ">=";
+                else if (c == '<') op = "<";
+                else if (c == '>') op = ">";
+                if (op == null) return a;
+                pos += op.Length;
+                object b = ParseAdditive();
+                a = Compare(a, b, op);
+            }
+        }
+
+        private object ParseAdditive()
+        {
+            object a = ParseMultiplicative();
+            while (true)
+            {
+                char c = Cur;
+                if (c != '+' && c != '-') return a;
+                pos++;
+                object b = ParseMultiplicative();
+                a = Arith(c, a, b);
+            }
+        }
+
+        private object ParseMultiplicative()
+        {
+            object a = ParseUnary();
+            while (true)
+            {
+                char c = Cur;
+                if (c != '*' && c != '/' && c != '%') return a;
+                pos++;
+                object b = ParseUnary();
+                a = Arith(c, a, b);
+            }
+        }
+
+        private object ParseUnary()
+        {
+            char c = Cur;
+            if (c == '-')
+            {
+                pos++;
+                object v = ParseUnary();
+                if (v == null) throw new InvalidOperationException("Unary '-' on null");
+                if (v is string) throw new InvalidOperationException("Unary '-' on string");
+                if (v is bool) throw new InvalidOperationException("Unary '-' on bool");
+                return -((dynamic)v);
+            }
+            if (c == '+') { pos++; return ParseUnary(); }
+            if (c == '!')
+            {
+                pos++;
+                object v = ParseUnary();
+                if (v == null || !(v is bool)) throw new InvalidOperationException("'!' requires a boolean operand");
+                return !(bool)v;
+            }
+            return ParsePostfix();
+        }
+
+        private object ParsePostfix()
+        {
+            object v = ParsePrimary();
+            while (true)
+            {
+                SkipWs();
+                if (pos < s.Length && s[pos] == '[')
+                {
+                    pos++;
+                    object idx = ParseExpression();
+                    if (Cur != ']') throw new InvalidOperationException("Expected ']'");
+                    pos++;
+                    v = Index(v, idx);
+                }
+                else if (pos < s.Length && s[pos] == '.')
+                {
+                    pos++;
+                    SkipWs();
+                    string name = ReadIdent();
+                    SkipWs();
+                    if (pos < s.Length && s[pos] == '(')
+                    {
+                        pos++;
+                        var args = new List<object>();
+                        SkipWs();
+                        if (Cur != ')')
+                        {
+                            args.Add(ParseExpression());
+                            while (Cur == ',') { pos++; args.Add(ParseExpression()); }
+                        }
+                        if (Cur != ')') throw new InvalidOperationException("Expected ')'");
+                        pos++;
+                        v = Invoke(v, name, args);
+                    }
+                    else
+                    {
+                        v = Member(v, name);
+                    }
+                }
+                else
+                {
+                    return v;
+                }
+            }
+        }
+
+        private object ParsePrimary()
+        {
+            SkipWs();
+            if (pos >= s.Length) throw new InvalidOperationException("Unexpected end of expression");
+            char c = s[pos];
+            if (c == '(')
+            {
+                pos++;
+                object v = ParseExpression();
+                if (Cur != ')') throw new InvalidOperationException("Expected ')'");
+                pos++;
+                return v;
+            }
+            if (c == '"') return ParseString();
+            if (char.IsDigit(c)) return ParseNumber();
+            if (char.IsLetter(c) || c == '_')
+            {
+                string name = ReadIdent();
+                switch (name)
+                {
+                    case "true": return true;
+                    case "false": return false;
+                    case "null": return null;
+                }
+                if (vars != null && vars.TryGetValue(name, out object val))
+                    return val;
+                Type t = FindType(name);
+                if (t != null) return t;
+                throw new InvalidOperationException("Unknown identifier '" + name + "'");
+            }
+            throw new InvalidOperationException("Unexpected character '" + c + "' at position " + pos);
+        }
+
+        private static readonly Dictionary<string, Type> typeCache = new Dictionary<string, Type>();
+
+        private static Type FindType(string name)
+        {
+            if (typeCache.TryGetValue(name, out Type cached)) return cached;
+            switch (name)
+            {
+                case "int": return typeof(int);
+                case "long": return typeof(long);
+                case "double": return typeof(double);
+                case "float": return typeof(float);
+                case "decimal": return typeof(decimal);
+                case "short": return typeof(short);
+                case "byte": return typeof(byte);
+                case "sbyte": return typeof(sbyte);
+                case "char": return typeof(char);
+                case "bool": return typeof(bool);
+                case "string": return typeof(string);
+                case "object": return typeof(object);
+                case "uint": return typeof(uint);
+                case "ulong": return typeof(ulong);
+                case "ushort": return typeof(ushort);
+            }
+            Type t = Type.GetType("System." + name);
+            if (t != null) { typeCache[name] = t; return t; }
+            foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                if (asm.IsDynamic) continue;
+                Type[] types;
+                try { types = asm.GetExportedTypes(); }
+                catch { continue; }
+                foreach (var ty in types)
+                {
+                    if (ty.IsPublic && ty.Name == name)
+                    {
+                        typeCache[name] = ty;
+                        return ty;
+                    }
+                }
+            }
+            return null;
+        }
+
+        private string ReadIdent()
+        {
+            SkipWs();
+            int start = pos;
+            while (pos < s.Length && (char.IsLetterOrDigit(s[pos]) || s[pos] == '_')) pos++;
+            if (pos == start) throw new InvalidOperationException("Expected identifier at position " + pos);
+            return s.Substring(start, pos - start);
+        }
+
+        private string ParseString()
+        {
+            pos++;
+            var sb = new StringBuilder();
+            while (pos < s.Length && s[pos] != '"')
+            {
+                char c = s[pos];
+                if (c == '\\' && pos + 1 < s.Length)
+                {
+                    char e = s[pos + 1];
+                    switch (e)
+                    {
+                        case 'n': sb.Append('\n'); break;
+                        case 't': sb.Append('\t'); break;
+                        case 'r': sb.Append('\r'); break;
+                        case '\\': sb.Append('\\'); break;
+                        case '"': sb.Append('"'); break;
+                        case '\'': sb.Append('\''); break;
+                        default: sb.Append(e); break;
+                    }
+                    pos += 2;
+                }
+                else
+                {
+                    sb.Append(c);
+                    pos++;
+                }
+            }
+            if (pos >= s.Length) throw new InvalidOperationException("Unterminated string literal");
+            pos++;
+            return sb.ToString();
+        }
+
+        private object ParseNumber()
+        {
+            int start = pos;
+            bool isDouble = false;
+            while (pos < s.Length && (char.IsDigit(s[pos]) || s[pos] == '.' || s[pos] == 'e' || s[pos] == 'E'
+                || ((s[pos] == '-' || s[pos] == '+') && pos > start && (s[pos - 1] == 'e' || s[pos - 1] == 'E'))))
+            {
+                if (s[pos] == '.' || s[pos] == 'e' || s[pos] == 'E') isDouble = true;
+                pos++;
+            }
+            string num = s.Substring(start, pos - start);
+            if (isDouble)
+                return double.Parse(num, CultureInfo.InvariantCulture);
+            if (long.TryParse(num, NumberStyles.Integer, CultureInfo.InvariantCulture, out long lv))
+                return lv;
+            return double.Parse(num, CultureInfo.InvariantCulture);
+        }
+
+        private static object Arith(char op, object a, object b)
+        {
+            try
+            {
+                if (op == '+' && (a is string || b is string))
+                {
+                    return (a == null ? "" : Convert.ToString(a, CultureInfo.InvariantCulture))
+                        + (b == null ? "" : Convert.ToString(b, CultureInfo.InvariantCulture));
+                }
+                if (a == null || b == null) throw new InvalidOperationException("Arithmetic on null");
+                if (a is bool || b is bool) throw new InvalidOperationException("Arithmetic on bool");
+                if (a is string || b is string) throw new InvalidOperationException("Arithmetic on string");
+                dynamic x = a, y = b;
+                switch (op)
+                {
+                    case '+': return x + y;
+                    case '-': return x - y;
+                    case '*': return x * y;
+                    case '/': return x / y;
+                    default: return x % y;
+                }
+            }
+            catch (InvalidOperationException) { throw; }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException("Arithmetic error: " + e.Message);
+            }
+        }
+
+        private static bool Eq(object a, object b)
+        {
+            if (a == null && b == null) return true;
+            if (a == null || b == null) return false;
+            if (a is string || b is string)
+                return Convert.ToString(a, CultureInfo.InvariantCulture) == Convert.ToString(b, CultureInfo.InvariantCulture);
+            if (a.GetType() == b.GetType() && a is IComparable c) return c.CompareTo(b) == 0;
+            return ((dynamic)a) == ((dynamic)b);
+        }
+
+        private static object Compare(object a, object b, string op)
+        {
+            try
+            {
+                if (op == "==") return Eq(a, b);
+                if (op == "!=") return !Eq(a, b);
+                if (a == null || b == null) throw new InvalidOperationException("Cannot compare null");
+                if (a is string || b is string) throw new InvalidOperationException("Cannot order-compare strings");
+                if (a is bool || b is bool) throw new InvalidOperationException("Cannot order-compare booleans");
+                dynamic x = a, y = b;
+                switch (op)
+                {
+                    case "<": return x < y;
+                    case "<=": return x <= y;
+                    case ">": return x > y;
+                    default: return x >= y;
+                }
+            }
+            catch (InvalidOperationException) { throw; }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException("Comparison error: " + e.Message);
+            }
+        }
+
+        private static object Index(object target, object index)
+        {
+            if (target == null) throw new InvalidOperationException("Cannot index null");
+            try
+            {
+                return ((dynamic)target)[(dynamic)index];
+            }
+            catch (InvalidOperationException) { throw; }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException("Indexing failed: " + e.Message);
+            }
+        }
+
+        private static object Member(object target, string name)
+        {
+            if (target == null) throw new InvalidOperationException("Cannot access member on null");
+            try
+            {
+                if (target is Type ty)
+                {
+                    var sProp = ty.GetProperty(name);
+                    if (sProp != null) return sProp.GetValue(null, null);
+                    var sField = ty.GetField(name);
+                    if (sField != null) return sField.GetValue(null);
+                    throw new InvalidOperationException("No static member '" + name + "' on " + ty.Name);
+                }
+                var t = target.GetType();
+                var prop = t.GetProperty(name);
+                if (prop != null) return prop.GetValue(target, null);
+                var field = t.GetField(name);
+                if (field != null) return field.GetValue(target);
+                throw new InvalidOperationException("No member '" + name + "' on " + t.Name);
+            }
+            catch (InvalidOperationException) { throw; }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException("Member access failed: " + e.Message);
+            }
+        }
+
+        private static object Invoke(object target, string name, List<object> args)
+        {
+            if (target == null) throw new InvalidOperationException("Cannot call method on null");
+            try
+            {
+                bool isStatic = target is Type;
+                var t = isStatic ? (Type)target : target.GetType();
+                MethodInfo method = null;
+                int bestScore = -1;
+                foreach (var m in t.GetMethods())
+                {
+                    if (m.Name != name || m.IsStatic != isStatic || m.GetParameters().Length != args.Count) continue;
+                    var types = m.GetParameters().Select(p => p.ParameterType).ToArray();
+                    int sc = 0;
+                    bool ok = true;
+                    for (int i = 0; i < args.Count; i++)
+                    {
+                        int s = ScoreArg(args[i], types[i]);
+                        if (s <= 0) { ok = false; break; }
+                        sc += s;
+                    }
+                    if (ok && sc > bestScore) { bestScore = sc; method = m; }
+                }
+                if (method == null)
+                    throw new InvalidOperationException("No method '" + name + "' with " + args.Count + " args on " + t.Name);
+                var paramTypes = method.GetParameters().Select(p => p.ParameterType).ToArray();
+                var converted = new object[args.Count];
+                for (int i = 0; i < args.Count; i++)
+                {
+                    converted[i] = ConvertArg(args[i], paramTypes[i]);
+                }
+                return method.Invoke(isStatic ? null : target, converted);
+            }
+            catch (InvalidOperationException) { throw; }
+            catch (Exception e)
+            {
+                throw new InvalidOperationException("Method call failed: " + e.Message);
+            }
+        }
+
+        private static int ScoreArg(object v, Type t)
+        {
+            if (v == null) return (t.IsClass || t.IsInterface) && !t.IsPrimitive ? 1 : 0;
+            Type vt = v.GetType();
+            if (t == vt) return 3;
+            if (vt == typeof(string) || vt == typeof(bool)) return 0;
+            if (t == typeof(object)) return 1;
+            if (vt == typeof(long) || vt == typeof(int) || vt == typeof(short) || vt == typeof(byte)
+                || vt == typeof(double) || vt == typeof(float) || vt == typeof(char))
+            {
+                if (t == typeof(int)) return vt == typeof(long) ? 2 : 1;
+                if (t == typeof(long)) return 2;
+                if (t == typeof(double)) return vt == typeof(double) || vt == typeof(float) ? 3 : 2;
+                if (t == typeof(float)) return vt == typeof(double) ? 0 : 2;
+                if (t == typeof(short) || t == typeof(byte) || t == typeof(char)) return 1;
+                if (t == typeof(decimal)) return 2;
+                return 0;
+            }
+            return 0;
+        }
+
+        private static object ConvertArg(object v, Type t)
+        {
+            if (v == null) return null;
+            if (t == typeof(int)) return Convert.ToInt32(v, CultureInfo.InvariantCulture);
+            if (t == typeof(long)) return Convert.ToInt64(v, CultureInfo.InvariantCulture);
+            if (t == typeof(double)) return Convert.ToDouble(v, CultureInfo.InvariantCulture);
+            if (t == typeof(float)) return Convert.ToSingle(v, CultureInfo.InvariantCulture);
+            if (t == typeof(short)) return Convert.ToInt16(v, CultureInfo.InvariantCulture);
+            if (t == typeof(byte)) return Convert.ToByte(v, CultureInfo.InvariantCulture);
+            if (t == typeof(bool)) return Convert.ToBoolean(v);
+            return v;
+        }
+    }
+}
 `;
 
 const SIMPLE_TYPE_RE = /\b(var|int|long|double|float|decimal|bool|string|char|byte|short|uint|ulong|ushort|sbyte|object|dynamic)\s+(\w+)\s*(?=[=;,)])/g;
@@ -558,9 +1143,9 @@ export function generateCsharpDebugWrapper(
 
         if (inMethod && !varsInited && (braceOnThisLine || bareBrace)) {
             const bodyIndent = indent + '    ';
-            result.push(`${bodyIndent}var ${V} = new Dictionary<string, string>();`);
+            result.push(`${bodyIndent}var ${V} = new Dictionary<string, object>();`);
             for (const p of paramNames) {
-                result.push(`${bodyIndent}${V}["${p}"] = DebugSupport.RenderValue(${p});`);
+                result.push(`${bodyIndent}${V}["${p}"] = ${p};`);
             }
             if (isMainMethod && !mainInited) {
                 const bpStr = initBreakpoints ? `DebugSupport.Init("${initBreakpoints}")` : 'DebugSupport.Init("")';
@@ -576,7 +1161,7 @@ export function generateCsharpDebugWrapper(
                 if (!allVarNames.includes(vn)) allVarNames.push(vn);
             }
             for (const vn of allVarNames) {
-                result.push(`${indent}${V}["${vn}"] = DebugSupport.RenderValue(${vn});`);
+                result.push(`${indent}${V}["${vn}"] = ${vn};`);
             }
         }
 

--- a/src/lib/runners/DebugRunner.ts
+++ b/src/lib/runners/DebugRunner.ts
@@ -25,6 +25,7 @@ const docker = new Dockerode();
 
 const DEBUG_STATE_FILE = '/tmp/cojudge_debug_state.json';
 const DEBUG_CMD_FILE = '/tmp/cojudge_debug_cmd.json';
+const DEBUG_EVAL_RESULT_FILE = '/tmp/cojudge_eval_result.json';
 
 export type DebugState = {
     status: 'running' | 'paused' | 'completed' | 'error' | 'stopped';
@@ -77,6 +78,7 @@ import sys, os, json, time, types, io
 _COJUDGE_BREAKPOINTS = ${bpStr}
 _COJUDGE_STATE_FILE = '${DEBUG_STATE_FILE}'
 _COJUDGE_CMD_FILE = '${DEBUG_CMD_FILE}'
+_COJUDGE_EVAL_RESULT_FILE = '${DEBUG_EVAL_RESULT_FILE}'
 _COJUDGE_SOURCE_FILE = '${sourceFile}'
 _COJUDGE_ENTRY_FILE = '${entryFile}'
 
@@ -106,7 +108,29 @@ def _write_state(status, line=None, vars=None, error=None):
     except:
         pass
 
-def _wait_for_cmd():
+def _write_eval_result(value=None, error=None):
+    payload = {}
+    if error is not None:
+        payload['error'] = error
+    else:
+        payload['value'] = value
+    try:
+        with open(_COJUDGE_EVAL_RESULT_FILE, 'w') as f:
+            json.dump(payload, f)
+    except:
+        pass
+
+def _eval_expression(expr, frame):
+    try:
+        val = eval(expr, frame.f_globals, frame.f_locals)
+        try:
+            _write_eval_result(value=repr(val))
+        except:
+            _write_eval_result(value='<' + type(val).__name__ + '>')
+    except Exception as e:
+        _write_eval_result(error=str(e))
+
+def _wait_for_cmd(frame=None):
     global _COJUDGE_BREAKPOINTS
     while True:
         try:
@@ -115,6 +139,14 @@ def _wait_for_cmd():
             if cmd.get('action') == 'set_breakpoints':
                 _COJUDGE_BREAKPOINTS = set(cmd.get('breakpoints', []))
                 os.remove(_COJUDGE_CMD_FILE)
+                continue
+            if cmd.get('action') == 'eval':
+                expr = cmd.get('expression', '')
+                try:
+                    os.remove(_COJUDGE_CMD_FILE)
+                except:
+                    pass
+                _eval_expression(expr, frame)
                 continue
             if cmd.get('action') in ('continue', 'step', 'stop'):
                 os.remove(_COJUDGE_CMD_FILE)
@@ -160,7 +192,7 @@ def _cojudge_trace(frame, event, arg):
 
         _write_state('paused', line=lineno, vars=vars_dict)
 
-        cmd = _wait_for_cmd()
+        cmd = _wait_for_cmd(frame)
 
         if cmd.get('action') == 'stop':
             _write_state('stopped')
@@ -209,12 +241,37 @@ async function readDebugState(container: Dockerode.Container): Promise<DebugStat
     return { status: 'running' };
 }
 
-async function writeDebugCmd(container: Dockerode.Container, action: 'continue' | 'step' | 'stop' | 'set_breakpoints', extra?: Record<string, any>): Promise<void> {
+async function readEvalResult(container: Dockerode.Container): Promise<{ value?: string; error?: string } | null> {
+    try {
+        const exec = await container.exec({
+            Cmd: ['cat', DEBUG_EVAL_RESULT_FILE],
+            AttachStdout: true,
+            AttachStderr: true
+        });
+        const stream: any = await exec.start({ hijack: true, stdin: false });
+        let stdout = '';
+        await new Promise<void>((resolve) => {
+            (container as any).modem.demuxStream(
+                stream,
+                { write: (chunk: any) => (stdout += chunk.toString()) },
+                { write: () => {} }
+            );
+            stream.on('end', resolve);
+            stream.on('error', resolve);
+        });
+        if (stdout.trim()) {
+            return JSON.parse(stdout.trim());
+        }
+    } catch {}
+    return null;
+}
+
+async function writeDebugCmd(container: Dockerode.Container, action: 'continue' | 'step' | 'stop' | 'set_breakpoints' | 'eval', extra?: Record<string, any>): Promise<void> {
     const cmdContent: any = { action };
     if (extra) Object.assign(cmdContent, extra);
     const cmd = JSON.stringify(cmdContent);
     let escaped: string;
-    if (action === 'set_breakpoints') {
+    if (action === 'set_breakpoints' || action === 'eval') {
         escaped = `echo '${cmd.replace(/'/g, "'\\''")}' > ${DEBUG_CMD_FILE}`;
     } else {
         const newState = JSON.stringify({ status: 'running' });
@@ -1013,14 +1070,42 @@ export async function debugEval(jobId: string, variable: string): Promise<{ vari
         throw new Error(`Cannot evaluate '${variable}': session is ${state.status} (must be paused at a breakpoint)`);
     }
 
+    const expr = variable.trim();
+    if (!expr) throw new Error('Empty expression');
+
+    const isBareIdent = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(expr);
     const vars = state.vars || {};
-    if (!(variable in vars)) {
+    if (isBareIdent && expr in vars) {
+        return { variable: expr, value: vars[expr], line: state.line };
+    }
+
+    // Live evaluation inside the paused container: write an eval command,
+    // then poll for the result file the driver writes.
+    await runExec(session.container, ['sh', '-c', `rm -f ${DEBUG_EVAL_RESULT_FILE}; true`]);
+    await writeDebugCmd(session.container, 'eval', { expression: expr });
+
+    const start = Date.now();
+    while (Date.now() - start < 5000) {
+        const result = await readEvalResult(session.container);
+        if (result) {
+            if (result.error) {
+                const available = Object.keys(vars);
+                const hint = isBareIdent && available.length > 0
+                    ? ` Available variables: ${available.join(', ')}`
+                    : '';
+                throw new Error(`${result.error}${hint}`);
+            }
+            return { variable: expr, value: result.value ?? '', line: state.line };
+        }
+        await new Promise(r => setTimeout(r, 150));
+    }
+
+    if (isBareIdent) {
         const available = Object.keys(vars);
         const hint = available.length > 0
             ? `Available variables: ${available.join(', ')}`
             : 'No variables in scope at this point';
-        throw new Error(`Variable '${variable}' not found. ${hint}`);
+        throw new Error(`Variable '${expr}' not found. ${hint}`);
     }
-
-    return { variable, value: vars[variable], line: state.line };
+    throw new Error(`Timed out evaluating '${expr}'`);
 }

--- a/src/lib/runners/JavaDebugDriver.ts
+++ b/src/lib/runners/JavaDebugDriver.ts
@@ -12,6 +12,7 @@ import java.util.*;
 public class DebugDriver {
     static final String STATE_FILE = "/tmp/cojudge_debug_state.json";
     static final String CMD_FILE = "/tmp/cojudge_debug_cmd.json";
+    static final String EVAL_RESULT_FILE = "/tmp/cojudge_eval_result.json";
     static String MAIN_CLASS = "Main";
     static String SOURCE_FILE = "Main.java";
 
@@ -114,7 +115,7 @@ public class DebugDriver {
         Map<String, String> vars = collectVars(thread);
         writeState("paused", line, vars, null);
 
-        Map<String, Object> cmd = waitForCmd();
+        Map<String, Object> cmd = waitForCmd(thread);
         String action = String.valueOf(cmd.get("action"));
 
         if (activeStep != null) {
@@ -202,7 +203,611 @@ public class DebugDriver {
         return i >= 0 ? tn.substring(i + 1) : tn;
     }
 
-    static Map<String, Object> waitForCmd() {
+    // ---------------- expression evaluator (JDB-style, on top of JDI) ----------------
+
+    static void writeEvalResult(Value v, String error) {
+        String value = null;
+        if (error == null) {
+            value = v == null ? "null" : render(v, 0);
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (error != null) sb.append("\"error\":").append(jstr(error));
+        else sb.append("\"value\":").append(jstr(value));
+        sb.append("}");
+        try {
+            Files.write(Paths.get(EVAL_RESULT_FILE), sb.toString().getBytes());
+        } catch (Exception ignore) {}
+    }
+
+    static Value evaluateExpr(String expr, ThreadReference thread) throws Exception {
+        ExprParser p = new ExprParser(expr, thread);
+        Object v = p.parseExpression();
+        if (!p.atEnd()) throw new IllegalArgumentException("Unexpected token at position " + p.pos);
+        if (v instanceof ReferenceType) {
+            throw new IllegalArgumentException("'" + expr + "' resolves to a class, not a value");
+        }
+        if (v != null && !(v instanceof Value)) {
+            throw new IllegalArgumentException("Cannot use '" + expr + "' as a value");
+        }
+        return (Value) v;
+    }
+
+    static class ExprParser {
+        final String s;
+        final ThreadReference thread;
+        int pos = 0;
+
+        ExprParser(String s, ThreadReference thread) {
+            this.s = s;
+            this.thread = thread;
+        }
+
+        void skipWs() { while (pos < s.length() && Character.isWhitespace(s.charAt(pos))) pos++; }
+        boolean atEnd() { skipWs(); return pos >= s.length(); }
+        char cur() { skipWs(); return pos < s.length() ? s.charAt(pos) : '\0'; }
+        char peek(int off) { return pos + off < s.length() ? s.charAt(pos + off) : '\0'; }
+
+        Object parseExpression() { return parseOr(); }
+
+        Object parseOr() {
+            Object a = parseAnd();
+            while (cur() == '|' && peek(1) == '|') {
+                pos += 2;
+                Object b = parseAnd();
+                a = boolOp(a, b, "||");
+            }
+            return a;
+        }
+
+        Object parseAnd() {
+            Object a = parseEquality();
+            while (cur() == '&' && peek(1) == '&') {
+                pos += 2;
+                Object b = parseEquality();
+                a = boolOp(a, b, "&&");
+            }
+            return a;
+        }
+
+        Object parseEquality() {
+            Object a = parseRelational();
+            while (true) {
+                String op = null;
+                if (cur() == '=' && peek(1) == '=') op = "==";
+                else if (cur() == '!' && peek(1) == '=') op = "!=";
+                if (op == null) return a;
+                pos += 2;
+                Object b = parseRelational();
+                a = compareOp(thread, a, b, op);
+            }
+        }
+
+        Object parseRelational() {
+            Object a = parseAdditive();
+            while (true) {
+                String op = null;
+                char c = cur();
+                if (c == '<' && peek(1) == '=') op = "<=";
+                else if (c == '>' && peek(1) == '=') op = ">=";
+                else if (c == '<') op = "<";
+                else if (c == '>') op = ">";
+                if (op == null) return a;
+                pos += op.length();
+                Object b = parseAdditive();
+                a = compareOp(thread, a, b, op);
+            }
+        }
+
+        Object parseAdditive() {
+            Object a = parseMultiplicative();
+            while (true) {
+                char c = cur();
+                if (c != '+' && c != '-') return a;
+                pos++;
+                Object b = parseMultiplicative();
+                a = arithOp(thread, c, a, b);
+            }
+        }
+
+        Object parseMultiplicative() {
+            Object a = parseUnary();
+            while (true) {
+                char c = cur();
+                if (c != '*' && c != '/' && c != '%') return a;
+                pos++;
+                Object b = parseUnary();
+                a = arithOp(thread, c, a, b);
+            }
+        }
+
+        Object parseUnary() {
+            char c = cur();
+            if (c == '-') {
+                pos++;
+                return unaryMinus(thread, parseUnary());
+            }
+            if (c == '+') { pos++; return parseUnary(); }
+            if (c == '!') {
+                pos++;
+                Object v = parseUnary();
+                if (!(v instanceof BooleanValue))
+                    throw new IllegalArgumentException("'!' requires a boolean operand");
+                return thread.virtualMachine().mirrorOf(!((BooleanValue) v).value());
+            }
+            return parsePostfix();
+        }
+
+        Object parsePostfix() {
+            Object v = parsePrimary();
+            while (true) {
+                skipWs();
+                if (pos < s.length() && s.charAt(pos) == '[') {
+                    pos++;
+                    Object idx = parseExpression();
+                    if (cur() != ']') throw new IllegalArgumentException("Expected ']'");
+                    pos++;
+                    v = arrayIndex(v, idx);
+                } else if (pos < s.length() && s.charAt(pos) == '.') {
+                    pos++;
+                    skipWs();
+                    String name = readIdent();
+                    skipWs();
+                    if (pos < s.length() && s.charAt(pos) == '(') {
+                        pos++;
+                        List<Value> args = new ArrayList<>();
+                        skipWs();
+                        if (cur() != ')') {
+                            args.add(asValue(parseExpression(), "argument"));
+                            while (cur() == ',') { pos++; args.add(asValue(parseExpression(), "argument")); }
+                        }
+                        if (cur() != ')') throw new IllegalArgumentException("Expected ')'");
+                        pos++;
+                        v = invokeMethod(thread, v, name, args);
+                    } else {
+                        v = fieldAccess(v, name);
+                    }
+                } else {
+                    return v;
+                }
+            }
+        }
+
+        Object parsePrimary() {
+            skipWs();
+            if (pos >= s.length()) throw new IllegalArgumentException("Unexpected end of expression");
+            char c = s.charAt(pos);
+            if (c == '(') {
+                pos++;
+                Object v = parseExpression();
+                if (cur() != ')') throw new IllegalArgumentException("Expected ')'");
+                pos++;
+                return v;
+            }
+            if (c == '"') return parseString();
+            if (Character.isDigit(c)) return parseNumber();
+            if (Character.isJavaIdentifierStart(c)) {
+                String name = readIdent();
+                switch (name) {
+                    case "true": return thread.virtualMachine().mirrorOf(true);
+                    case "false": return thread.virtualMachine().mirrorOf(false);
+                    case "null": return null;
+                    default: return resolveIdent(name);
+                }
+            }
+            throw new IllegalArgumentException("Unexpected character '" + c + "' at position " + pos);
+        }
+
+        String readIdent() {
+            skipWs();
+            int start = pos;
+            while (pos < s.length() && Character.isJavaIdentifierPart(s.charAt(pos))) pos++;
+            if (pos == start) throw new IllegalArgumentException("Expected identifier at position " + pos);
+            return s.substring(start, pos);
+        }
+
+        Value parseString() {
+            pos++;
+            StringBuilder sb = new StringBuilder();
+            while (pos < s.length() && s.charAt(pos) != '"') {
+                char c = s.charAt(pos);
+                if (c == '\\' && pos + 1 < s.length()) {
+                    char e = s.charAt(pos + 1);
+                    switch (e) {
+                        case 'n': sb.append('\n'); break;
+                        case 't': sb.append('\t'); break;
+                        case 'r': sb.append('\r'); break;
+                        case '\\': sb.append('\\'); break;
+                        case '"': sb.append('"'); break;
+                        case 'u':
+                            if (pos + 5 < s.length()) {
+                                try { sb.append((char) Integer.parseInt(s.substring(pos + 2, pos + 6), 16)); pos += 4; }
+                                catch (NumberFormatException ignore) { sb.append('u'); }
+                            } else { sb.append('u'); }
+                            break;
+                        default: sb.append(e);
+                    }
+                    pos += 2;
+                } else {
+                    sb.append(c);
+                    pos++;
+                }
+            }
+            if (pos >= s.length()) throw new IllegalArgumentException("Unterminated string literal");
+            pos++;
+            return thread.virtualMachine().mirrorOf(sb.toString());
+        }
+
+        Value parseNumber() {
+            int start = pos;
+            boolean isDouble = false;
+            while (pos < s.length() && (Character.isDigit(s.charAt(pos))
+                    || s.charAt(pos) == '.' || s.charAt(pos) == 'e' || s.charAt(pos) == 'E')) {
+                if (s.charAt(pos) == '.' || s.charAt(pos) == 'e' || s.charAt(pos) == 'E') isDouble = true;
+                pos++;
+            }
+            String num = s.substring(start, pos);
+            VirtualMachine vm = thread.virtualMachine();
+            try {
+                if (isDouble) return vm.mirrorOf(Double.parseDouble(num));
+                long lv = Long.parseLong(num);
+                if (lv >= Integer.MIN_VALUE && lv <= Integer.MAX_VALUE) return vm.mirrorOf((int) lv);
+                return vm.mirrorOf(lv);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Invalid number '" + num + "'");
+            }
+        }
+
+        Object resolveIdent(String name) {
+            try {
+                StackFrame frame = thread.frame(0);
+                if ("this".equals(name)) return frame.thisObject();
+                LocalVariable lv = frame.visibleVariableByName(name);
+                if (lv != null) return frame.getValue(lv);
+                for (String pkg : new String[]{"java.lang.", "java.util.", "java.math."}) {
+                    List<ReferenceType> cs = thread.virtualMachine().classesByName(pkg + name);
+                    if (!cs.isEmpty()) return cs.get(0);
+                }
+                List<ReferenceType> classes = thread.virtualMachine().classesByName(name);
+                if (!classes.isEmpty()) return classes.get(0);
+                for (ReferenceType rt : thread.virtualMachine().allClasses()) {
+                    String n = rt.name();
+                    int dot = n.lastIndexOf('.');
+                    String simple = dot >= 0 ? n.substring(dot + 1) : n;
+                    if (simple.equals(name) && n.startsWith("java.lang.")) return rt;
+                }
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Cannot resolve '" + name + "': " + e.getMessage());
+            }
+            throw new IllegalArgumentException("Unknown identifier '" + name + "'");
+        }
+    }
+
+    static Value asValue(Object v, String what) {
+        if (v == null) return null;
+        if (v instanceof ReferenceType)
+            throw new IllegalArgumentException("'" + ((ReferenceType) v).name() + "' is a class, not a value (" + what + ")");
+        if (v instanceof Value) return (Value) v;
+        throw new IllegalArgumentException("Cannot use value in " + what);
+    }
+
+    static List<ReferenceType> typeChain(ReferenceType rt) {
+        List<ReferenceType> chain = new ArrayList<>();
+        ReferenceType cur = rt;
+        while (cur != null) {
+            chain.add(cur);
+            cur = (cur instanceof ClassType) ? ((ClassType) cur).superclass() : null;
+        }
+        return chain;
+    }
+
+    static Value boolOp(Object a, Object b, String op) {
+        if (!(a instanceof BooleanValue) || !(b instanceof BooleanValue))
+            throw new IllegalArgumentException("'" + op + "' requires boolean operands");
+        boolean x = ((BooleanValue) a).value();
+        boolean y = ((BooleanValue) b).value();
+        boolean r = "||".equals(op) ? (x || y) : (x && y);
+        return ((BooleanValue) a).virtualMachine().mirrorOf(r);
+    }
+
+    static Value unaryMinus(ThreadReference thread, Object v) {
+        if (!(v instanceof PrimitiveValue))
+            throw new IllegalArgumentException("Unary '-' requires a numeric operand");
+        PrimitiveValue p = (PrimitiveValue) v;
+        VirtualMachine vm = thread.virtualMachine();
+        if (p instanceof DoubleValue) return vm.mirrorOf(-p.doubleValue());
+        if (p instanceof FloatValue) return vm.mirrorOf(-p.floatValue());
+        return vm.mirrorOf(-p.longValue());
+    }
+
+    static Value arithOp(ThreadReference thread, char op, Object a, Object b) {
+        if (a == null || b == null) throw new IllegalArgumentException("Arithmetic on null");
+        Value va = (Value) a, vb = (Value) b;
+        VirtualMachine vm = thread.virtualMachine();
+        if (op == '+') {
+            if (a instanceof StringReference || b instanceof StringReference) {
+                return vm.mirrorOf(strValue(va) + strValue(vb));
+            }
+        }
+        if (!(a instanceof PrimitiveValue) || !(b instanceof PrimitiveValue))
+            throw new IllegalArgumentException("Arithmetic requires numeric operands");
+        if (a instanceof DoubleValue || a instanceof FloatValue || b instanceof DoubleValue || b instanceof FloatValue) {
+            double x = ((PrimitiveValue) a).doubleValue();
+            double y = ((PrimitiveValue) b).doubleValue();
+            switch (op) {
+                case '+': return vm.mirrorOf(x + y);
+                case '-': return vm.mirrorOf(x - y);
+                case '*': return vm.mirrorOf(x * y);
+                case '/': return vm.mirrorOf(x / y);
+                default: return vm.mirrorOf(x % y);
+            }
+        }
+        long x = ((PrimitiveValue) a).longValue();
+        long y = ((PrimitiveValue) b).longValue();
+        switch (op) {
+            case '+': return vm.mirrorOf(x + y);
+            case '-': return vm.mirrorOf(x - y);
+            case '*': return vm.mirrorOf(x * y);
+            case '/':
+                if (y == 0) throw new IllegalArgumentException("Division by zero");
+                return vm.mirrorOf(x / y);
+            default:
+                if (y == 0) throw new IllegalArgumentException("Division by zero");
+                return vm.mirrorOf(x % y);
+        }
+    }
+
+    static String strValue(Value v) {
+        if (v == null) return "null";
+        if (v instanceof StringReference) return ((StringReference) v).value();
+        if (v instanceof PrimitiveValue) return v.toString();
+        return render(v, 0);
+    }
+
+    static Value compareOp(ThreadReference thread, Object a, Object b, String op) {
+        VirtualMachine vm;
+        if (a instanceof Value) vm = ((Value) a).virtualMachine();
+        else if (b instanceof Value) vm = ((Value) b).virtualMachine();
+        else vm = thread.virtualMachine();
+        if (a == null || b == null) {
+            if (!op.equals("==") && !op.equals("!="))
+                throw new IllegalArgumentException("Cannot compare null");
+            return vm.mirrorOf(op.equals("==") ? (a == null && b == null) : (a != null || b != null));
+        }
+        if (!(a instanceof Value) || !(b instanceof Value))
+            throw new IllegalArgumentException("Cannot compare class references");
+        if (op.equals("==") || op.equals("!=")) {
+            boolean eq;
+            if (a instanceof StringReference && b instanceof StringReference) {
+                eq = ((StringReference) a).value().equals(((StringReference) b).value());
+            } else if (a instanceof BooleanValue && b instanceof BooleanValue) {
+                eq = ((BooleanValue) a).value() == ((BooleanValue) b).value();
+            } else if (a instanceof PrimitiveValue && b instanceof PrimitiveValue) {
+                if (a instanceof DoubleValue || a instanceof FloatValue || b instanceof DoubleValue || b instanceof FloatValue) {
+                    eq = ((PrimitiveValue) a).doubleValue() == ((PrimitiveValue) b).doubleValue();
+                } else {
+                    eq = ((PrimitiveValue) a).longValue() == ((PrimitiveValue) b).longValue();
+                }
+            } else {
+                eq = a.equals(b);
+            }
+            return vm.mirrorOf("==".equals(op) ? eq : !eq);
+        }
+        if (!(a instanceof PrimitiveValue) || !(b instanceof PrimitiveValue))
+            throw new IllegalArgumentException("Order comparison requires numeric operands");
+        if (a instanceof DoubleValue || a instanceof FloatValue || b instanceof DoubleValue || b instanceof FloatValue) {
+            double x = ((PrimitiveValue) a).doubleValue();
+            double y = ((PrimitiveValue) b).doubleValue();
+            switch (op) {
+                case "<": return vm.mirrorOf(x < y);
+                case "<=": return vm.mirrorOf(x <= y);
+                case ">": return vm.mirrorOf(x > y);
+                default: return vm.mirrorOf(x >= y);
+            }
+        }
+        long x = ((PrimitiveValue) a).longValue();
+        long y = ((PrimitiveValue) b).longValue();
+        switch (op) {
+            case "<": return vm.mirrorOf(x < y);
+            case "<=": return vm.mirrorOf(x <= y);
+            case ">": return vm.mirrorOf(x > y);
+            default: return vm.mirrorOf(x >= y);
+        }
+    }
+
+    static Value arrayIndex(Object v, Object idx) {
+        if (!(v instanceof ArrayReference))
+            throw new IllegalArgumentException("Cannot index non-array value");
+        if (idx == null || !(idx instanceof PrimitiveValue))
+            throw new IllegalArgumentException("Array index must be numeric");
+        ArrayReference arr = (ArrayReference) v;
+        int i = (int) ((PrimitiveValue) idx).longValue();
+        if (i < 0 || i >= arr.length())
+            throw new IllegalArgumentException("Array index out of bounds: " + i);
+        return arr.getValue(i);
+    }
+
+    static Object fieldAccess(Object v, String name) {
+        if (v instanceof ArrayReference && "length".equals(name)) {
+            return ((Value) v).virtualMachine().mirrorOf(((ArrayReference) v).length());
+        }
+        if (v instanceof ReferenceType) {
+            ReferenceType rt = (ReferenceType) v;
+            for (Field f : rt.allFields()) {
+                if (f.name().equals(name) && f.isStatic()) return rt.getValue(f);
+            }
+            throw new IllegalArgumentException("No static field '" + name + "' on " + rt.name());
+        }
+        if (v instanceof ObjectReference) {
+            ObjectReference obj = (ObjectReference) v;
+            for (ReferenceType rt : typeChain(obj.referenceType())) {
+                Field f = rt.fieldByName(name);
+                if (f != null) return obj.getValue(f);
+            }
+            throw new IllegalArgumentException("No field '" + name + "' on " + obj.referenceType().name());
+        }
+        throw new IllegalArgumentException("Cannot access field '" + name + "' on non-object");
+    }
+
+    static List<Value> coerceArgs(Method m, List<Value> args) {
+        List<Value> out = new ArrayList<>();
+        List<String> types = m.argumentTypeNames();
+        for (int i = 0; i < args.size(); i++) {
+            out.add(coerce(args.get(i), types.get(i)));
+        }
+        return out;
+    }
+
+    static Value coerce(Value v, String typeName) {
+        if (v == null) return v;
+        try {
+            VirtualMachine vm = v.virtualMachine();
+            PrimitiveValue p = (PrimitiveValue) v;
+            switch (typeName) {
+                case "int": return vm.mirrorOf(p.intValue());
+                case "long": return vm.mirrorOf(p.longValue());
+                case "double": return vm.mirrorOf(p.doubleValue());
+                case "float": return vm.mirrorOf(p.floatValue());
+                case "short": return vm.mirrorOf(p.shortValue());
+                case "byte": return vm.mirrorOf(p.byteValue());
+                case "char": return vm.mirrorOf((char) p.charValue());
+                case "boolean": return vm.mirrorOf(p.booleanValue());
+                case "java.lang.Integer": return vm.mirrorOf(p.intValue());
+                case "java.lang.Long": return vm.mirrorOf(p.longValue());
+                case "java.lang.Double": return vm.mirrorOf(p.doubleValue());
+                case "java.lang.Float": return vm.mirrorOf(p.floatValue());
+                case "java.lang.Short": return vm.mirrorOf(p.shortValue());
+                case "java.lang.Byte": return vm.mirrorOf(p.byteValue());
+                case "java.lang.Character": return vm.mirrorOf((char) p.charValue());
+                case "java.lang.Boolean": return vm.mirrorOf(p.booleanValue());
+                case "java.lang.String":
+                    if (v instanceof StringReference) return v;
+                    return vm.mirrorOf(strValue(v));
+                default: return v;
+            }
+        } catch (Exception e) {
+            return v;
+        }
+    }
+
+    static int scoreArg(Value v, String typeName) {
+        if (v == null) {
+            return (!typeName.equals("int") && !typeName.equals("long") && !typeName.equals("double")
+                    && !typeName.equals("float") && !typeName.equals("boolean") && !typeName.equals("short")
+                    && !typeName.equals("byte") && !typeName.equals("char")) ? 2 : 0;
+        }
+        if (v instanceof StringReference) {
+            return typeName.equals("java.lang.String") ? 3 : 0;
+        }
+        if (v instanceof PrimitiveValue) {
+            PrimitiveValue p = (PrimitiveValue) v;
+            switch (typeName) {
+                case "int":
+                    if (p instanceof IntegerValue) return 3;
+                    if (p instanceof ShortValue || p instanceof ByteValue || p instanceof CharValue) return 2;
+                    if (p instanceof LongValue) return 1;
+                    return 0;
+                case "long":
+                    if (p instanceof LongValue) return 3;
+                    if (p instanceof IntegerValue || p instanceof ShortValue || p instanceof ByteValue || p instanceof CharValue) return 2;
+                    return 0;
+                case "double":
+                    if (p instanceof DoubleValue) return 3;
+                    if (p instanceof FloatValue) return 2;
+                    return 1;
+                case "float":
+                    if (p instanceof FloatValue) return 3;
+                    if (p instanceof DoubleValue) return 0;
+                    return 2;
+                case "boolean":
+                    return p instanceof BooleanValue ? 3 : 0;
+                case "char":
+                    if (p instanceof CharValue) return 3;
+                    return p instanceof IntegerValue ? 1 : 0;
+                case "short":
+                    if (p instanceof ShortValue || p instanceof ByteValue) return 3;
+                    return p instanceof IntegerValue ? 1 : 0;
+                case "byte":
+                    return p instanceof ByteValue ? 3 : 0;
+                case "java.lang.Integer": return p instanceof IntegerValue ? 2 : 0;
+                case "java.lang.Long": return p instanceof LongValue ? 2 : 0;
+                case "java.lang.Double": return p instanceof DoubleValue ? 2 : 0;
+                case "java.lang.Float": return p instanceof FloatValue ? 2 : 0;
+                case "java.lang.Boolean": return p instanceof BooleanValue ? 2 : 0;
+                case "java.lang.Character": return p instanceof CharValue ? 2 : 0;
+                case "java.lang.Short": return p instanceof ShortValue ? 2 : 0;
+                case "java.lang.Byte": return p instanceof ByteValue ? 2 : 0;
+                default:
+                    return typeName.startsWith("[") ? 0 : 1;
+            }
+        }
+        if (typeName.equals("java.lang.String") || !typeName.startsWith("[")) return 2;
+        return 0;
+    }
+
+    static Method bestMethod(List<Method> methods, List<Value> args) {
+        Method best = null;
+        int bestScore = -1;
+        for (Method m : methods) {
+            if (m.argumentTypeNames().size() != args.size()) continue;
+            int sc = 0;
+            boolean ok = true;
+            List<String> types = m.argumentTypeNames();
+            for (int i = 0; i < args.size(); i++) {
+                int s = scoreArg(args.get(i), types.get(i));
+                if (s <= 0) { ok = false; break; }
+                sc += s;
+            }
+            if (!ok) continue;
+            if (sc > bestScore) {
+                bestScore = sc;
+                best = m;
+            }
+        }
+        return best;
+    }
+
+    static Object invokeMethod(ThreadReference thread, Object target, String name, List<Value> args) {
+        if (target instanceof ClassType) {
+            ClassType ct = (ClassType) target;
+            List<Method> candidates = new ArrayList<>();
+            for (ReferenceType t : typeChain(ct)) {
+                for (Method m : t.allMethods()) {
+                    if (m.name().equals(name) && m.isStatic()) candidates.add(m);
+                }
+            }
+            Method m = bestMethod(candidates, args);
+            if (m == null) {
+                throw new IllegalArgumentException("No static method '" + name + "' with " + args.size() + " args on " + ct.name());
+            }
+            try {
+                return ct.invokeMethod(thread, m, coerceArgs(m, args), ObjectReference.INVOKE_SINGLE_THREADED);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Static method call failed: " + e.getMessage());
+            }
+        }
+        if (target instanceof ObjectReference) {
+            ObjectReference obj = (ObjectReference) target;
+            List<Method> candidates = new ArrayList<>();
+            for (ReferenceType t : typeChain(obj.referenceType())) {
+                for (Method m : t.allMethods()) {
+                    if (m.name().equals(name) && !m.isStatic()) candidates.add(m);
+                }
+            }
+            Method m = bestMethod(candidates, args);
+            if (m == null) {
+                throw new IllegalArgumentException("No method '" + name + "' with " + args.size() + " args on " + obj.referenceType().name());
+            }
+            try {
+                return obj.invokeMethod(thread, m, coerceArgs(m, args), ObjectReference.INVOKE_SINGLE_THREADED);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Method call failed: " + e.getMessage());
+            }
+        }
+        throw new IllegalArgumentException("Cannot call method on non-object value");
+    }
+
+    static Map<String, Object> waitForCmd(ThreadReference thread) {
         while (true) {
             try {
                 File f = new File(CMD_FILE);
@@ -224,6 +829,17 @@ public class DebugDriver {
                             for (ReferenceType rt : vm.allClasses()) trySetBreakpoints(rt);
                         }
                         f.delete();
+                        continue;
+                    }
+                    if ("eval".equals(action)) {
+                        f.delete();
+                        try {
+                            String expr = String.valueOf(cmd.get("expression"));
+                            Value v = evaluateExpr(expr, thread);
+                            writeEvalResult(v, null);
+                        } catch (Exception e) {
+                            writeEvalResult(null, e.getMessage());
+                        }
                         continue;
                     }
                     if ("continue".equals(action) || "step".equals(action) || "stop".equals(action)) {
@@ -263,7 +879,48 @@ public class DebugDriver {
                 m.put("breakpoints", list);
             }
         }
+        String expr = extractJsonString(s, "expression");
+        if (expr != null) m.put("expression", expr);
         return m;
+    }
+
+    static String extractJsonString(String s, String key) {
+        int ki = s.indexOf("\"" + key + "\"");
+        if (ki < 0) return null;
+        int ci = s.indexOf(':', ki);
+        if (ci < 0) return null;
+        int q1 = s.indexOf('"', ci);
+        if (q1 < 0) return null;
+        StringBuilder sb = new StringBuilder();
+        int i = q1 + 1;
+        while (i < s.length()) {
+            char c = s.charAt(i);
+            if (c == '\\') {
+                if (i + 1 >= s.length()) break;
+                char e = s.charAt(i + 1);
+                switch (e) {
+                    case '"': sb.append('"'); break;
+                    case '\\': sb.append('\\'); break;
+                    case 'n': sb.append('\n'); break;
+                    case 't': sb.append('\t'); break;
+                    case 'r': sb.append('\r'); break;
+                    case 'u':
+                        if (i + 5 < s.length()) {
+                            try { sb.append((char) Integer.parseInt(s.substring(i + 2, i + 6), 16)); i += 4; }
+                            catch (NumberFormatException ignore) { sb.append('u'); }
+                        } else { sb.append('u'); }
+                        break;
+                    default: sb.append(e);
+                }
+                i += 2;
+            } else if (c == '"') {
+                return sb.toString();
+            } else {
+                sb.append(c);
+                i++;
+            }
+        }
+        return null;
     }
 
     static void redirect(final InputStream in) {

--- a/src/lib/runners/RustDebugDriver.ts
+++ b/src/lib/runners/RustDebugDriver.ts
@@ -9,6 +9,7 @@ import time
 STATE_FILE = '/tmp/cojudge_debug_state.json'
 CMD_FILE = '/tmp/cojudge_debug_cmd.json'
 STDOUT_FILE = '/tmp/cojudge_stdout.txt'
+EVAL_RESULT_FILE = '/tmp/cojudge_eval_result.json'
 
 def send_mi(gdb_proc, cmd):
     gdb_proc.stdin.write(cmd + '\n')
@@ -88,6 +89,35 @@ def _format_scalar(raw):
         short = type_name.group(1).rsplit('::', 1)[-1]
         return '<' + short + '>'
     return raw[:60]
+
+def unescape_mi(raw):
+    return raw.replace('\\"', '"').replace('\\\\', '\\')
+
+def _mi_eval_with_error(gdb_proc, expr):
+    quoted = '"' + expr.replace('\\', '\\\\').replace('"', '\\"') + '"'
+    send_mi(gdb_proc, '-data-evaluate-expression ' + quoted)
+    resp = read_mi_until(gdb_proc)
+    for record in resp:
+        if record.startswith('^error'):
+            m = re.search(r'msg="((?:[^"\\]|\\.)*)"', record)
+            msg = m.group(1) if m else 'evaluation failed'
+            return None, unescape_mi(msg)
+        m = re.match(r'\^done,value="((?:[^"\\]|\\.)*)"', record)
+        if m:
+            return unescape_mi(m.group(1)), None
+    return None, 'no result from gdb'
+
+def write_eval_result(value, error):
+    payload = {}
+    if error is not None:
+        payload['error'] = error
+    else:
+        payload['value'] = value
+    try:
+        with open(EVAL_RESULT_FILE, 'w') as f:
+            json.dump(payload, f)
+    except:
+        pass
 
 def collect_variables(gdb_proc):
     send_mi(gdb_proc, '-stack-list-variables --no-values')
@@ -283,6 +313,15 @@ def main():
                         elif action == 'continue':
                             send_mi(gdb_proc, '-exec-continue')
                             break
+                        elif action == 'eval':
+                            expr = cmd.get('expression', '')
+                            raw, err = _mi_eval_with_error(gdb_proc, expr)
+                            if err is not None:
+                                write_eval_result(None, err)
+                            elif raw is not None and '{' in raw:
+                                write_eval_result(_format_scalar(raw), None)
+                            else:
+                                write_eval_result(raw, None)
                         elif action == 'set_breakpoints':
                             new_bps = cmd.get('breakpoints', [])
                             new_bps_int = []

--- a/src/lib/runners/TypeScriptDebugDriver.ts
+++ b/src/lib/runners/TypeScriptDebugDriver.ts
@@ -28,6 +28,7 @@ import inspector from 'node:inspector';
 const STATE_FILE = '/tmp/cojudge_debug_state.json';
 const CMD_FILE = '/tmp/cojudge_debug_cmd.json';
 const OUTPUT_FILE = '/tmp/cojudge_debug_output.txt';
+const EVAL_RESULT_FILE = '/tmp/cojudge_eval_result.json';
 
 const ENTRY_FILE = '${entryFile}';
 const SOURCE_BASENAME = '${sourceBasename}';
@@ -52,6 +53,32 @@ function readCmd() {
 
 function consumeCmd() {
     try { fs.unlinkSync(CMD_FILE); } catch {}
+}
+
+function writeEvalResult(payload) {
+    try { fs.writeFileSync(EVAL_RESULT_FILE, JSON.stringify(payload)); } catch {}
+}
+
+async function evaluateExpression(session, frame, expression) {
+    const r = await post(session, 'Debugger.evaluateOnCallFrame', {
+        callFrameId: frame.callFrameId,
+        expression,
+        returnByValue: true,
+        throwOnSideEffect: false
+    });
+    if (r.exceptionDetails) {
+        const exc = r.exceptionDetails;
+        throw new Error((exc.exception && exc.exception.description) || exc.text || 'Evaluation failed');
+    }
+    const res = r && r.result ? r.result : null;
+    if (!res) throw new Error('Evaluation failed');
+    if (res.value !== undefined) {
+        const v = res.value;
+        if (typeof v === 'object' && v !== null) return JSON.stringify(v);
+        return String(v);
+    }
+    if (res.description) return String(res.description);
+    return '';
 }
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -219,6 +246,16 @@ async function runWorker() {
                 if (cmd.action === 'set_breakpoints') {
                     consumeCmd();
                     await setBreakpoints(cmd.breakpoints || []);
+                    continue;
+                }
+                if (cmd.action === 'eval') {
+                    consumeCmd();
+                    try {
+                        const val = await evaluateExpression(session, frame, cmd.expression || '');
+                        writeEvalResult({ value: val });
+                    } catch (e) {
+                        writeEvalResult({ error: String((e && e.message) || e) });
+                    }
                     continue;
                 }
                 if (cmd.action === 'continue') {

--- a/src/lib/runners/go_debug_driver.go
+++ b/src/lib/runners/go_debug_driver.go
@@ -16,6 +16,7 @@ import (
 
 const STATE_FILE = "/tmp/cojudge_debug_state.json"
 const CMD_FILE = "/tmp/cojudge_debug_cmd.json"
+const EVAL_RESULT_FILE = "/tmp/cojudge_eval_result.json"
 
 var dlvAddr string
 var outputBuffer bytes.Buffer
@@ -89,11 +90,11 @@ func rpcCall(method string, params interface{}) (json.RawMessage, error) {
 }
 
 type dlvState struct {
-	Exited bool   `json:"-"`
+	Exited bool `json:"-"`
 	State  struct {
-		Exited        bool   `json:"Exited"`
-		ExitStatus    int    `json:"ExitStatus"`
-		Running       bool   `json:"Running"`
+		Exited        bool `json:"Exited"`
+		ExitStatus    int  `json:"ExitStatus"`
+		Running       bool `json:"Running"`
 		CurrentThread *struct {
 			File string `json:"File"`
 			Line int    `json:"Line"`
@@ -184,12 +185,12 @@ func writeState(status string, line int, vars map[string]string, errMsg string) 
 }
 
 type dlvVariable struct {
-	Name       string         `json:"name"`
-	Value      string         `json:"value"`
-	Type       string         `json:"type"`
-	Len        int64          `json:"len"`
-	Unreadable string         `json:"unreadable"`
-	Children   []dlvVariable  `json:"children"`
+	Name       string        `json:"name"`
+	Value      string        `json:"value"`
+	Type       string        `json:"type"`
+	Len        int64         `json:"len"`
+	Unreadable string        `json:"unreadable"`
+	Children   []dlvVariable `json:"children"`
 }
 
 func renderVar(v dlvVariable, depth int) string {
@@ -233,11 +234,11 @@ func collectVars() map[string]string {
 		"Frame":       0,
 	}
 	cfg := map[string]interface{}{
-		"FollowPointers":    true,
+		"FollowPointers":     true,
 		"MaxVariableRecurse": 2,
-		"MaxArrayValues":    100,
-		"MaxStringLen":      200,
-		"MaxStructFields":   -1,
+		"MaxArrayValues":     100,
+		"MaxStringLen":       200,
+		"MaxStructFields":    -1,
 	}
 
 	locResult, err := rpcCall("RPCServer.ListLocalVars", map[string]interface{}{
@@ -281,6 +282,55 @@ func collectVars() map[string]string {
 	}
 
 	return vars
+}
+
+func evalScope() map[string]interface{} {
+	return map[string]interface{}{
+		"GoroutineID": -1,
+		"Frame":       0,
+	}
+}
+
+func evalCfg() map[string]interface{} {
+	return map[string]interface{}{
+		"FollowPointers":     true,
+		"MaxVariableRecurse": 2,
+		"MaxArrayValues":     100,
+		"MaxStringLen":       200,
+		"MaxStructFields":    -1,
+	}
+}
+
+func evalExpression(expr string) (string, error) {
+	result, err := rpcCall("RPCServer.Eval", map[string]interface{}{
+		"Scope": evalScope(),
+		"Expr":  expr,
+		"Cfg":   evalCfg(),
+	})
+	if err != nil {
+		return "", err
+	}
+	var v struct {
+		Variable dlvVariable `json:"Variable"`
+	}
+	if err := json.Unmarshal(result, &v); err != nil {
+		return "", err
+	}
+	if v.Variable.Unreadable != "" {
+		return "", fmt.Errorf("%s", v.Variable.Unreadable)
+	}
+	return renderVar(v.Variable, 0), nil
+}
+
+func writeEvalResult(value, errorMsg string) {
+	payload := map[string]interface{}{}
+	if errorMsg != "" {
+		payload["error"] = errorMsg
+	} else {
+		payload["value"] = value
+	}
+	data, _ := json.Marshal(payload)
+	os.WriteFile(EVAL_RESULT_FILE, data, 0644)
 }
 
 func createBreakpoints(sourceFile string, lines []int) {
@@ -489,6 +539,16 @@ func main() {
 				createBreakpoints(sourceFile, newBps)
 				vars := collectVars()
 				writeState("paused", line, vars, "")
+				continue
+
+			case "eval":
+				expr, _ := cmdMap["expression"].(string)
+				val, err := evalExpression(expr)
+				if err != nil {
+					writeEvalResult("", err.Error())
+				} else {
+					writeEvalResult(val, "")
+				}
 				continue
 			}
 

--- a/src/routes/api/debug/+server.ts
+++ b/src/routes/api/debug/+server.ts
@@ -49,7 +49,7 @@ export const POST: RequestHandler = async ({ request }) => {
             return json({ status: 'ok' });
         } else if (action === 'eval') {
             if (!variable || typeof variable !== 'string') {
-                return json({ error: 'Missing variable name for eval action' }, { status: 400 });
+                return json({ error: 'Missing expression for eval action' }, { status: 400 });
             }
             const result = await debugEval(jobId, variable.trim());
             return json(result);


### PR DESCRIPTION
## Summary

Adds live expression evaluation while debugging, across all 7 supported languages, plus a **Debug Console** tab in the UI (playground and problem pages) for entering arbitrary expressions at a paused breakpoint.

## Changes

### Expression evaluation (backend)
- New eval protocol: host writes `{"action":"eval","expression":...}` to the debugger's command file; each language driver evaluates in-context at the paused frame and writes the result back (`{"value":...}` or `{"error":...}`)
- Implemented in all languages: Python (`eval` on frame locals), TypeScript (CDP `Debugger.evaluateOnCallFrame`), C++/Rust (quoted GDB MI `-data-evaluate-expression`), Go (dlv `RPCServer.Eval`), Java (hand-written JDI evaluator with overload scoring and simple-name type resolution, e.g. `Math.min(x, y)`, `Integer.MAX_VALUE`), C# (reflection-based evaluator with `System.*` type resolution, e.g. `Math.Max`, `int.MaxValue`)
- `debugEval` fast path returns cached variables without a round-trip; unknown identifiers return an error with available-variables hint

### Debug Console UI
- **ExecutionPanel** (problems): new `Debug Console` tab during debug sessions — `>` input evaluates expressions at the paused frame, history shows results/errors, with Clear + Step/Continue/Stop actions
- **PlaygroundExecutionPanel**: tab bar now has Output + Debug Console tabs with the same REPL
- CLI: `cojudge debug eval <jobId> <expr>` accepts full expressions instead of single variable names

## Verification
- All 7 languages verified via CLI (`x + y` = 7, `x * y - x / y` = 12, string concat, static method calls, unknown-identifier errors)
- Debug Console verified end-to-end in the browser against live Docker debug sessions on both pages
- `npm run build` clean, no new svelte-check errors, e2e suite unchanged from base
