### PR TITLE
feat: add tab context menu

### DIFF
--- a/e2e/tab-context-menu.test.ts
+++ b/e2e/tab-context-menu.test.ts
@@ -1,0 +1,125 @@
+import { expect, test, type Page } from '@playwright/test';
+
+function tabsFor(key: string) {
+  const now = Date.now();
+  return [
+    {
+      fileId: `${key}-a`,
+      fileName: 'Left',
+      language: 'java',
+      lastLanguage: 'java',
+      content: '// left',
+      viewState: null,
+      isActive: false,
+      order: 0,
+      isOpen: true,
+      lastUpdated: now
+    },
+    {
+      fileId: `${key}-b`,
+      fileName: 'Middle',
+      language: 'java',
+      lastLanguage: 'java',
+      content: '// middle',
+      viewState: null,
+      isActive: false,
+      order: 1,
+      isOpen: true,
+      lastUpdated: now + 1
+    },
+    {
+      fileId: `${key}-c`,
+      fileName: 'Right',
+      language: 'java',
+      lastLanguage: 'java',
+      content: '// right',
+      viewState: null,
+      isActive: false,
+      order: 2,
+      isOpen: true,
+      lastUpdated: now + 2
+    },
+    {
+      fileId: `${key}-d`,
+      fileName: 'Far Right',
+      language: 'java',
+      lastLanguage: 'java',
+      content: '// far right',
+      viewState: null,
+      isActive: false,
+      order: 3,
+      isOpen: true,
+      lastUpdated: now + 3
+    }
+  ];
+}
+
+async function seedFiles(page: Page, key: string) {
+  await page.addInitScript(({ key, files }) => {
+    localStorage.setItem('files', JSON.stringify({ [key]: JSON.stringify(files) }));
+  }, { key, files: tabsFor(key) });
+  await page.reload();
+}
+
+function tab(page: Page, name: string) {
+  return page.locator('.editor-header .tab').filter({ hasText: name });
+}
+
+test('playground tab context menu closes tabs on either side or all other tabs', async ({ page }) => {
+  await page.goto('/playground');
+  await seedFiles(page, 'playground');
+
+  const menu = page.getByRole('menu', { name: 'Tab actions' });
+  const menuItems = menu.getByRole('menuitem');
+  await tab(page, 'Middle').click({ button: 'right' });
+  await expect(menuItems).toHaveText(['Close', 'Close Left', 'Close Right', 'Close Others', 'Rename']);
+
+  await menu.getByRole('menuitem', { name: 'Close Left' }).click();
+  await expect(page.locator('.editor-header .tab')).toHaveCount(3);
+  await expect(tab(page, 'Left')).toHaveCount(0);
+
+  await tab(page, 'Middle').click({ button: 'right' });
+  await menu.getByRole('menuitem', { name: 'Close Right' }).click();
+  await expect(page.locator('.editor-header .tab')).toHaveCount(1);
+  await expect(tab(page, 'Middle')).toHaveCount(1);
+
+  await seedFiles(page, 'playground');
+  await tab(page, 'Middle').click({ button: 'right' });
+  await menu.getByRole('menuitem', { name: 'Close Others' }).click();
+  await expect(page.locator('.editor-header .tab')).toHaveCount(1);
+  await expect(tab(page, 'Middle')).toHaveCount(1);
+
+  await seedFiles(page, 'playground');
+  await tab(page, 'Middle').click({ button: 'right' });
+  await menu.getByRole('menuitem', { name: 'Rename' }).click();
+  await expect(page.locator('.tab-rename-input')).toBeVisible();
+  await page.locator('.tab-rename-input').press('Escape');
+
+  await tab(page, 'Middle').click({ button: 'right' });
+  await menu.getByRole('menuitem', { name: 'Close', exact: true }).click();
+  await expect(page.locator('.editor-header .tab')).toHaveCount(3);
+  await expect(tab(page, 'Middle')).toHaveCount(0);
+});
+
+test('problem tabs expose context actions and close other files together', async ({ page }) => {
+  await page.goto('/problems/two-sum');
+  await seedFiles(page, 'two-sum');
+
+  await expect(page.locator('.editor-header .tab')).toHaveCount(4);
+  const menu = page.getByRole('menu', { name: 'Tab actions' });
+  await tab(page, 'Middle').click({ button: 'right' });
+  await expect(menu.getByRole('menuitem')).toHaveText(['Close', 'Close Left', 'Close Right', 'Close Others', 'Rename']);
+
+  await menu.getByRole('menuitem', { name: 'Rename' }).click();
+  await expect(page.locator('.tab-rename-input')).toBeVisible();
+  await page.locator('.tab-rename-input').press('Escape');
+
+  await tab(page, 'Middle').click({ button: 'right' });
+
+  await menu.getByRole('menuitem', { name: 'Close Others' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Remove files?' });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'Remove files' }).click();
+  await expect(page.locator('.editor-header .tab')).toHaveCount(1);
+  await expect(tab(page, 'Middle')).toHaveCount(1);
+});

--- a/src/lib/components/TabContextMenu.svelte
+++ b/src/lib/components/TabContextMenu.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+    import { createEventDispatcher } from 'svelte';
+
+    export let x = 0;
+    export let y = 0;
+    export let closeDisabled = false;
+    export let closeLeftDisabled = false;
+    export let closeRightDisabled = false;
+    export let closeOthersDisabled = false;
+    export let renameDisabled = false;
+
+    const dispatch = createEventDispatcher<{
+        close: void;
+        closeLeft: void;
+        closeRight: void;
+        closeOthers: void;
+        rename: void;
+    }>();
+</script>
+
+<div
+    class="tab-context-menu"
+    role="menu"
+    aria-label="Tab actions"
+    tabindex="-1"
+    style="left: {x}px; top: {y}px;"
+    on:contextmenu|preventDefault|stopPropagation
+>
+    <button
+        type="button"
+        class="tab-context-menu-item"
+        role="menuitem"
+        disabled={closeDisabled}
+        on:click={() => dispatch('close')}
+    >Close</button>
+    <button
+        type="button"
+        class="tab-context-menu-item"
+        role="menuitem"
+        disabled={closeLeftDisabled}
+        on:click={() => dispatch('closeLeft')}
+    >Close Left</button>
+    <button
+        type="button"
+        class="tab-context-menu-item"
+        role="menuitem"
+        disabled={closeRightDisabled}
+        on:click={() => dispatch('closeRight')}
+    >Close Right</button>
+    <button
+        type="button"
+        class="tab-context-menu-item"
+        role="menuitem"
+        disabled={closeOthersDisabled}
+        on:click={() => dispatch('closeOthers')}
+    >Close Others</button>
+    <div class="tab-context-menu-separator" role="separator"></div>
+    <button
+        type="button"
+        class="tab-context-menu-item"
+        role="menuitem"
+        disabled={renameDisabled}
+        on:click={() => dispatch('rename')}
+    >Rename</button>
+</div>
+
+<style>
+    .tab-context-menu {
+        position: fixed;
+        min-width: 160px;
+        border: 1px solid var(--color-border);
+        background-color: var(--color-bg);
+        border-radius: 6px;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+        z-index: 1001;
+        padding: 4px;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .tab-context-menu-item {
+        width: 100%;
+        background: transparent;
+        border: none;
+        color: var(--color-text);
+        text-align: left;
+        padding: 8px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+        font: inherit;
+        font-size: 0.85rem;
+        white-space: nowrap;
+    }
+
+    .tab-context-menu-item:hover:not(:disabled) {
+        background-color: var(--color-second-bg);
+    }
+
+    .tab-context-menu-item:disabled {
+        color: var(--color-text-secondary);
+        cursor: default;
+        opacity: 0.45;
+    }
+
+    .tab-context-menu-separator {
+        height: 1px;
+        margin: 4px 0;
+        background-color: var(--color-border);
+    }
+</style>

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -4,6 +4,7 @@
     import CloudSyncModal from '$lib/components/CloudSyncModal.svelte';
     import LanguageIcon from '$lib/components/LanguageIcon.svelte';
     import ShareModal from '$lib/components/ShareModal.svelte';
+    import TabContextMenu from '$lib/components/TabContextMenu.svelte';
     import Tooltip from '$lib/components/Tooltip.svelte';
     import WhiteboardIcon from '$lib/components/WhiteboardIcon.svelte';
     import Whiteboard from '$lib/components/Whiteboard.svelte';
@@ -370,6 +371,7 @@ func main() {
     let importInputEl: HTMLInputElement | null = null;
     let contextMenu: { x: number; y: number; parentId: string | null } | null = null;
     let contextMenuEl: HTMLElement | null = null;
+    let tabContextMenu: { x: number; y: number; fileId: string } | null = null;
     // Collapse state is device-local UI preference: it is kept in localStorage
     // but not in CLOUD_KEYS, so cloud sync never collects or restores it.
     const COLLAPSED_FOLDERS_KEY = 'playground-collapsed-folders';
@@ -1453,9 +1455,28 @@ func main() {
         contextMenuEl = null;
     }
 
+    function closeTabContextMenu() {
+        tabContextMenu = null;
+    }
+
+    function openTabContextMenu(e: MouseEvent, fileId: string) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!tabs.some((tab) => tab.fileId === fileId && tab.isOpen)) return;
+
+        closeContextMenu();
+        showAddMenu = false;
+        const menuW = 160;
+        const menuH = 120;
+        const x = Math.min(e.clientX, window.innerWidth - menuW - 8);
+        const y = Math.min(e.clientY, window.innerHeight - menuH - 8);
+        tabContextMenu = { x: Math.max(8, x), y: Math.max(8, y), fileId };
+    }
+
     function openExplorerContextMenu(e: MouseEvent, node: FlatExplorerItem) {
         e.preventDefault();
         e.stopPropagation();
+        closeTabContextMenu();
         if (node.kind === 'empty') return;
         // Cancel any pending explorer drag started by the right-click mousedown
         if (explorerPointerDrag) {
@@ -1652,6 +1673,44 @@ func main() {
         }
     }
 
+    type TabContextAction = 'close' | 'left' | 'right' | 'others';
+
+    function getContextTabIds(fileId: string, action: TabContextAction): string[] {
+        const openTabs = tabs.filter((tab) => tab.isOpen);
+        const targetIndex = openTabs.findIndex((tab) => tab.fileId === fileId);
+        if (targetIndex === -1) return [];
+        if (action === 'close') return [fileId];
+        if (action === 'left') return openTabs.slice(0, targetIndex).map((tab) => tab.fileId);
+        if (action === 'right') return openTabs.slice(targetIndex + 1).map((tab) => tab.fileId);
+        return openTabs.filter((_, index) => index !== targetIndex).map((tab) => tab.fileId);
+    }
+
+    function getContextTabPosition(fileId: string): { index: number; count: number } {
+        const openTabs = tabs.filter((tab) => tab.isOpen);
+        return { index: openTabs.findIndex((tab) => tab.fileId === fileId), count: openTabs.length };
+    }
+
+    function isContextTabRenameDisabled(fileId: string): boolean {
+        return tabs.find((tab) => tab.fileId === fileId)?.type === 'whiteboard';
+    }
+
+    function closeTabsFromContext(action: TabContextAction) {
+        const menu = tabContextMenu;
+        if (!menu) return;
+        const idsToClose = getContextTabIds(menu.fileId, action);
+        closeTabContextMenu();
+        for (const fileId of idsToClose) closeTab(fileId);
+    }
+
+    function renameTabFromContext() {
+        const menu = tabContextMenu;
+        if (!menu) return;
+        const tab = tabs.find((item) => item.fileId === menu.fileId);
+        closeTabContextMenu();
+        if (!tab || tab.type === 'whiteboard') return;
+        startRename(tab.fileId, tab.fileName, 'tab');
+    }
+
     async function deleteFile(fileId: string) {
         const files = getFiles();
         const isFolder = files.some((f) => f.fileId === fileId && isFolderEntry(f));
@@ -1794,6 +1853,9 @@ func main() {
             if (contextMenu && contextMenuEl && !contextMenuEl.contains(e.target as Node)) {
                 closeContextMenu();
             }
+            if (tabContextMenu && !(e.target as HTMLElement | null)?.closest('.tab-context-menu')) {
+                closeTabContextMenu();
+            }
         };
         const handleDocContextMenu = (e: MouseEvent) => {
             if (contextMenu && contextMenuEl && !contextMenuEl.contains(e.target as Node)) {
@@ -1801,12 +1863,16 @@ func main() {
                 const target = e.target as HTMLElement | null;
                 if (!target?.closest('[data-explorer-id]')) closeContextMenu();
             }
+            if (tabContextMenu && !(e.target as HTMLElement | null)?.closest('.tab, .tab-context-menu')) {
+                closeTabContextMenu();
+            }
         };
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
                 showSettings = false;
                 showAddMenu = false;
                 closeContextMenu();
+                closeTabContextMenu();
             }
         };
         const handleScroll = () => {
@@ -4991,7 +5057,9 @@ func main() {
                             on:click={() => handleTabClick(t)}
                             on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activateTab(t.fileId); } }}
                             on:pointerdown={(e) => handleTabPointerDown(e, t.fileId)}
+                            on:contextmenu={(e) => openTabContextMenu(e, t.fileId)}
                             on:mousedown={(e) => {
+                                if (e.button === 2) return;
                                 e.preventDefault();
                                 e.stopPropagation();
                                 if (e.which === 2) {
@@ -5060,6 +5128,22 @@ func main() {
                     <button class="tab-add" aria-label="New tab" on:click={() => addNewTab('tab')}>+</button>
                 </div>
             </div>
+            {#if tabContextMenu}
+                {@const tabContextPosition = getContextTabPosition(tabContextMenu.fileId)}
+                <TabContextMenu
+                    x={tabContextMenu.x}
+                    y={tabContextMenu.y}
+                    renameDisabled={isContextTabRenameDisabled(tabContextMenu.fileId)}
+                    closeLeftDisabled={tabContextPosition.index <= 0}
+                    closeRightDisabled={tabContextPosition.index < 0 || tabContextPosition.index >= tabContextPosition.count - 1}
+                    closeOthersDisabled={tabContextPosition.count <= 1}
+                    on:close={() => closeTabsFromContext('close')}
+                    on:closeLeft={() => closeTabsFromContext('left')}
+                    on:closeRight={() => closeTabsFromContext('right')}
+                    on:closeOthers={() => closeTabsFromContext('others')}
+                    on:rename={renameTabFromContext}
+                />
+            {/if}
             <div style="display:flex;align-items:center;gap:var(--spacing-2);">
                 {#if activeTab?.type === 'preview'}
                     <div class="markdown-mode-switch" role="group" aria-label="Markdown view mode">

--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -2,6 +2,7 @@
     import SaveStatus from '$lib/components/SaveStatus.svelte';
     import ExecutionPanel from '$lib/components/ExecutionPanel.svelte';
     import ShareModal from '$lib/components/ShareModal.svelte';
+    import TabContextMenu from '$lib/components/TabContextMenu.svelte';
     import GameResultPopup from '$lib/components/GameResultPopup.svelte';
     import GameHistoryPopup from '$lib/components/GameHistoryPopup.svelte';
     import GameModePopup from '$lib/components/GameModePopup.svelte';
@@ -195,6 +196,7 @@
     let tabs: TabMeta[] = getInitialTabs();
     let activeTabId: number = 0;
     $: activeTab = tabs[activeTabId];
+    let tabContextMenu: { x: number; y: number; fileId: string } | null = null;
     let editingTabId: string | null = null;
     let editingName = '';
     let renameInputEl: HTMLInputElement | null = null;
@@ -382,6 +384,22 @@
         activateTab(t.fileId);
     }
 
+    function closeTabContextMenu() {
+        tabContextMenu = null;
+    }
+
+    function openTabContextMenu(e: MouseEvent, fileId: string) {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!tabs.some((tab) => tab.fileId === fileId)) return;
+
+        const menuW = 160;
+        const menuH = 120;
+        const x = Math.min(e.clientX, window.innerWidth - menuW - 8);
+        const y = Math.min(e.clientY, window.innerHeight - menuH - 8);
+        tabContextMenu = { x: Math.max(8, x), y: Math.max(8, y), fileId };
+    }
+
     $: tabDropIndicatorStyle = (() => {
         if (tabDragInsertIndex < 0) return null;
         const bar = document.querySelector<HTMLElement>('.editor-header .tab-bar');
@@ -444,7 +462,7 @@
         $fileSyncVersion;
     }
 
-    async function closeTab(fileId: string) {
+    async function closeTab(fileId: string, skipConfirm = false) {
         const tabToClose = tabs.find((t) => t.fileId === fileId);
         if (tabToClose?.type === 'whiteboard') {
             const idx = tabs.findIndex((t) => t.fileId === fileId);
@@ -463,7 +481,7 @@
             return;
         }
         if (tabs.length <= 1) return;
-        if (!await showConfirm('This file and all of its saved language versions will be permanently removed.', {
+        if (!skipConfirm && !await showConfirm('This file and all of its saved language versions will be permanently removed.', {
             title: 'Remove file?',
             confirmLabel: 'Remove file',
             tone: 'danger'
@@ -484,6 +502,60 @@
         tabs = newTabs;
         // Re-number orders after removal
         persistTabOrder();
+    }
+
+    type TabContextAction = 'close' | 'left' | 'right' | 'others';
+
+    function getContextTabIds(fileId: string, action: TabContextAction): string[] {
+        const targetIndex = tabs.findIndex((tab) => tab.fileId === fileId);
+        if (targetIndex === -1) return [];
+        if (action === 'close') return [fileId];
+        if (action === 'left') return tabs.slice(0, targetIndex).map((tab) => tab.fileId);
+        if (action === 'right') return tabs.slice(targetIndex + 1).map((tab) => tab.fileId);
+        return tabs.filter((_, index) => index !== targetIndex).map((tab) => tab.fileId);
+    }
+
+    async function closeTabsFromContext(action: TabContextAction) {
+        const menu = tabContextMenu;
+        if (!menu) return;
+        const idsToClose = getContextTabIds(menu.fileId, action);
+        closeTabContextMenu();
+        if (!idsToClose.length) return;
+
+        const filesToRemove = idsToClose.filter((fileId) => tabs.find((tab) => tab.fileId === fileId)?.type !== 'whiteboard');
+        if (filesToRemove.length > 0) {
+            const isSingleFile = filesToRemove.length === 1;
+            if (!await showConfirm(
+                isSingleFile
+                    ? 'This file and all of its saved language versions will be permanently removed.'
+                    : 'These files and all of their saved language versions will be permanently removed.',
+                {
+                    title: isSingleFile ? 'Remove file?' : 'Remove files?',
+                    confirmLabel: isSingleFile ? 'Remove file' : 'Remove files',
+                    tone: 'danger'
+                }
+            )) return;
+        }
+
+        for (const fileId of idsToClose) await closeTab(fileId, true);
+    }
+
+    function isContextTabCloseDisabled(fileId: string): boolean {
+        const tab = tabs.find((item) => item.fileId === fileId);
+        return !tab || (tabs.length <= 1 && tab.type !== 'whiteboard');
+    }
+
+    function isContextTabRenameDisabled(fileId: string): boolean {
+        return tabs.find((tab) => tab.fileId === fileId)?.type === 'whiteboard';
+    }
+
+    function renameTabFromContext() {
+        const menu = tabContextMenu;
+        if (!menu) return;
+        const tab = tabs.find((item) => item.fileId === menu.fileId);
+        closeTabContextMenu();
+        if (!tab || tab.type === 'whiteboard') return;
+        startRename(tab.fileId, tab.fileName);
     }
 
     function handleMouseDown(event: MouseEvent) {
@@ -570,10 +642,19 @@
             if (showSettings && settingsContainer && !settingsContainer.contains(e.target as Node)) {
                 showSettings = false;
             }
+            if (tabContextMenu && !(e.target as HTMLElement | null)?.closest('.tab-context-menu')) {
+                closeTabContextMenu();
+            }
+        };
+        const handleDocContextMenu = (e: MouseEvent) => {
+            if (tabContextMenu && !(e.target as HTMLElement | null)?.closest('.tab, .tab-context-menu')) {
+                closeTabContextMenu();
+            }
         };
         const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === 'Escape') {
                 showSettings = false;
+                closeTabContextMenu();
             }
             if ((e.ctrlKey || e.metaKey) && (e.key === 'b' || e.key === 'B')) {
                 e.preventDefault();
@@ -610,15 +691,20 @@
         const handleCloudFlush = () => {
             if (!isCloudRestoreInProgress()) saveCurrentViewState();
         };
+        const handleResize = () => closeTabContextMenu();
         document.addEventListener('click', handleDocClick);
+        document.addEventListener('contextmenu', handleDocContextMenu);
         document.addEventListener('keydown', handleKeyDown);
         window.addEventListener('beforeunload', handleUnload);
         window.addEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
+        window.addEventListener('resize', handleResize);
         return () => {
             document.removeEventListener('click', handleDocClick);
+            document.removeEventListener('contextmenu', handleDocContextMenu);
             document.removeEventListener('keydown', handleKeyDown);
             window.removeEventListener('beforeunload', handleUnload);
             window.removeEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
+            window.removeEventListener('resize', handleResize);
         };
     });
 
@@ -1024,7 +1110,9 @@
                                 on:click={() => handleTabClick(t)}
                                 on:keydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activateTab(t.fileId); } }}
                                 on:pointerdown={(e) => handleTabPointerDown(e, t.fileId)}
+                                on:contextmenu={(e) => openTabContextMenu(e, t.fileId)}
                                 on:mousedown={(e) => {
+                                    if (e.button === 2) return;
                                     e.preventDefault();
                                     e.stopPropagation();
                                 }}
@@ -1084,6 +1172,23 @@
                         <button class="tab-add" aria-label="New tab" title="New tab" on:click={() => addNewTab()}>+</button>
                     </div>
                 </div>
+                {#if tabContextMenu}
+                    {@const tabContextPosition = tabs.findIndex((tab) => tab.fileId === tabContextMenu?.fileId)}
+                    <TabContextMenu
+                        x={tabContextMenu.x}
+                        y={tabContextMenu.y}
+                        closeDisabled={isContextTabCloseDisabled(tabContextMenu.fileId)}
+                        renameDisabled={isContextTabRenameDisabled(tabContextMenu.fileId)}
+                        closeLeftDisabled={tabContextPosition <= 0}
+                        closeRightDisabled={tabContextPosition < 0 || tabContextPosition >= tabs.length - 1}
+                        closeOthersDisabled={tabs.length <= 1}
+                        on:close={() => closeTabsFromContext('close')}
+                        on:closeLeft={() => closeTabsFromContext('left')}
+                        on:closeRight={() => closeTabsFromContext('right')}
+                        on:closeOthers={() => closeTabsFromContext('others')}
+                        on:rename={renameTabFromContext}
+                    />
+                {/if}
             </div>
             <div style="display:flex;align-items:center;gap:var(--spacing-2);">
                 <Tooltip text={"Whiteboard"} pos={"bottom"}>


### PR DESCRIPTION
## Summary
- add right-click tab actions for playground and problem tabs
- support Close, Close Left, Close Right, Close Others, and Rename
- add focused Playwright coverage for the tab actions

## Verification
- npm test -- --run
- npx playwright test e2e/tab-context-menu.test.ts
- npm run build