### PR TITLE
fix: reload active tab after discarding cloud changes

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -55,6 +55,34 @@ test('closing the active WYSIWYG tab keeps the other markdown tab in WYSIWYG mod
   await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Notes');
 });
 
+test('discarding an active WYSIWYG file reloads the restored content', async ({ page }) => {
+  await page.goto('/playground');
+  await page.evaluate(() => {
+    localStorage.setItem('user-settings', JSON.stringify({ playgroundPreferredLanguage: 'markdown' }));
+    localStorage.setItem('playground-markdown-mode', 'wysiwyg');
+    localStorage.setItem('files', JSON.stringify({
+      playground: JSON.stringify([
+        { fileId: 'active-file', fileName: 'Notes', language: 'markdown', content: '# Local version', isOpen: true, order: 0, lastUpdated: Date.now() }
+      ])
+    }));
+  });
+  await page.reload();
+  await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Local version');
+
+  await page.evaluate(() => {
+    const restoredFiles = JSON.stringify({
+      playground: JSON.stringify([
+        { fileId: 'active-file', fileName: 'Notes', language: 'markdown', content: '# Cloud version', isOpen: true, order: 0, lastUpdated: Date.now() }
+      ])
+    });
+    localStorage.setItem('files', restoredFiles);
+    window.dispatchEvent(new StorageEvent('storage', { key: 'files', newValue: restoredFiles }));
+    window.dispatchEvent(new CustomEvent('cojudge:cloud-file-discarded', { detail: { fileId: 'active-file' } }));
+  });
+
+  await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Cloud version');
+});
+
 test('playground markdown editor pastes clipboard images as base64 markdown', async ({ page }) => {
   await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
   await openMarkdownPlayground(page);
@@ -767,5 +795,4 @@ test('WYSIWYG Tab/Shift+Tab on checklists keeps checkboxes intact', async ({ pag
   await expect(editable.locator('li').nth(1).locator('input[type="checkbox"]')).toBeChecked();
   await expect.poll(() => getMarkdownContent(page)).toMatch(/- +\[ \] +one\s*\n- +\[x\] +two/);
 });
-
 

--- a/src/lib/cloudFileChange.ts
+++ b/src/lib/cloudFileChange.ts
@@ -42,6 +42,7 @@ export type FileChange = {
 export const WHITEBOARD_FILE_ID = 'whiteboard';
 export const WHITEBOARD_BOARD_KEY = 'cojudge-whiteboard-v1';
 export const WHITEBOARD_RESTORED_EVENT = 'cojudge:whiteboard-restored';
+export const CLOUD_FILE_DISCARDED_EVENT = 'cojudge:cloud-file-discarded';
 export const SOLUTION_FILE_ID_PREFIX = 'solution:';
 export const TESTCASES_FILE_ID_PREFIX = 'testcases:';
 export const GAME_RESULT_FILE_ID_PREFIX = 'game-result:';

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -59,6 +59,7 @@ import {
 	computeOtherChanges,
 	computeWhiteboardChange,
 	computeWorkspaceChanges,
+	CLOUD_FILE_DISCARDED_EVENT,
 	discardChange,
 	discardFile,
 	OTHER_CHANGE_FILE_ID_PREFIXES,
@@ -1253,6 +1254,10 @@ export async function discardLocalFileChange(fileId: string): Promise<void> {
 		}
 	}
 
+	// The active editor keeps its own in-memory value. Notify the page after the
+	// restored store is complete so it can reload that value before the next
+	// cloud flush compares local progress.
+	window.dispatchEvent(new CustomEvent(CLOUD_FILE_DISCARDED_EVENT, { detail: { fileId } }));
 	await refreshCloudLocalState();
 }
 

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -12,7 +12,7 @@
     import { ensureAuthenticated, initFirebase } from '$lib/firebase';
     import { isDesktopRuntime } from '$lib/firebaseSettings';
     import { cloudSyncState } from '$lib/cloudSync';
-    import { WHITEBOARD_FILE_ID } from '$lib/cloudFileChange';
+    import { CLOUD_FILE_DISCARDED_EVENT, WHITEBOARD_FILE_ID, WORKSPACE_FILE_ID_PREFIX } from '$lib/cloudFileChange';
     import { CLOUD_FLUSH_EVENT, isCloudRestoreInProgress, writeProgressStorageItem } from '$lib/progressBackup';
     import codeStore from '$lib/stores/codeStore.js';
     import fileStore, { isDotFileName, type FileEntry, fileSyncVersion } from '$lib/stores/fileStore.js';
@@ -2177,6 +2177,19 @@ func main() {
         return sourceEntry?.content ?? '';
     }
 
+    function renderWysiwygFromStore() {
+        if (!wysiwygEl || !wysiwygSourceFileId) return;
+        wysiwygEl.innerHTML = renderMarkdownPlain(getActivePreviewSourceContent(), {
+            resolveFileLanguage: (fileId) => getLanguageForTab(fileId)
+        });
+        wrapImageThumbnails(wysiwygEl);
+        wrapCodeBlocksWithCopy(wysiwygEl);
+        ensureFileMentionCarets(wysiwygEl);
+        prepareTaskListCheckboxes(wysiwygEl);
+        ensureTrailingEmptyLine(wysiwygEl);
+        resolvePastedImages(wysiwygEl);
+    }
+
     async function enterPreviewEditMode(force = false) {
         if (!activeTab?.sourceFileId) return;
         if (!force && previewEditMode && wysiwygSourceFileId === activeTab.sourceFileId && wysiwygEl) {
@@ -2186,15 +2199,7 @@ func main() {
         previewEditMode = true;
         await tick();
         if (wysiwygEl) {
-            wysiwygEl.innerHTML = renderMarkdownPlain(getActivePreviewSourceContent(), {
-                resolveFileLanguage: (fileId) => getLanguageForTab(fileId)
-            });
-            wrapImageThumbnails(wysiwygEl);
-            wrapCodeBlocksWithCopy(wysiwygEl);
-            ensureFileMentionCarets(wysiwygEl);
-            prepareTaskListCheckboxes(wysiwygEl);
-            ensureTrailingEmptyLine(wysiwygEl);
-            resolvePastedImages(wysiwygEl);
+            renderWysiwygFromStore();
             wysiwygEl.focus();
         }
     }
@@ -3297,6 +3302,37 @@ func main() {
             }
             return { ...s, [fkey]: JSON.stringify(files) };
         });
+    }
+
+    function handleCloudFileDiscard(event: Event) {
+        const fileId = (event as CustomEvent<{ fileId?: unknown }>).detail?.fileId;
+        if (typeof fileId !== 'string') return;
+
+        const activeSourceId = activeTab?.type === 'preview'
+            ? activeTab.sourceFileId
+            : activeTab?.fileId;
+        const workspaceWasDiscarded = fileId === `${WORKSPACE_FILE_ID_PREFIX}${fileKey()}`;
+        if (!activeSourceId || (fileId !== activeSourceId && !workspaceWasDiscarded)) return;
+
+        if (activeTab?.type === 'preview') {
+            // WYSIWYG content is not driven by a Svelte prop. Replace the DOM
+            // before refreshCloudLocalState emits its next flush event, or the
+            // stale DOM would immediately save the discarded content again.
+            if (previewEditMode && wysiwygSourceFileId === activeTab.sourceFileId) {
+                if (wysiwygDebounce) {
+                    clearTimeout(wysiwygDebounce);
+                    wysiwygDebounce = null;
+                }
+                renderWysiwygFromStore();
+            }
+            return;
+        }
+        if (activeTab?.type === 'whiteboard') return;
+
+        // CodeEditor is also bound to an in-memory value. Suppress its reactive
+        // save while loading the restored entry into the active editor.
+        skipNextSave = true;
+        void loadOrInitFile(language);
     }
 
     // Switch WYSIWYG mode when changing tabs
@@ -4514,11 +4550,13 @@ func main() {
         window.addEventListener('keydown', handleKeyDown);
         window.addEventListener('beforeunload', handleUnload);
         window.addEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
+        window.addEventListener(CLOUD_FILE_DISCARDED_EVENT, handleCloudFileDiscard);
         return () => {
             document.removeEventListener('click', handleDocClick);
             window.removeEventListener('keydown', handleKeyDown);
             window.removeEventListener('beforeunload', handleUnload);
             window.removeEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
+            window.removeEventListener(CLOUD_FILE_DISCARDED_EVENT, handleCloudFileDiscard);
         };
     });
 </script>


### PR DESCRIPTION
## Summary
- Reload the active playground editor after discarding a cloud file change.
- Refresh active WYSIWYG content before the follow-up cloud flush so stale DOM content is not written back.
- Add regression coverage for an active WYSIWYG file.

## Verification
- `npm test -- --run`
- `npm run build`
- `npx playwright test e2e/playground-markdown.test.ts --grep "discarding an active WYSIWYG file"`