### PR TITLE
fix: WYSIWYG inline code auto-close swallows typed text

### DIFF
--- a/e2e/playground-inline-code.test.ts
+++ b/e2e/playground-inline-code.test.ts
@@ -1,0 +1,162 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function openWysiwyg(page: Page, content: string) {
+  await page.goto('/playground');
+  await page.evaluate((seed) => {
+    localStorage.setItem('user-settings', JSON.stringify({ playgroundPreferredLanguage: 'markdown' }));
+    localStorage.setItem('playground-markdown-mode', 'source');
+    localStorage.setItem('files', JSON.stringify({
+      playground: JSON.stringify([
+        { fileId: 'n1', fileName: 'Notes', language: 'markdown', content: seed, isOpen: true, order: 0, lastUpdated: Date.now() }
+      ])
+    }));
+  }, content);
+  await page.reload();
+  const dismiss = page.getByRole('button', { name: 'Dismiss' });
+  if (await dismiss.isVisible().catch(() => false)) await dismiss.click();
+  await expect(page.locator('.monaco-editor')).toBeVisible();
+  await page.getByRole('button', { name: 'WYSIWYG' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+  await editable.locator('p').first().click();
+  await page.keyboard.press('End');
+  return editable;
+}
+
+function getMarkdownContent(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    const allFiles = JSON.parse(localStorage.getItem('files') || '{}');
+    const files = JSON.parse(allFiles['playground'] || '[]');
+    const entry = files.find((file: { language: string }) => file.language === 'markdown');
+    return entry ? entry.content : null;
+  });
+}
+
+// Chrome's contenteditable stores significant typed spaces as non-breaking
+// spaces, so the markdown round-trip keeps them as \u00A0. Normalize them for
+// assertions; the code-wrap behavior under test is unaffected.
+async function getMarkdownText(page: Page): Promise<string | null> {
+  const markdown = await getMarkdownContent(page);
+  return markdown ? markdown.replace(/\u00A0/g, ' ') : null;
+}
+
+const markerSpan = (editable: ReturnType<Page['locator']>) =>
+  editable.locator('span[style*="var(--color-second-bg)"]');
+
+test('WYSIWYG auto-close: text typed after the closing backtick stays outside the code', async ({ page }) => {
+  const editable = await openWysiwyg(page, 'hello');
+
+  await page.keyboard.type(' `code`extra');
+
+  await expect(markerSpan(editable)).toHaveText('code');
+  await expect(editable.locator('p').first()).toContainText('codeextra');
+  await expect.poll(() => getMarkdownText(page)).toContain('`code`extra');
+
+  // Keep typing: more characters must stay outside the already-closed code
+  await page.keyboard.type('!');
+  await expect.poll(() => getMarkdownText(page)).toContain('`code`extra!');
+});
+
+test('WYSIWYG auto-close: a space and words after the closing backtick stay outside the code', async ({ page }) => {
+  const editable = await openWysiwyg(page, 'hello');
+
+  await page.keyboard.type(' `code` more words');
+
+  await expect(markerSpan(editable)).toHaveText('code');
+  await expect(editable.locator('p').first()).toContainText('code more words');
+  await expect.poll(() => getMarkdownText(page)).toContain('`code` more words');
+});
+
+test('WYSIWYG auto-close: two code pairs on the same line both wrap without nesting', async ({ page }) => {
+  const editable = await openWysiwyg(page, 'hello');
+
+  await page.keyboard.type(' `a` and `b`');
+
+  const spans = markerSpan(editable);
+  await expect(spans).toHaveCount(2);
+  await expect(spans.nth(0)).toHaveText('a');
+  await expect(spans.nth(1)).toHaveText('b');
+  await expect(editable.locator('p').first()).toContainText('a and b');
+  await expect.poll(() => getMarkdownText(page)).toContain('`a` and `b`');
+});
+
+test('WYSIWYG auto-close: wrapping before an existing marker span keeps both spans marked', async ({ page }) => {
+  const editable = await openWysiwyg(page, 'hello');
+
+  // First pair at the end of the line
+  await page.keyboard.type(' `a`');
+  await expect(markerSpan(editable)).toHaveText('a');
+
+  // Jump to the start of the line and type a second pair there: the new span
+  // is inserted BEFORE the existing one, so the marker update must target the
+  // newly inserted span, not the last span in document order.
+  await page.keyboard.press('Home');
+  await page.keyboard.type('x `b`');
+
+  const spans = markerSpan(editable);
+  await expect(spans).toHaveCount(2);
+  await expect(spans.nth(0)).toHaveText('b');
+  await expect(spans.nth(1)).toHaveText('a');
+  await expect.poll(() => getMarkdownText(page)).toContain('x `b`hello `a`');
+});
+
+test('WYSIWYG auto-close: wrapping a second pair right after a previous auto-close works', async ({ page }) => {
+  const editable = await openWysiwyg(page, 'hello');
+
+  await page.keyboard.type(' `a`');
+  await expect(markerSpan(editable)).toHaveText('a');
+
+  // Caret must sit AFTER the first span (not inside it), so the next pair
+  // typed immediately afterwards forms its own code instead of nesting.
+  await page.keyboard.type('`b`');
+
+  const spans = markerSpan(editable);
+  await expect(spans).toHaveCount(2);
+  await expect(spans.nth(0)).toHaveText('a');
+  await expect(spans.nth(1)).toHaveText('b');
+  await expect.poll(() => getMarkdownText(page)).toContain('`a``b`');
+});
+
+test('WYSIWYG auto-close: auto-close works after toolbar-wrapped inline code', async ({ page }) => {
+  const editable = await openWysiwyg(page, 'hello world');
+
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.getByRole('button', { name: 'Inline code' }).click();
+  await expect(editable.locator('code')).toHaveText('hello world');
+
+  // Move the caret past the wrapped code, then type a new pair after it
+  await editable.locator('code').click();
+  await page.keyboard.press('End');
+  await page.keyboard.press('ArrowRight');
+  await page.keyboard.type(' `x`');
+
+  await expect(markerSpan(editable)).toHaveText('x');
+  await expect.poll(() => getMarkdownText(page)).toContain('`hello world`');
+  await expect.poll(() => getMarkdownText(page)).toContain('`x`');
+});
+
+test('WYSIWYG auto-close: undo still cancels the wrap after typing continued', async ({ page }) => {
+  const editable = await openWysiwyg(page, 'hello');
+
+  await page.keyboard.type(' `code` x');
+  await expect(markerSpan(editable)).toHaveText('code');
+  await expect.poll(() => getMarkdownText(page)).toContain('`code` x');
+
+  // The wrap and the characters typed after it are separate undo steps, so
+  // two undos restore the literal backticks (and drop the text after the pair)
+  await page.keyboard.press('ControlOrMeta+z');
+  await page.keyboard.press('ControlOrMeta+z');
+  await expect(markerSpan(editable)).toHaveCount(0);
+  await expect(editable.locator('p').first()).toContainText('`code`');
+});
+
+test('WYSIWYG auto-close: whitespace around the code text stays literal (no wrap)', async ({ page }) => {
+  const editable = await openWysiwyg(page, 'hello');
+
+  await page.keyboard.type(' ` code`');
+
+  await expect(markerSpan(editable)).toHaveCount(0);
+  await expect(editable.locator('p').first()).toContainText('` code`');
+  // The literal backticks are stored escaped so they render as plain text
+  await expect.poll(() => getMarkdownText(page)).toContain('\\` code\\`');
+});

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -2445,6 +2445,14 @@ func main() {
         });
     }
 
