### PR TITLE
fix: use whiteboard icon for recent files

### DIFF
--- a/e2e/playground-tabs.test.ts
+++ b/e2e/playground-tabs.test.ts
@@ -52,3 +52,39 @@ test('closing the active tab keeps the next tab\'s own language', async ({ page 
   await expect(page.locator('#language-select')).toHaveValue('python');
   await expect(page.locator('.monaco-editor .view-lines')).toContainText('python file B');
 });
+
+test('recent whiteboards use the whiteboard icon', async ({ page }) => {
+  await page.goto('/playground');
+  await page.evaluate(() => {
+    const now = Date.now();
+    const files = [
+      {
+        fileId: 'whiteboard',
+        fileName: 'Whiteboard',
+        language: 'plaintext',
+        content: '',
+        isActive: false,
+        order: 0,
+        isOpen: false,
+        type: 'whiteboard',
+        lastUpdated: now + 1000
+      },
+      {
+        fileId: 'markdown-file',
+        fileName: 'Notes',
+        language: 'markdown',
+        content: '# Notes',
+        isActive: false,
+        order: 1,
+        isOpen: false,
+        lastUpdated: now
+      }
+    ];
+    localStorage.setItem('files', JSON.stringify({ playground: JSON.stringify(files) }));
+  });
+  await page.reload();
+
+  const card = page.locator('.recent-file-card').filter({ hasText: 'Whiteboard' });
+  await expect(card).toHaveCount(1);
+  await expect(card.locator('svg[viewBox="0 0 24 24"]')).toHaveCount(1);
+});

--- a/src/lib/components/WhiteboardIcon.svelte
+++ b/src/lib/components/WhiteboardIcon.svelte
@@ -21,6 +21,9 @@
 >
 	{#if name === 'menu'}
 		<path d="M4 7h16M4 12h16M4 17h16" />
+	{:else if name === 'whiteboard'}
+		<rect x="3" y="4" width="18" height="16" rx="2" />
+		<path d="m8 15 6-6 2 2-6 6H8v-2Z" />
 	{:else if name === 'lock'}
 		<rect x="5.5" y="10" width="13" height="10" rx="2" />
 		<path d="M8.5 10V7a3.5 3.5 0 0 1 7 0" />

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -5,6 +5,7 @@
     import LanguageIcon from '$lib/components/LanguageIcon.svelte';
     import ShareModal from '$lib/components/ShareModal.svelte';
     import Tooltip from '$lib/components/Tooltip.svelte';
+    import WhiteboardIcon from '$lib/components/WhiteboardIcon.svelte';
     import Whiteboard from '$lib/components/Whiteboard.svelte';
     import { showAlert, showConfirm } from '$lib/dialogs';
     import { consumeForkTransfer } from '$lib/forkTransfer';
@@ -87,6 +88,10 @@ func main() {
 
     function isSpecialTabType(type?: string): type is 'preview' | 'whiteboard' {
         return type === 'preview' || type === 'whiteboard';
+    }
+
+    function isWhiteboardTab(fileId: string): boolean {
+        return tabs.some((tab) => tab.fileId === fileId && tab.type === 'whiteboard');
     }
 
     type ExplorerNode = {
@@ -4899,7 +4904,11 @@ func main() {
                                 </svg>
                                 <div class="search-result-file-info" on:click|stopPropagation={() => activateTab(result.fileId)}>
                                     <span class="file-icon">
-                                        <LanguageIcon language={tabLanguages[result.fileId] ?? result.language} size={17} />
+                                        {#if isWhiteboardTab(result.fileId)}
+                                            <WhiteboardIcon name="whiteboard" size={17} />
+                                        {:else}
+                                            <LanguageIcon language={tabLanguages[result.fileId] ?? result.language} size={17} />
+                                        {/if}
                                     </span>
                                     <span class="file-name">{@html highlightMatch(result.fileName, globalSearchQuery, globalSearchCaseSensitive, globalSearchRegex)}</span>
                                 </div>
@@ -4971,10 +4980,7 @@ func main() {
                                         <LanguageIcon language="markdown" size={17} />
                                     </span>
                                 {:else if t.type === 'whiteboard'}
-                                    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="margin-right:2px;flex-shrink:0;">
-                                        <rect x="3" y="4" width="18" height="16" rx="2"></rect>
-                                        <path d="m8 15 6-6 2 2-6 6H8v-2Z"></path>
-                                    </svg>
+                                    <WhiteboardIcon name="whiteboard" size={12} strokeWidth={2} />
                                 {:else}
                                     <span class="tab-lang-icon">
                                         <LanguageIcon language={tabLanguages[t.fileId] ?? language} size={17} />
@@ -5326,7 +5332,9 @@ func main() {
                                     }}
                                 >
                                     <div class="recent-file-card-header">
-                                        {#if file.type === 'preview'}
+                                        {#if file.type === 'whiteboard'}
+                                            <WhiteboardIcon name="whiteboard" size={17} />
+                                        {:else if file.type === 'preview'}
                                             <LanguageIcon language="markdown" size={17} />
                                         {:else}
                                             <LanguageIcon language={tabLanguages[file.fileId] ?? language} size={17} />
@@ -5446,7 +5454,9 @@ func main() {
                             on:mouseenter={() => selectedIndex = i}
                         >
                             <span class="search-file-info">
-                                {#if file.type === 'preview'}
+                                {#if file.type === 'whiteboard'}
+                                    <WhiteboardIcon name="whiteboard" size={17} />
+                                {:else if file.type === 'preview'}
                                     <LanguageIcon language="markdown" size={17} />
                                 {:else}
                                     <LanguageIcon language={tabLanguages[file.fileId] ?? language} size={17} />
@@ -5485,7 +5495,9 @@ func main() {
                         on:mouseenter={() => mentionSelectedIndex = i}
                     >
                         <span class="search-file-info">
-                            {#if file.type === 'preview'}
+                            {#if file.type === 'whiteboard'}
+                                <WhiteboardIcon name="whiteboard" size={17} />
+                            {:else if file.type === 'preview'}
                                 <LanguageIcon language="markdown" size={17} />
                             {:else}
                                 <LanguageIcon language={tabLanguages[file.fileId] ?? language} size={17} />


### PR DESCRIPTION
## Summary
- render whiteboard tabs with the board-and-pencil icon instead of a language icon
- reuse the whiteboard icon across playground file views
- add an end-to-end regression test for Recent Files

## Verification
- npm test -- --run
- npx playwright test e2e/playground-tabs.test.ts