### PR TITLE
fix: reduce cloud sync latency

### DIFF
--- a/e2e/cloud-sync.test.ts
+++ b/e2e/cloud-sync.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from '@playwright/test';
 test('Cojudge Cloud is optional and explicitly offline-first', async ({ page }) => {
 	await page.goto('/');
 	await page.getByRole('button', { name: 'Toggle menu' }).click();
-	await page.getByRole('menuitem', { name: /Cojudge Cloud/ }).click();
+	await page.getByRole('menuitem', { name: /Cloud Sync/ }).click();
 
 	const dialog = page.getByRole('dialog', { name: 'Cojudge Cloud' });
 	await expect(dialog).toBeVisible();
@@ -18,7 +18,7 @@ test('cloud status fits in the responsive menu without wrapping labels', async (
 	await page.getByRole('button', { name: 'Toggle menu' }).click();
 
 	const menu = page.getByRole('menu');
-	const cloudItem = page.getByRole('menuitem', { name: /Cojudge Cloud/ });
+	const cloudItem = page.getByRole('menuitem', { name: /Cloud Sync/ });
 	await expect(menu).toBeVisible();
 	const menuBox = await menu.boundingBox();
 	expect(menuBox?.width).toBeGreaterThanOrEqual(220);

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -4,14 +4,15 @@ import { onIdTokenChanged, type Auth, type Unsubscribe, type User } from 'fireba
 import {
 	collection,
 	doc,
-	getDocFromServer,
-	getDocsFromServer,
+	getDoc,
+	getDocs,
+	limit,
 	orderBy,
 	query,
 	runTransaction,
 	serverTimestamp,
 	type Firestore
-} from 'firebase/firestore';
+} from 'firebase/firestore/lite';
 import { initFirebase, signInWithGoogle, signOutFirebase } from '$lib/firebase';
 import {
 	CLOUD_HISTORY_LIMIT,
@@ -648,23 +649,30 @@ function parseHistoryMeta(snapshotId: string, data: Record<string, unknown>): Re
 }
 
 async function readRemoteMeta(db: Firestore, uid: string): Promise<RemoteSnapshotMeta | null> {
-	const result = await getDocFromServer(latestRef(db, uid));
+	const result = await getDoc(latestRef(db, uid));
 	return result.exists() ? parseRemoteMeta(result.data()) : null;
 }
 
 async function readRemoteHistory(
 	db: Firestore,
 	uid: string,
-	current: RemoteSnapshotMeta | null
+	current: RemoteSnapshotMeta | null | Promise<RemoteSnapshotMeta | null>
 ): Promise<RemoteSnapshotMeta[]> {
-	const result = await getDocsFromServer(
-		query(collection(db, 'users', uid, 'snapshots'), orderBy('createdAt', 'desc'))
-	);
+	const [result, resolvedCurrent] = await Promise.all([
+		getDocs(
+			query(
+				collection(db, 'users', uid, 'snapshots'),
+				orderBy('createdAt', 'desc'),
+				limit(CLOUD_HISTORY_LIMIT)
+			)
+		),
+		current
+	]);
 	const history = result.docs
 		.map((snapshot) => parseHistoryMeta(snapshot.id, snapshot.data()))
 		.filter((snapshot): snapshot is RemoteSnapshotMeta => snapshot !== null);
-	if (current && !history.some((snapshot) => snapshot.revisionId === current.revisionId)) {
-		history.unshift(current);
+	if (resolvedCurrent && !history.some((snapshot) => snapshot.revisionId === resolvedCurrent.revisionId)) {
+		history.unshift(resolvedCurrent);
 	}
 	return history.slice(0, CLOUD_HISTORY_LIMIT);
 }
@@ -692,7 +700,7 @@ async function uploadSnapshot(
 	uid: string,
 	local: LocalSnapshot,
 	previous: RemoteSnapshotMeta | null
-): Promise<RemoteSnapshotMeta> {
+): Promise<string> {
 	const { parts, totalBytes } = encodeProgressParts(local.serialized);
 	if (totalBytes > MAX_SNAPSHOT_BYTES || parts.length > MAX_SNAPSHOT_PARTS) {
 		throw new Error('This progress snapshot is too large for Cojudge Cloud.');
@@ -747,12 +755,7 @@ async function uploadSnapshot(
 			updatedAt: serverTimestamp()
 		});
 	});
-
-	const confirmed = await readRemoteMeta(db, uid);
-	if (!confirmed || confirmed.revisionId !== revisionId) {
-		throw new Error('Cojudge Cloud could not confirm the uploaded snapshot.');
-	}
-	return confirmed;
+	return revisionId;
 }
 
 async function downloadSnapshot(
@@ -760,7 +763,7 @@ async function downloadSnapshot(
 	uid: string,
 	meta: RemoteSnapshotMeta
 ): Promise<DownloadedSnapshot> {
-	const result = await getDocsFromServer(query(partsRef(db, uid, meta.snapshotId), orderBy('index')));
+	const result = await getDocs(query(partsRef(db, uid, meta.snapshotId), orderBy('index')));
 	if (result.size !== meta.partCount) throw new Error('Cloud snapshot is incomplete.');
 
 	const parts = result.docs.map((part, index) => {
@@ -900,8 +903,11 @@ async function refreshRemoteState(
 	db: Firestore,
 	uid: string
 ): Promise<{ remote: RemoteSnapshotMeta | null; history: RemoteSnapshotMeta[] }> {
-	const remote = await readRemoteMeta(db, uid);
-	const history = await readRemoteHistory(db, uid, remote);
+	const remotePromise = readRemoteMeta(db, uid);
+	const [remote, history] = await Promise.all([
+		remotePromise,
+		readRemoteHistory(db, uid, remotePromise)
+	]);
 	return { remote, history };
 }
 
@@ -1027,19 +1033,23 @@ async function runSync(mode: SyncMode, context: OperationContext): Promise<void>
 		}
 		if (direction === 'upload') {
 			setCloudProgress('Uploading progress…', 55);
-			const uploaded = await uploadSnapshot(context.db, context.uid, local, remote);
+			const revisionId = await uploadSnapshot(context.db, context.uid, local, remote);
 			if (!isOperationCurrent(context)) return;
+			setCloudProgress('Finalizing…', 85);
+			const updated = await refreshRemoteState(context.db, context.uid);
+			if (!isOperationCurrent(context)) return;
+			const uploaded = updated.remote;
+			if (!uploaded || uploaded.revisionId !== revisionId) {
+				throw new Error('Cojudge Cloud could not confirm the uploaded snapshot.');
+			}
 			writeCloudClone(
 				cloudAccountId(context.projectId, context.uid),
 				uploaded.checksum,
 				local.serialized,
 				uploaded.revisionId
 			);
-			setCloudProgress('Finalizing…', 85);
-			const updatedHistory = await readRemoteHistory(context.db, context.uid, uploaded);
-			if (!isOperationCurrent(context)) return;
 			setCloudProgress('Finalizing…', 95);
-			publishHistory(updatedHistory, uploaded.revisionId);
+			publishHistory(updated.history, uploaded.revisionId);
 			await finalizeCloudRevision(context, uploaded.checksum);
 			return;
 		}
@@ -1324,7 +1334,7 @@ async function runRevisionRestore(
 
 		let selected = cached;
 		if (cached.revisionId !== remote.revisionId) {
-			const result = await getDocFromServer(
+			const result = await getDoc(
 				snapshotRef(context.db, context.uid, cached.snapshotId)
 			);
 			if (!isOperationCurrent(context)) return;

--- a/src/lib/components/CloudSyncModal.svelte
+++ b/src/lib/components/CloudSyncModal.svelte
@@ -405,7 +405,7 @@
         >
             <div class="modal-heading-row">
                 <div>
-                    <span class="modal-eyebrow">Cojudge Cloud</span>
+                    <span id="cloud-settings-title" class="modal-eyebrow">Cojudge Cloud</span>
                 </div>
                 <div class="modal-heading-right">
                     <span class:configured={$cloudSyncState.authStatus === 'signed-in'} class="firebase-status-pill">

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -8,7 +8,7 @@ import {
 	signOut,
 	type Auth
 } from 'firebase/auth';
-import { getFirestore, type Firestore } from 'firebase/firestore';
+import { getFirestore, type Firestore } from 'firebase/firestore/lite';
 import {
 	getFirebaseSettings,
 	isDesktopRuntime,

--- a/src/routes/p/[id]/+page.svelte
+++ b/src/routes/p/[id]/+page.svelte
@@ -4,7 +4,7 @@
     import { initFirebase } from '$lib/firebase';
     import { storeForkTransfer, type ForkTransfer } from '$lib/forkTransfer';
     import userSettingsStorage from '$lib/stores/userSettingsStorage';
-    import { doc, getDoc } from 'firebase/firestore';
+    import { doc, getDoc } from 'firebase/firestore/lite';
     import { onMount } from 'svelte';
 
     let code = '';

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -20,7 +20,7 @@
     import { type ProgrammingLanguage } from '$lib/utils/util.js';
     import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, wrapImageThumbnails, wrapCodeBlocksWithCopy, ensureTrailingEmptyLine, ensureFileMentionCarets, prepareTaskListCheckboxes, isTaskListItem, isEmptyTaskListItem, createTaskCheckbox, ensureTaskCheckbox, ensureTaskItemCaretAnchor, removeTaskCheckbox, inlineCodeSpanHtml, INLINE_CODE_STYLE_MARKER, THUMB_WRAPPER_CLASS, THUMB_DELETE_CLASS, CODE_COPY_WRAPPER_CLASS, resolvePastedImages, isUrlLike, normalizeUrl, linkHtml, parsePlaygroundFileId, playgroundFileHref, fileMentionHtml, FILE_MENTION_CLASS } from '$lib/utils/markdown';
     import { storePastedImage, deletePastedImage, inlinePastedImageLinks } from '$lib/utils/imageStore';
-    import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore';
+    import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore/lite';
     import QRCode from 'qrcode';
     import { browser } from '$app/environment';
     import { onMount, tick, onDestroy } from 'svelte';

--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -19,7 +19,7 @@
     import userSettingsStorage, { type ThemeChoice } from '$lib/stores/userSettingsStorage';
     import userStore from '$lib/stores/userStore';
     import { getDifficultyClass, type ProgrammingLanguage } from '$lib/utils/util.js';
-    import { doc, setDoc } from 'firebase/firestore';
+    import { doc, setDoc } from 'firebase/firestore/lite';
     import { browser } from '$app/environment';
     import { renderMarkdown } from '$lib/utils/markdown';
     import QRCode from 'qrcode';


### PR DESCRIPTION
## Summary
- Switch Firestore cloud/share operations to Firestore Lite direct HTTP transport.
- Parallelize latest metadata and revision-history reads, and limit history queries to five retained revisions.
- Remove redundant upload confirmation round trips while preserving revision confirmation.
- Update Cloud Sync E2E selectors and restore the modal accessible name.

## Verification
- 
> cojudge@0.2.4 test
> vitest --run


 RUN  v1.6.1 /Users/waiyip/Documents/CS/cojudge

 ✓ src/lib/utils/imageStore.test.ts  (7 tests) 1ms
 ✓ src/lib/progressValidation.test.ts  (3 tests) 2ms
 ✓ src/lib/cloudSyncPolicy.test.ts  (9 tests) 2ms
 ✓ src/lib/utils/vimMode.test.ts  (5 tests) 2ms
 ✓ src/lib/server/courseCatalog.test.ts  (3 tests) 6ms
 ✓ src/lib/progressBackup.test.ts  (15 tests) 5ms
 ✓ src/lib/utils/javaUtil.test.ts  (7 tests) 6ms
 ✓ src/lib/cloudFileChange.test.ts  (35 tests) 6ms
 ✓ src/lib/utils/markdown.test.ts  (20 tests) 45ms
 ✓ src/lib/firebaseSettings.test.ts  (2 tests) 2ms
 ✓ src/lib/utils/csharpUtil.test.ts  (1 test) 1ms
 ✓ src/lib/dialogs.test.ts  (2 tests) 1ms

 Test Files  12 passed (12)
      Tests  109 passed (109)
   Start at  16:02:38
   Duration  307ms (transform 305ms, setup 0ms, collect 554ms, tests 79ms, environment 1ms, prepare 557ms)
- 
> cojudge@0.2.4 build
> vite build

vite v7.1.10 building SSR bundle for production...
transforming...
✓ 295 modules transformed.
rendering chunks...
vite v7.1.10 building for production...
transforming...
✓ 1505 modules transformed.
rendering chunks...
computing gzip size...
.svelte-kit/output/client/_app/version.json                                                0.03 kB │ gzip:   0.05 kB
.svelte-kit/output/client/.vite/manifest.json                                             43.65 kB │ gzip:   4.72 kB
.svelte-kit/output/client/_app/immutable/assets/codicon.B_Z2XQ3P.ttf                      90.73 kB
.svelte-kit/output/client/_app/immutable/assets/SaveStatus.BIpUDotB.css                    0.19 kB │ gzip:   0.14 kB
.svelte-kit/output/client/_app/immutable/assets/index.BGWSABQA.css                         0.55 kB │ gzip:   0.25 kB
.svelte-kit/output/client/_app/immutable/assets/v4.CC9TBNL0.css                            1.61 kB │ gzip:   0.52 kB
.svelte-kit/output/client/_app/immutable/assets/CodeEditor.COt_Lj3d.css                    1.74 kB │ gzip:   0.74 kB
.svelte-kit/output/client/_app/immutable/assets/3.D1xdPj9B.css                             2.31 kB │ gzip:   0.78 kB
.svelte-kit/output/client/_app/immutable/assets/GameHistoryPopup.CNYGoT43.css              6.07 kB │ gzip:   1.43 kB
.svelte-kit/output/client/_app/immutable/assets/PlaygroundExecutionPanel.B-l1izn2.css      7.64 kB │ gzip:   1.70 kB
.svelte-kit/output/client/_app/immutable/assets/CloudSyncModal.CbYJuFv_.css               11.65 kB │ gzip:   2.36 kB
.svelte-kit/output/client/_app/immutable/assets/0.DQuT3NrD.css                            13.57 kB │ gzip:   3.37 kB
.svelte-kit/output/client/_app/immutable/assets/4.BpXbojsr.css                            22.01 kB │ gzip:   3.90 kB
.svelte-kit/output/client/_app/immutable/assets/Whiteboard.DbTp8n3V.css                   22.57 kB │ gzip:   4.82 kB
.svelte-kit/output/client/_app/immutable/assets/2.uEz0Ncmv.css                            23.75 kB │ gzip:   4.56 kB
.svelte-kit/output/client/_app/immutable/assets/5.CfYFH13P.css                            26.38 kB │ gzip:   5.05 kB
.svelte-kit/output/client/_app/immutable/assets/editor.CSjFbaO2.css                       71.14 kB │ gzip:  11.76 kB
.svelte-kit/output/client/_app/immutable/assets/editor.kXWXwTYS.css                       74.19 kB │ gzip:  11.78 kB
.svelte-kit/output/client/_app/immutable/chunks/DsnmJJEf.js                                0.07 kB │ gzip:   0.08 kB
.svelte-kit/output/client/_app/immutable/entry/start.bqeucMbS.js                           0.12 kB │ gzip:   0.11 kB
.svelte-kit/output/client/_app/immutable/chunks/BKzfSrAm.js                                0.18 kB │ gzip:   0.16 kB
.svelte-kit/output/client/_app/immutable/chunks/DEyqTK25.js                                0.23 kB │ gzip:   0.16 kB
.svelte-kit/output/client/_app/immutable/chunks/DdmLRnwz.js                                0.31 kB │ gzip:   0.22 kB
.svelte-kit/output/client/_app/immutable/nodes/6.CoZHSqZ2.js                               0.40 kB │ gzip:   0.29 kB
.svelte-kit/output/client/_app/immutable/chunks/BK-Er6B_.js                                0.44 kB │ gzip:   0.31 kB
.svelte-kit/output/client/_app/immutable/chunks/CX4E8Exi.js                                0.45 kB │ gzip:   0.31 kB
.svelte-kit/output/client/_app/immutable/chunks/DI3JwpL2.js                                0.54 kB │ gzip:   0.34 kB
.svelte-kit/output/client/_app/immutable/nodes/1.BMoEg-wG.js                               0.55 kB │ gzip:   0.35 kB
.svelte-kit/output/client/_app/immutable/chunks/DsqdWQfm.js                                0.75 kB │ gzip:   0.40 kB
.svelte-kit/output/client/_app/immutable/chunks/DK2JB5P7.js                                0.83 kB │ gzip:   0.52 kB
.svelte-kit/output/client/_app/immutable/chunks/CLn7w4U2.js                                0.92 kB │ gzip:   0.55 kB
.svelte-kit/output/client/_app/immutable/chunks/CCmIPRYR.js                                1.00 kB │ gzip:   0.52 kB
.svelte-kit/output/client/_app/immutable/chunks/DzS-00a_.js                                1.09 kB │ gzip:   0.46 kB
.svelte-kit/output/client/_app/immutable/chunks/BUTAJqXx.js                                1.15 kB │ gzip:   0.60 kB
.svelte-kit/output/client/_app/immutable/chunks/PPVm8Dsz.js                                1.23 kB │ gzip:   0.71 kB
.svelte-kit/output/client/_app/immutable/chunks/DW-iEeAp.js                                1.35 kB │ gzip:   0.68 kB
.svelte-kit/output/client/_app/immutable/chunks/DIe1whTN.js                                1.40 kB │ gzip:   0.81 kB
.svelte-kit/output/client/_app/immutable/chunks/CY7eBZ1X.js                                1.67 kB │ gzip:   0.67 kB
.svelte-kit/output/client/_app/immutable/chunks/CEtHHOZo.js                                1.86 kB │ gzip:   0.96 kB
.svelte-kit/output/client/_app/immutable/chunks/NuAJNp_2.js                                1.93 kB │ gzip:   0.80 kB
.svelte-kit/output/client/_app/immutable/chunks/BkYORWVg.js                                2.01 kB │ gzip:   0.97 kB
.svelte-kit/output/client/_app/immutable/chunks/C-Z0qGbt.js                                2.06 kB │ gzip:   1.00 kB
.svelte-kit/output/client/_app/immutable/chunks/CNLwL-5S.js                                2.08 kB │ gzip:   0.97 kB
.svelte-kit/output/client/_app/immutable/chunks/CWJXk6_X.js                                2.09 kB │ gzip:   1.01 kB
.svelte-kit/output/client/_app/immutable/chunks/B73Rz2Vi.js                                2.12 kB │ gzip:   0.82 kB
.svelte-kit/output/client/_app/immutable/chunks/DQgI0aMF.js                                2.25 kB │ gzip:   1.06 kB
.svelte-kit/output/client/_app/immutable/chunks/B0f_kfhO.js                                2.37 kB │ gzip:   1.08 kB
.svelte-kit/output/client/_app/immutable/chunks/i5vlodri.js                                2.43 kB │ gzip:   1.11 kB
.svelte-kit/output/client/_app/immutable/chunks/CoFMxtfn.js                                2.51 kB │ gzip:   1.17 kB
.svelte-kit/output/client/_app/immutable/chunks/Cv8Q1oIk.js                                2.65 kB │ gzip:   1.21 kB
.svelte-kit/output/client/_app/immutable/chunks/Bro5TxWW.js                                2.67 kB │ gzip:   1.11 kB
.svelte-kit/output/client/_app/immutable/chunks/CHOz6TMc.js                                2.68 kB │ gzip:   1.07 kB
.svelte-kit/output/client/_app/immutable/chunks/CT69anq1.js                                2.78 kB │ gzip:   1.12 kB
.svelte-kit/output/client/_app/immutable/chunks/D3_omgou.js                                2.80 kB │ gzip:   1.31 kB
.svelte-kit/output/client/_app/immutable/chunks/DZrecYTG.js                                2.83 kB │ gzip:   1.22 kB
.svelte-kit/output/client/_app/immutable/chunks/DmmVatk_.js                                2.90 kB │ gzip:   1.29 kB
.svelte-kit/output/client/_app/immutable/chunks/Do3om1aL.js                                3.01 kB │ gzip:   1.36 kB
.svelte-kit/output/client/_app/immutable/chunks/DSYeAfZJ.js                                3.04 kB │ gzip:   1.24 kB
.svelte-kit/output/client/_app/immutable/chunks/UinWyerT.js                                3.06 kB │ gzip:   1.47 kB
.svelte-kit/output/client/_app/immutable/chunks/Crs71t_0.js                                3.23 kB │ gzip:   1.47 kB
.svelte-kit/output/client/_app/immutable/chunks/DPHFSvlv.js                                3.24 kB │ gzip:   1.55 kB
.svelte-kit/output/client/_app/immutable/chunks/CXPhtye8.js                                3.32 kB │ gzip:   1.35 kB
.svelte-kit/output/client/_app/immutable/chunks/kdqmooAN.js                                3.38 kB │ gzip:   1.43 kB
.svelte-kit/output/client/_app/immutable/chunks/LHZKkiTC.js                                3.44 kB │ gzip:   1.56 kB
.svelte-kit/output/client/_app/immutable/chunks/Db27epIL.js                                3.47 kB │ gzip:   1.56 kB
.svelte-kit/output/client/_app/immutable/chunks/DzEMNnJn.js                                3.52 kB │ gzip:   1.53 kB
.svelte-kit/output/client/_app/immutable/chunks/gvNmO7T7.js                                3.63 kB │ gzip:   1.58 kB
.svelte-kit/output/client/_app/immutable/chunks/aJZxDyGN.js                                3.69 kB │ gzip:   1.63 kB
.svelte-kit/output/client/_app/immutable/chunks/BmAhXvBK.js                                3.80 kB │ gzip:   1.64 kB
.svelte-kit/output/client/_app/immutable/chunks/B_RV1VWk.js                                3.82 kB │ gzip:   1.52 kB
.svelte-kit/output/client/_app/immutable/chunks/Jybkv92b.js                                3.84 kB │ gzip:   1.45 kB
.svelte-kit/output/client/_app/immutable/chunks/BxY8jQel.js                                3.84 kB │ gzip:   1.64 kB
.svelte-kit/output/client/_app/immutable/chunks/hYRv8Pm9.js                                3.98 kB │ gzip:   1.99 kB
.svelte-kit/output/client/_app/immutable/chunks/ClypNyeA.js                                4.03 kB │ gzip:   1.54 kB
.svelte-kit/output/client/_app/immutable/chunks/BWG0_Ndc.js                                4.12 kB │ gzip:   2.08 kB
.svelte-kit/output/client/_app/immutable/chunks/IhVsqIRg.js                                4.14 kB │ gzip:   1.53 kB
.svelte-kit/output/client/_app/immutable/chunks/BdQ2YOlQ.js                                4.14 kB │ gzip:   1.57 kB
.svelte-kit/output/client/_app/immutable/chunks/DKyH9JmC.js                                4.20 kB │ gzip:   1.92 kB
.svelte-kit/output/client/_app/immutable/chunks/DHsFRhEB.js                                4.21 kB │ gzip:   1.81 kB
.svelte-kit/output/client/_app/immutable/chunks/CbwRRPKT.js                                4.27 kB │ gzip:   1.67 kB
.svelte-kit/output/client/_app/immutable/chunks/VlE3CBOS.js                                4.41 kB │ gzip:   1.97 kB
.svelte-kit/output/client/_app/immutable/chunks/DIJ4FZXT.js                                4.45 kB │ gzip:   1.83 kB
.svelte-kit/output/client/_app/immutable/chunks/B6Wl4IzE.js                                4.50 kB │ gzip:   1.80 kB
.svelte-kit/output/client/_app/immutable/chunks/D-slbKV0.js                                4.76 kB │ gzip:   1.54 kB
.svelte-kit/output/client/_app/immutable/chunks/BUo8W1mD.js                                4.77 kB │ gzip:   1.88 kB
.svelte-kit/output/client/_app/immutable/chunks/JyYr1uFz.js                                5.07 kB │ gzip:   1.80 kB
.svelte-kit/output/client/_app/immutable/chunks/Bw1b5y8H.js                                5.12 kB │ gzip:   1.58 kB
.svelte-kit/output/client/_app/immutable/chunks/AyTLGYqW.js                                5.16 kB │ gzip:   2.12 kB
.svelte-kit/output/client/_app/immutable/chunks/Drpmjn0z.js                                5.27 kB │ gzip:   1.54 kB
.svelte-kit/output/client/_app/immutable/chunks/BZwWVyXa.js                                5.42 kB │ gzip:   2.22 kB
.svelte-kit/output/client/_app/immutable/chunks/BBqF43jn.js                                5.55 kB │ gzip:   2.24 kB
.svelte-kit/output/client/_app/immutable/chunks/5y_j5fCc.js                                5.59 kB │ gzip:   2.39 kB
.svelte-kit/output/client/_app/immutable/chunks/BPuwVLEy.js                                5.66 kB │ gzip:   2.32 kB
.svelte-kit/output/client/_app/immutable/entry/app.C2g_8K05.js                             5.66 kB │ gzip:   2.46 kB
.svelte-kit/output/client/_app/immutable/chunks/BpjgtWKM.js                                6.04 kB │ gzip:   2.21 kB
.svelte-kit/output/client/_app/immutable/nodes/0.DI0UxsHO.js                               6.19 kB │ gzip:   2.90 kB
.svelte-kit/output/client/_app/immutable/chunks/B5eNRc1C.js                                6.22 kB │ gzip:   1.68 kB
.svelte-kit/output/client/_app/immutable/chunks/BUar4NT1.js                                6.30 kB │ gzip:   2.90 kB
.svelte-kit/output/client/_app/immutable/nodes/3.DCNNFMjq.js                               6.48 kB │ gzip:   2.48 kB
.svelte-kit/output/client/_app/immutable/chunks/B_SoBQ7d.js                                6.66 kB │ gzip:   1.91 kB
.svelte-kit/output/client/_app/immutable/chunks/DHXmMabG.js                                7.01 kB │ gzip:   2.76 kB
.svelte-kit/output/client/_app/immutable/chunks/CkN4Ak1D.js                                7.03 kB │ gzip:   1.76 kB
.svelte-kit/output/client/_app/immutable/chunks/DLmSFmGV.js                                7.40 kB │ gzip:   2.81 kB
.svelte-kit/output/client/_app/immutable/chunks/Dk9bQ0kk.js                                7.56 kB │ gzip:   2.25 kB
.svelte-kit/output/client/_app/immutable/chunks/Dm0LjZUV.js                                7.59 kB │ gzip:   2.90 kB
.svelte-kit/output/client/_app/immutable/chunks/CA6oPEf2.js                                7.65 kB │ gzip:   2.39 kB
.svelte-kit/output/client/_app/immutable/chunks/C54nbXh4.js                                7.85 kB │ gzip:   2.91 kB
.svelte-kit/output/client/_app/immutable/chunks/DhU902_m.js                                8.10 kB │ gzip:   2.60 kB
.svelte-kit/output/client/_app/immutable/chunks/DuRtQTDq.js                                8.27 kB │ gzip:   2.23 kB
.svelte-kit/output/client/_app/immutable/chunks/PEYlOpmK.js                                8.50 kB │ gzip:   3.29 kB
.svelte-kit/output/client/_app/immutable/chunks/ChM_C8BL.js                                8.75 kB │ gzip:   2.74 kB
.svelte-kit/output/client/_app/immutable/chunks/DO6QdQ7w.js                                9.03 kB │ gzip:   2.44 kB
.svelte-kit/output/client/_app/immutable/chunks/e6c1FGlM.js                                9.25 kB │ gzip:   4.02 kB
.svelte-kit/output/client/_app/immutable/chunks/1OFUINyw.js                                9.29 kB │ gzip:   2.23 kB
.svelte-kit/output/client/_app/immutable/chunks/DPtOx95P.js                                9.89 kB │ gzip:   3.77 kB
.svelte-kit/output/client/_app/immutable/chunks/ChVwwZJh.js                               10.50 kB │ gzip:   2.69 kB
.svelte-kit/output/client/_app/immutable/chunks/V7kKEQQR.js                               10.54 kB │ gzip:   4.01 kB
.svelte-kit/output/client/_app/immutable/chunks/DL88RyNK.js                               11.52 kB │ gzip:   4.23 kB
.svelte-kit/output/client/_app/immutable/chunks/BA_Dla6X.js                               12.05 kB │ gzip:   4.49 kB
.svelte-kit/output/client/_app/immutable/chunks/qYyj0wfh.js                               13.71 kB │ gzip:   4.66 kB
.svelte-kit/output/client/_app/immutable/chunks/CLmtn2Jv.js                               14.41 kB │ gzip:   5.47 kB
.svelte-kit/output/client/_app/immutable/chunks/3PcAh47f.js                               16.35 kB │ gzip:   4.30 kB
.svelte-kit/output/client/_app/immutable/chunks/B9suJjOM.js                               17.19 kB │ gzip:   5.01 kB
.svelte-kit/output/client/_app/immutable/chunks/Dq_bim5W.js                               18.07 kB │ gzip:   4.15 kB
.svelte-kit/output/client/_app/immutable/chunks/CVYD1GVc.js                               18.84 kB │ gzip:   4.62 kB
.svelte-kit/output/client/_app/immutable/chunks/Ca8xljEQ.js                               19.69 kB │ gzip:   6.90 kB
.svelte-kit/output/client/_app/immutable/chunks/DL7rA9UT.js                               23.89 kB │ gzip:   6.84 kB
.svelte-kit/output/client/_app/immutable/chunks/DNTXe89k.js                               24.36 kB │ gzip:   7.59 kB
.svelte-kit/output/client/_app/immutable/chunks/CeGt3syP.js                               26.01 kB │ gzip:  10.36 kB
.svelte-kit/output/client/_app/immutable/chunks/D6cQIC_s.js                               29.60 kB │ gzip:  11.67 kB
.svelte-kit/output/client/_app/immutable/chunks/BW1PM89l.js                               33.40 kB │ gzip:   9.15 kB
.svelte-kit/output/client/_app/immutable/chunks/CPOL3mk6.js                               33.95 kB │ gzip:   9.26 kB
.svelte-kit/output/client/_app/immutable/nodes/2.3WPIFwPI.js                              37.89 kB │ gzip:  11.79 kB
.svelte-kit/output/client/_app/immutable/chunks/37FCFWuS.js                               39.86 kB │ gzip:  12.37 kB
.svelte-kit/output/client/_app/immutable/chunks/D5HCgHq5.js                               42.81 kB │ gzip:  12.47 kB
.svelte-kit/output/client/_app/immutable/chunks/lEp4Z9aF.js                               42.94 kB │ gzip:  13.18 kB
.svelte-kit/output/client/_app/immutable/chunks/B-mLN6fv.js                               57.75 kB │ gzip:  21.07 kB
.svelte-kit/output/client/_app/immutable/chunks/BPcXshlo.js                               70.47 kB │ gzip:  22.87 kB
.svelte-kit/output/client/_app/immutable/nodes/5.Cvjbvb2U.js                              92.35 kB │ gzip:  28.94 kB
.svelte-kit/output/client/_app/immutable/nodes/4.u2mu4c_s.js                             122.36 kB │ gzip:  33.28 kB
.svelte-kit/output/client/_app/immutable/chunks/COYumYui.js                              201.70 kB │ gzip:  63.64 kB
.svelte-kit/output/client/_app/immutable/chunks/D5fuff0k.js                              303.17 kB │ gzip:  67.48 kB
.svelte-kit/output/client/_app/immutable/chunks/CXJQj-Jy.js                            1,110.27 kB │ gzip: 283.70 kB
.svelte-kit/output/client/_app/immutable/chunks/BkNpNc-h.js                            2,568.49 kB │ gzip: 670.31 kB
✓ built in 7.68s
.svelte-kit/output/server/.vite/manifest.json                                                   12.94 kB
.svelte-kit/output/server/_app/immutable/assets/markdown.BKLQQVas.css                            0.17 kB
.svelte-kit/output/server/_app/immutable/assets/Tooltip.BGWSABQA.css                             0.55 kB
.svelte-kit/output/server/_app/immutable/assets/_page.D1xdPj9B.css                               2.31 kB
.svelte-kit/output/server/_app/immutable/assets/CloudSyncModal.CM3hpWQY.css                     11.63 kB
.svelte-kit/output/server/_app/immutable/assets/_layout.CBtiHy5M.css                            13.48 kB
.svelte-kit/output/server/_app/immutable/assets/Whiteboard.D6ESqKE5.css                         22.43 kB
.svelte-kit/output/server/_app/immutable/assets/_page.B-3bR3Y2.css                              23.60 kB
.svelte-kit/output/server/_app/immutable/assets/_page._8f-PRS3.css                              23.70 kB
.svelte-kit/output/server/_app/immutable/assets/_page.LZ7XDHmo.css                              29.50 kB
.svelte-kit/output/server/chunks/dialogs.js                                                      0.11 kB
.svelte-kit/output/server/entries/pages/_layout.server.ts.js                                     0.18 kB
.svelte-kit/output/server/chunks/index-server.js                                                 0.20 kB
.svelte-kit/output/server/chunks/shared-server.js                                                0.28 kB
.svelte-kit/output/server/chunks/GameHistoryPopup.svelte_svelte_type_style_lang.js               0.32 kB
.svelte-kit/output/server/internal.js                                                            0.38 kB
.svelte-kit/output/server/chunks/state.svelte.js                                                 0.38 kB
.svelte-kit/output/server/chunks/userSettingsStorage.js                                          0.39 kB
.svelte-kit/output/server/entries/pages/whiteboard/_page.svelte.js                               0.52 kB
.svelte-kit/output/server/chunks/environment.js                                                  0.62 kB
.svelte-kit/output/server/chunks/Tooltip.js                                                      0.74 kB
.svelte-kit/output/server/entries/endpoints/api/problems/_slug_/asset/_...path_/_server.ts.js    0.84 kB
.svelte-kit/output/server/entries/endpoints/api/reveal-file/_server.ts.js                        0.84 kB
.svelte-kit/output/server/entries/endpoints/api/export/_server.ts.js                             1.00 kB
.svelte-kit/output/server/entries/fallbacks/error.svelte.js                                      1.10 kB
.svelte-kit/output/server/entries/endpoints/api/export-file/_server.ts.js                        1.12 kB
.svelte-kit/output/server/chunks/utils2.js                                                       1.15 kB
.svelte-kit/output/server/chunks/utils.js                                                        1.19 kB
.svelte-kit/output/server/chunks/shared.js                                                       1.35 kB
.svelte-kit/output/server/entries/pages/problems/_slug_/_page.server.ts.js                       1.56 kB
.svelte-kit/output/server/chunks/index.js                                                        1.58 kB
.svelte-kit/output/server/entries/endpoints/api/image/pull/_server.ts.js                         1.63 kB
.svelte-kit/output/server/entries/pages/p/_id_/_page.svelte.js                                   1.79 kB
.svelte-kit/output/server/entries/endpoints/api/image/status/_server.ts.js                       2.04 kB
.svelte-kit/output/server/chunks/util.js                                                         2.12 kB
.svelte-kit/output/server/entries/endpoints/api/debug/_server.ts.js                              2.28 kB
.svelte-kit/output/server/chunks/imagePuller.js                                                  2.76 kB
.svelte-kit/output/server/chunks/hooks.server.js                                                 3.45 kB
.svelte-kit/output/server/entries/pages/_page.server.ts.js                                       4.75 kB
.svelte-kit/output/server/chunks/containerSession.js                                             5.42 kB
.svelte-kit/output/server/chunks/exports.js                                                      5.52 kB
.svelte-kit/output/server/entries/pages/_layout.svelte.js                                        7.20 kB
.svelte-kit/output/server/entries/endpoints/api/run/_server.ts.js                                8.11 kB
.svelte-kit/output/server/entries/endpoints/api/submit/_server.ts.js                             9.98 kB
.svelte-kit/output/server/chunks/TypeScriptRunner.js                                            13.35 kB
.svelte-kit/output/server/chunks/markdown.js                                                    14.16 kB
.svelte-kit/output/server/entries/pages/_page.svelte.js                                         17.58 kB
.svelte-kit/output/server/entries/endpoints/api/playground/run/_server.ts.js                    20.47 kB
.svelte-kit/output/server/chunks/CloudSyncModal.js                                              23.75 kB
.svelte-kit/output/server/chunks/index2.js                                                      24.30 kB
.svelte-kit/output/server/remote-entry.js                                                       27.62 kB
.svelte-kit/output/server/chunks/GoRunner.js                                                    28.04 kB
.svelte-kit/output/server/chunks/internal.js                                                    28.68 kB
.svelte-kit/output/server/chunks/context.js                                                     49.72 kB
.svelte-kit/output/server/entries/pages/problems/_slug_/_page.svelte.js                         50.10 kB
.svelte-kit/output/server/chunks/Whiteboard.js                                                  53.53 kB
.svelte-kit/output/server/entries/pages/playground/_page.svelte.js                              90.31 kB
.svelte-kit/output/server/index.js                                                             126.44 kB
.svelte-kit/output/server/chunks/tsUtil.js                                                     145.05 kB
.svelte-kit/output/server/chunks/DebugRunner.js                                                172.13 kB
✓ built in 9.40s

Run npm run preview to preview your production build locally.

> Using @sveltejs/adapter-node
  ✔ done
- 
> cojudge@0.2.4 test:e2e
> playwright test e2e/cloud-sync.test.ts


Running 4 tests using 1 worker

  ✓  1 e2e/cloud-sync.test.ts:2:1 › Cojudge Cloud is optional and explicitly offline-first (295ms)
  ✓  2 e2e/cloud-sync.test.ts:20:1 › cloud status fits in the responsive menu without wrapping labels (128ms)
  ✓  3 e2e/cloud-sync.test.ts:40:1 › progress exports omit Firebase auth and cloud bookkeeping (171ms)
  ✓  4 e2e/cloud-sync.test.ts:75:1 › progress imports cannot replace the Firebase project (131ms)

  4 passed (15.1s)
- 
> cojudge@0.2.4 check
> svelte-kit sync && svelte-check --tsconfig ./tsconfig.json

Loading svelte-check in workspace: /Users/waiyip/Documents/CS/cojudge
Getting Svelte diagnostics...

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:47:11
Error: Property 'style' does not exist on type 'Element'. 
function applyCollapsedState(wrapper: HTMLElement, preEl: Element, expandLabel: Element | null, collapseBtn: Element) {
    preEl.style.display = 'none';
    wrapper.classList.add('collapsed');

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:52:34
Error: Property 'style' does not exist on type 'Element'. 
    collapseBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>';
    if (expandLabel) expandLabel.style.display = '';
}

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:56:11
Error: Property 'style' does not exist on type 'Element'. 
function applyExpandedState(wrapper: HTMLElement, preEl: Element, expandLabel: Element | null, collapseBtn: Element) {
    preEl.style.display = '';
    wrapper.classList.remove('collapsed');

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:61:34
Error: Property 'style' does not exist on type 'Element'. 
    collapseBtn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="18 15 12 9 6 15"></polyline></svg>';
    if (expandLabel) expandLabel.style.display = 'none';
}

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:522:55
Error: Parameter 'match' implicitly has an 'any' type. 
            const regex = /\/\/(.*)|#(.*)|"(.*?)"|'(.*?)'|\b(int|float|double|char|void|if|else|while|for|return|class|public|private|protected|static|new|import|from|def|fn|let|mut|using|namespace|include|cout|endl|String|args|console|log|var|const|type|interface|bool|boolean|true|false|self|Self|None|nil|range|in|is|yield|async|await|try|except|catch|finally|throw|raise|break|continue|case|switch|default|package|func|go|chan|defer|struct|interface|type|map|select|pub|use|mod|trait|impl|enum|where|match)\b/g;
            escapedText = escapedText.replace(regex, (match, c1, c2, s1, s2, k) => {
                if (c1) return `<span class="hl-comment">//${c1}</span>`;

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:522:62
Error: Parameter 'c1' implicitly has an 'any' type. 
            const regex = /\/\/(.*)|#(.*)|"(.*?)"|'(.*?)'|\b(int|float|double|char|void|if|else|while|for|return|class|public|private|protected|static|new|import|from|def|fn|let|mut|using|namespace|include|cout|endl|String|args|console|log|var|const|type|interface|bool|boolean|true|false|self|Self|None|nil|range|in|is|yield|async|await|try|except|catch|finally|throw|raise|break|continue|case|switch|default|package|func|go|chan|defer|struct|interface|type|map|select|pub|use|mod|trait|impl|enum|where|match)\b/g;
            escapedText = escapedText.replace(regex, (match, c1, c2, s1, s2, k) => {
                if (c1) return `<span class="hl-comment">//${c1}</span>`;

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:522:66
Error: Parameter 'c2' implicitly has an 'any' type. 
            const regex = /\/\/(.*)|#(.*)|"(.*?)"|'(.*?)'|\b(int|float|double|char|void|if|else|while|for|return|class|public|private|protected|static|new|import|from|def|fn|let|mut|using|namespace|include|cout|endl|String|args|console|log|var|const|type|interface|bool|boolean|true|false|self|Self|None|nil|range|in|is|yield|async|await|try|except|catch|finally|throw|raise|break|continue|case|switch|default|package|func|go|chan|defer|struct|interface|type|map|select|pub|use|mod|trait|impl|enum|where|match)\b/g;
            escapedText = escapedText.replace(regex, (match, c1, c2, s1, s2, k) => {
                if (c1) return `<span class="hl-comment">//${c1}</span>`;

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:522:70
Error: Parameter 's1' implicitly has an 'any' type. 
            const regex = /\/\/(.*)|#(.*)|"(.*?)"|'(.*?)'|\b(int|float|double|char|void|if|else|while|for|return|class|public|private|protected|static|new|import|from|def|fn|let|mut|using|namespace|include|cout|endl|String|args|console|log|var|const|type|interface|bool|boolean|true|false|self|Self|None|nil|range|in|is|yield|async|await|try|except|catch|finally|throw|raise|break|continue|case|switch|default|package|func|go|chan|defer|struct|interface|type|map|select|pub|use|mod|trait|impl|enum|where|match)\b/g;
            escapedText = escapedText.replace(regex, (match, c1, c2, s1, s2, k) => {
                if (c1) return `<span class="hl-comment">//${c1}</span>`;

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:522:74
Error: Parameter 's2' implicitly has an 'any' type. 
            const regex = /\/\/(.*)|#(.*)|"(.*?)"|'(.*?)'|\b(int|float|double|char|void|if|else|while|for|return|class|public|private|protected|static|new|import|from|def|fn|let|mut|using|namespace|include|cout|endl|String|args|console|log|var|const|type|interface|bool|boolean|true|false|self|Self|None|nil|range|in|is|yield|async|await|try|except|catch|finally|throw|raise|break|continue|case|switch|default|package|func|go|chan|defer|struct|interface|type|map|select|pub|use|mod|trait|impl|enum|where|match)\b/g;
            escapedText = escapedText.replace(regex, (match, c1, c2, s1, s2, k) => {
                if (c1) return `<span class="hl-comment">//${c1}</span>`;

/Users/waiyip/Documents/CS/cojudge/src/lib/utils/markdown.ts:522:78
Error: Parameter 'k' implicitly has an 'any' type. 
            const regex = /\/\/(.*)|#(.*)|"(.*?)"|'(.*?)'|\b(int|float|double|char|void|if|else|while|for|return|class|public|private|protected|static|new|import|from|def|fn|let|mut|using|namespace|include|cout|endl|String|args|console|log|var|const|type|interface|bool|boolean|true|false|self|Self|None|nil|range|in|is|yield|async|await|try|except|catch|finally|throw|raise|break|continue|case|switch|default|package|func|go|chan|defer|struct|interface|type|map|select|pub|use|mod|trait|impl|enum|where|match)\b/g;
            escapedText = escapedText.replace(regex, (match, c1, c2, s1, s2, k) => {
                if (c1) return `<span class="hl-comment">//${c1}</span>`;

/Users/waiyip/Documents/CS/cojudge/src/routes/api/debug/+server.ts:22:14
Error: Type '({ request }: RequestEvent<RouteParams, "/api/debug">) => Promise<Response | undefined>' is not assignable to type 'RequestHandler'.
  Type 'Promise<Response | undefined>' is not assignable to type 'MaybePromise<Response>'.
    Type 'Promise<Response | undefined>' is not assignable to type 'Promise<Response>'.
      Type 'Response | undefined' is not assignable to type 'Response'.
        Type 'undefined' is not assignable to type 'Response'. 

export const POST: RequestHandler = async ({ request }) => {
    const { jobId, action, breakpoints, variable } = await request.json();

/Users/waiyip/Documents/CS/cojudge/src/routes/api/problems/[slug]/asset/[...path]/+server.ts:27:29
Error: Argument of type 'Buffer<ArrayBufferLike>' is not assignable to parameter of type 'BodyInit | null | undefined'.
  Type 'Buffer<ArrayBufferLike>' is missing the following properties from type 'URLSearchParams': size, append, delete, get, and 2 more. 
        const mimeType = MIME_TYPES[ext] || 'application/octet-stream';
        return new Response(data, {
            headers: { 'Content-Type': mimeType },

/Users/waiyip/Documents/CS/cojudge/src/routes/api/submit/+server.ts:226:37
Error: Property 'message' does not exist on type '{}'. 
                    isCorrect: false,
                    logs: String(e?.message || e)
                }));

/Users/waiyip/Documents/CS/cojudge/src/lib/components/CodeEditor.svelte:224:43
Error: 'editor' is possibly 'null'. (ts)
                    || e.target.type === monaco.editor.MouseTargetType.GUTTER_LINE_NUMBERS) {
                    const prevSelection = editor.getSelection();
                    const line = e.target.position.lineNumber;

/Users/waiyip/Documents/CS/cojudge/src/lib/components/ExecutionPanel.svelte:2244:5
Warn: Do not use empty rulesets (css)
    }
    .status {
    }

/Users/waiyip/Documents/CS/cojudge/src/lib/components/PlaygroundExecutionPanel.svelte:1305:5
Warn: Unused CSS selector ".btn-debug.active"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .btn-debug.active {
        background-color: rgba(229, 62, 62, 0.15);

/Users/waiyip/Documents/CS/cojudge/src/lib/components/Whiteboard.svelte:670:47
Error: Argument of type 'number | undefined' is not assignable to parameter of type 'number'.
  Type 'undefined' is not assignable to type 'number'. (ts)
			{ x: bounds.x, y: bounds.y + bounds.height }
		].map((point) => rotatePoint(point, center, element.rotation));
		const left = Math.min(...corners.map((point) => point.x));

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1620:5
Warn: Unused CSS selector ".cloud-account img"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-account img,
    .cloud-avatar {

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1627:5
Warn: Unused CSS selector ".cloud-account img"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-account img {
        object-fit: cover;

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1637:5
Warn: Unused CSS selector ".cloud-account div"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-account div,
    .cloud-sync-summary div {

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1638:5
Warn: Unused CSS selector ".cloud-sync-summary div"
https://svelte.dev/e/css_unused_selector (svelte)
    .cloud-account div,
    .cloud-sync-summary div {
        display: grid;

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1643:5
Warn: Unused CSS selector ".cloud-account strong"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-account strong,
    .cloud-sync-summary strong {

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1644:5
Warn: Unused CSS selector ".cloud-sync-summary strong"
https://svelte.dev/e/css_unused_selector (svelte)
    .cloud-account strong,
    .cloud-sync-summary strong {
        overflow: hidden;

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1651:5
Warn: Unused CSS selector ".cloud-account div > span"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-account div > span,
    .cloud-sync-summary div > span {

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1652:5
Warn: Unused CSS selector ".cloud-sync-summary div > span"
https://svelte.dev/e/css_unused_selector (svelte)
    .cloud-account div > span,
    .cloud-sync-summary div > span {
        overflow: hidden;

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1735:5
Warn: Unused CSS selector ".cloud-file-changes-heading strong"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-file-changes-heading strong {
        color: var(--color-text);

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1817:5
Warn: Unused CSS selector ".cloud-file-diff-heading[aria-expanded='true'] .diff-caret"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-file-diff-heading[aria-expanded='true'] .diff-caret {
        transform: rotate(0deg);

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1820:5
Warn: Unused CSS selector ".cloud-file-diff-heading[aria-expanded='false'] .diff-caret"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-file-diff-heading[aria-expanded='false'] .diff-caret {
        transform: rotate(-90deg);

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1845:5
Warn: Unused CSS selector ".cloud-file-blob-note span"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-file-blob-note span {
        overflow: hidden;

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1857:5
Warn: Unused CSS selector ".diff-line code"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .diff-line code {
        font: inherit;

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1885:5
Warn: Unused CSS selector ".home-modal-card .cloud-offline-note"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .home-modal-card .cloud-offline-note {
        margin-top: 1rem;

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1909:5
Warn: Unused CSS selector ".cloud-history-heading strong"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-history-heading strong {
        color: var(--color-text);

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1913:5
Warn: Unused CSS selector ".cloud-history-row strong"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-history-row strong {
        color: var(--color-text);

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1918:5
Warn: Unused CSS selector ".cloud-history-heading span"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .cloud-history-heading span,
    .cloud-history-details > span {

/Users/waiyip/Documents/CS/cojudge/src/routes/+page.svelte:1919:5
Warn: Unused CSS selector ".cloud-history-details > span"
https://svelte.dev/e/css_unused_selector (svelte)
    .cloud-history-heading span,
    .cloud-history-details > span {
        color: var(--color-text-secondary);

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:4764:25
Warn: Elements with the ARIA role "treeitem" must have the following attributes defined: "aria-selected"
https://svelte.dev/e/a11y_role_has_required_aria_props (svelte)
                        on:contextmenu={(e) => openExplorerContextMenu(e, t)}
                        role="treeitem"
                        aria-expanded={t.kind === 'folder' ? isFolderExpanded(t.fileId) : undefined}

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:4884:13
Warn: Elements with the 'menu' interactive role must have a tabindex value
https://svelte.dev/e/a11y_interactive_supports_focus (svelte)
        {#if contextMenu}
            <div
                class="explorer-context-menu"
                role="menu"
                bind:this={contextMenuEl}
                style="left: {contextMenu.x}px; top: {contextMenu.y}px;"
                on:contextmenu|preventDefault
            >
                <button class="add-menu-item" role="menuitem" on:click={contextCreateFile}>New File</button>
                <button class="add-menu-item" role="menuitem" on:click={contextCreateFolder}>New Folder</button>
            </div>
        {/if}

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:6142:5
Warn: Unused CSS selector ".markdown-preview img"
https://svelte.dev/e/css_unused_selector (svelte)

    .markdown-preview img {
        max-width: 100%;

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:6147:5
Warn: Unused CSS selector ".markdown-preview a"
https://svelte.dev/e/css_unused_selector (svelte)

    .markdown-preview a {
        color: var(--color-highlight);

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:6152:5
Warn: Unused CSS selector ".markdown-preview a:hover"
https://svelte.dev/e/css_unused_selector (svelte)

    .markdown-preview a:hover {
        text-decoration: underline;

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:6236:5
Warn: Unused CSS selector ".icon-button.active"
https://svelte.dev/e/css_unused_selector (svelte)

    .icon-button.active {
        color: var(--color-highlight);

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:6519:5
Warn: Unused CSS selector ".file-group-header"
https://svelte.dev/e/css_unused_selector (svelte)

    .file-group-header {
        padding: 4px var(--spacing-2);

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:6528:5
Warn: Unused CSS selector ".file-group:first-child .file-group-header"
https://svelte.dev/e/css_unused_selector (svelte)
    }
    .file-group:first-child .file-group-header {
        margin-top: 0;

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:24:24
Error: Could not find a declaration file for module 'qrcode'. '/Users/waiyip/Documents/CS/cojudge/node_modules/qrcode/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/qrcode` if it exists or add a new declaration (.d.ts) file containing `declare module 'qrcode';` (ts)
    import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore/lite';
    import QRCode from 'qrcode';
    import { browser } from '$app/environment';

/Users/waiyip/Documents/CS/cojudge/src/routes/playground/+page.svelte:3193:27
Error: 'nextNode' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer. (ts)
                while (node) {
                    const nextNode = node.nextSibling;
                    newLi.appendChild(node);

/Users/waiyip/Documents/CS/cojudge/src/routes/problems/[slug]/+page.svelte:25:24
Error: Could not find a declaration file for module 'qrcode'. '/Users/waiyip/Documents/CS/cojudge/node_modules/qrcode/lib/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/qrcode` if it exists or add a new declaration (.d.ts) file containing `declare module 'qrcode';` (ts)
    import { renderMarkdown } from '$lib/utils/markdown';
    import QRCode from 'qrcode';
    import { onMount, tick } from 'svelte';

====================================
svelte-check found 18 errors and 28 warnings in 11 files still reports the repository's existing unrelated diagnostics.