+    // True when el is an inline code element: a toolbar-wrapped <code> or a
+    // marker span created by the backtick auto-close.
+    function isInlineCodeElement(el: Element | null): boolean {
+        if (!(el instanceof HTMLElement)) return false;
+        if (el.tagName === 'CODE') return el.parentElement?.tagName !== 'PRE';
+        return (el.getAttribute('style') || '').includes(INLINE_CODE_STYLE_MARKER);
+    }
+
     // When the user types a closing backtick, try to match it with a previous
     // backtick in the same text node and form an inline code element. Runs on
     // the input event, after the backtick has been typed, so a single ctrl+z
@@ -2461,7 +2469,15 @@ func main() {
         const node = range.startContainer;
         if (node.nodeType !== Node.TEXT_NODE || !wysiwygEl.contains(node)) return;
         const parentEl = node.parentElement;
-        if (!parentEl || parentEl.closest('code') || parentEl.closest('pre')) return;
+        if (!parentEl || parentEl.closest('pre')) return;
+        // Never wrap inside an existing inline code element (a toolbar <code>
+        // or a previous marker span): the caret inside one would nest another
+        // span and corrupt the stored markdown.
+        let ancestor: Element | null = parentEl;
+        while (ancestor && ancestor !== wysiwygEl) {
+            if (isInlineCodeElement(ancestor)) return;
+            ancestor = ancestor.parentElement;
+        }
         const text = node.textContent ?? '';
         const offset = range.startOffset;
         if (offset < 1 || text.charAt(offset - 1) !== '`') return;
@@ -2476,13 +2492,46 @@ func main() {
             replaceRange.setEnd(node, offset);
             selection.removeAllRanges();
             selection.addRange(replaceRange);
+            // Track the spans that exist before inserting so the freshly
+            // inserted one can be found reliably: insertHTML can place it
+            // before other spans in the document, so picking the last span
+            // in document order would re-mark an unrelated span and leave the
+            // new one without the marker (breaking the markdown round-trip).
+            const existingSpans = new Set(wysiwygEl.querySelectorAll('span'));
             document.execCommand('insertHTML', false, inlineCodeSpanHtml(codeText));
-            // Rewrite the inserted span's background from the concrete color
-            // (which the sanitizer kept) to the theme-variable marker, so the
-            // code adapts to the active theme and round-trips back to backticks.
-            const inserted = wysiwygEl.querySelectorAll('span');
-            const markerSpan = inserted[inserted.length - 1];
-            if (markerSpan instanceof HTMLElement) markerSpan.style.backgroundColor = INLINE_CODE_STYLE_MARKER;
+            const inserted = Array.from(wysiwygEl.querySelectorAll('span')).find((span) => !existingSpans.has(span));
+            const markerSpan = inserted instanceof HTMLElement ? inserted : null;
+            if (markerSpan) {
+                // Rewrite the inserted span's background from the concrete
+                // color (which the sanitizer kept) to the theme-variable
+                // marker, so the code adapts to the active theme and
+                // round-trips back to backticks.
+                markerSpan.style.backgroundColor = INLINE_CODE_STYLE_MARKER;
+                // Anchor the caret just after the marker span so further
+                // typing continues outside the (already closed) inline code.
+                // Chrome redirects typing at the end of a paragraph after a
+                // trailing inline element back INTO that element (a caret
+                // after the span, in an empty node, or before a ZWSP all
+                // resolve inside the span), so the caret must sit AFTER a
+                // ZWSP in the text node that follows the span. htmlToMarkdown
+                // strips the ZWSP, so it never reaches the stored markdown.
+                let after: Node | null = markerSpan.nextSibling;
+                if (after && after.nodeType === Node.TEXT_NODE && after.textContent !== '') {
+                    // Existing text right after the span: caret at its start.
+                } else {
+                    if (after && after.nodeType === Node.TEXT_NODE) {
+                        after.textContent = '\u200B';
+                    } else {
+                        after = document.createTextNode('\u200B');
+                        markerSpan.after(after);
+                    }
+                }
+                const caret = document.createRange();
+                caret.setStart(after, after.textContent === '\u200B' ? 1 : 0);
+                caret.collapse(true);
+                selection.removeAllRanges();
+                selection.addRange(caret);
+            }
         } finally {
             applyingInlineCode = false;
         }


### PR DESCRIPTION
## Problem

In the WYSIWYG editor, the backtick auto-close for inline code was buggy in two ways:

1. **Typing after the closing backtick went inside the code** — after `` `code` `` auto-closed, characters typed next (`extra`, ` more words`) landed inside the (assumably closed) code span.
2. **Inconsistent wrapping** — wrapping could fail or corrupt the stored markdown in several scenarios.

## Root causes (all in `maybeAutoCloseInlineCode`)

- The caret was left **inside** the inserted marker span. Chrome redirects typing at the end of a paragraph after a trailing inline element back *into* that element — a caret after the span, in an empty text node, or before a ZWSP all resolve inside the span (verified in an isolated contenteditable). The caret must sit **after a ZWSP** in the following text node.
- The marker span was found by picking the **last span in document order**. When the new span is inserted before existing ones, an unrelated span gets re-marked and the new span keeps a concrete (un-marked) color, breaking the markdown round-trip.
- There was no guard against auto-closing **inside** an existing inline code element, so a second pair typed right after the first could nest.

## Changes

- `src/routes/playground/+page.svelte` — anchor the caret after a ZWSP in the trailing text node (`htmlToMarkdown` already strips ZWSPs); locate the inserted span by diffing pre-existing spans; refuse to wrap inside an existing inline code element.
- `e2e/playground-inline-code.test.ts` — 8 new scenarios: typing after the closing backtick, space + words after, two pairs per line, wrapping before an existing marker span, a second pair immediately after the first, toolbar-wrapped code, undo after continued typing, and the whitespace no-wrap case.

## Verification

- 8/8 new e2e tests pass; existing inline-code tests still pass (10/10 combined).
- 109/109 unit tests pass.
- `svelte-check` reports only pre-existing errors unrelated to this change.
- The 3 failing image-paste e2e tests were confirmed failing on `main` before this change (IndexedDB/clipboard environment issue).