### PR TITLE
feat: add selective cloud sync actions

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -62,25 +62,29 @@ test('discarding an active WYSIWYG file reloads the restored content', async ({ 
     localStorage.setItem('playground-markdown-mode', 'wysiwyg');
     localStorage.setItem('files', JSON.stringify({
       playground: JSON.stringify([
-        { fileId: 'active-file', fileName: 'Notes', language: 'markdown', content: '# Local version', isOpen: true, order: 0, lastUpdated: Date.now() }
+        { fileId: 'active-file', fileName: 'Notes', language: 'markdown', content: '\n\n# Local version', isOpen: true, order: 0, lastUpdated: Date.now() }
       ])
     }));
   });
   await page.reload();
   await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Local version');
+  await page.evaluate(() => window.dispatchEvent(new Event('cojudge:cloud-flush')));
+  await expect.poll(() => getMarkdownContent(page)).toBe('\n\n# Local version');
 
   await page.evaluate(() => {
     const restoredFiles = JSON.stringify({
       playground: JSON.stringify([
-        { fileId: 'active-file', fileName: 'Notes', language: 'markdown', content: '# Cloud version', isOpen: true, order: 0, lastUpdated: Date.now() }
+        { fileId: 'active-file', fileName: 'Notes', language: 'markdown', content: '\n\n# Cloud version', isOpen: true, order: 0, lastUpdated: Date.now() }
       ])
     });
     localStorage.setItem('files', restoredFiles);
     window.dispatchEvent(new StorageEvent('storage', { key: 'files', newValue: restoredFiles }));
     window.dispatchEvent(new CustomEvent('cojudge:cloud-file-discarded', { detail: { fileId: 'active-file' } }));
+    window.dispatchEvent(new Event('cojudge:cloud-flush'));
   });
 
   await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Cloud version');
+  await expect.poll(() => getMarkdownContent(page)).toBe('\n\n# Cloud version');
 });
 
 test('playground markdown editor pastes clipboard images as base64 markdown', async ({ page }) => {
@@ -795,4 +799,3 @@ test('WYSIWYG Tab/Shift+Tab on checklists keeps checkboxes intact', async ({ pag
   await expect(editable.locator('li').nth(1).locator('input[type="checkbox"]')).toBeChecked();
   await expect.poll(() => getMarkdownContent(page)).toMatch(/- +\[ \] +one\s*\n- +\[x\] +two/);
 });
-

--- a/src/lib/cloudFileChange.test.ts
+++ b/src/lib/cloudFileChange.test.ts
@@ -6,6 +6,7 @@ import {
 	computeWhiteboardChange,
 	computeWorkspaceChanges,
 	discardChange,
+	applySelectedChanges,
 	discardFile,
 	isBlobContent,
 	CHECKBOXES_FILE_ID,
@@ -243,6 +244,21 @@ describe('discardFile', () => {
 		expect(entries).toHaveLength(2);
 		expect(entries.map((entry) => entry.fileId).sort()).toEqual(['1', '2']);
 	});
+
+	it('re-adds a cloud file when its local workspace no longer exists', () => {
+		const cloudStore: FileStore = {
+			playground: JSON.stringify([
+				{ fileId: '1', fileName: 'Solution', language: 'python', content: 'print(1)' }
+			])
+		};
+
+		const updated = discardFile({}, '1', cloudStore);
+		const entries = JSON.parse(updated.playground) as Array<Record<string, unknown>>;
+
+		expect(entries).toHaveLength(1);
+		expect(entries[0].fileId).toBe('1');
+		expect(entries[0].content).toBe('print(1)');
+	});
 });
 
 describe('computeOtherChanges', () => {
@@ -400,6 +416,90 @@ describe('discardChange', () => {
 		const cloud: ProgressStore = { files: { playground: JSON.stringify([{ fileId: '1', fileName: 'Original' }]) } };
 		const updated = discardChange(local, `${WORKSPACE_FILE_ID_PREFIX}playground`, cloud);
 		expect(JSON.parse((updated.files as Record<string, string>).playground)[0].fileName).toBe('Original');
+	});
+});
+
+describe('applySelectedChanges', () => {
+	it('restores multiple files in one workspace while preserving unselected files', () => {
+		const local: ProgressStore = {
+			files: {
+				playground: JSON.stringify([
+					{ fileId: '1', fileName: 'A', language: 'python', content: 'local-a', isOpen: true },
+					{ fileId: '2', fileName: 'B', language: 'python', content: 'local-b', order: 4 },
+					{ fileId: '3', fileName: 'C', language: 'python', content: 'keep-local' }
+				])
+			}
+		};
+		const cloud: ProgressStore = {
+			files: {
+				playground: JSON.stringify([
+					{ fileId: '1', fileName: 'A', language: 'python', content: 'cloud-a' },
+					{ fileId: '2', fileName: 'B', language: 'python', content: 'cloud-b' },
+					{ fileId: '3', fileName: 'C', language: 'python', content: 'cloud-c' }
+				])
+			}
+		};
+
+		const updated = applySelectedChanges(local, ['1', '2'], cloud);
+		const entries = JSON.parse((updated.files as FileStore).playground) as Array<Record<string, unknown>>;
+
+		expect(entries.map((entry) => entry.content)).toEqual(['cloud-a', 'cloud-b', 'keep-local']);
+		expect(entries[0].isOpen).toBe(true);
+		expect(entries[1].order).toBe(4);
+	});
+
+	it('restores mixed file, solution, and whiteboard changes from one snapshot', () => {
+		const local: ProgressStore = {
+			files: store([{ fileId: '1', fileName: 'A', language: 'python', content: 'local' }]),
+			solutions: { selected: 'local', untouched: 'keep-local' },
+			'cojudge-whiteboard-v1': { elements: ['local'] }
+		};
+		const cloud: ProgressStore = {
+			files: store([{ fileId: '1', fileName: 'A', language: 'python', content: 'cloud' }]),
+			solutions: { selected: 'cloud', untouched: 'cloud-untouched' },
+			'cojudge-whiteboard-v1': { elements: ['cloud'] }
+		};
+
+		const updated = applySelectedChanges(
+			local,
+			['1', `${SOLUTION_FILE_ID_PREFIX}selected`, WHITEBOARD_FILE_ID],
+			cloud
+		);
+		const entries = JSON.parse((updated.files as FileStore).playground) as Array<Record<string, unknown>>;
+
+		expect(entries[0].content).toBe('cloud');
+		expect(updated.solutions).toEqual({ selected: 'cloud', untouched: 'keep-local' });
+		expect(updated['cojudge-whiteboard-v1']).toEqual({ elements: ['cloud'] });
+	});
+
+	it('pushes only selected local values into a cloud snapshot', () => {
+		const local: ProgressStore = {
+			files: store([
+				{ fileId: '1', fileName: 'A', language: 'python', content: 'local-a' },
+				{ fileId: '2', fileName: 'B', language: 'python', content: 'local-b' }
+			]),
+			solutions: { selected: 'local-selected', untouched: 'local-untouched' }
+		};
+		const cloud: ProgressStore = {
+			files: store([
+				{ fileId: '1', fileName: 'A', language: 'python', content: 'cloud-a' },
+				{ fileId: '2', fileName: 'B', language: 'python', content: 'cloud-b' }
+			]),
+			solutions: { selected: 'cloud-selected', untouched: 'cloud-untouched' }
+		};
+
+		const updated = applySelectedChanges(
+			cloud,
+			['1', `${SOLUTION_FILE_ID_PREFIX}selected`],
+			local
+		);
+		const entries = JSON.parse((updated.files as FileStore).playground) as Array<Record<string, unknown>>;
+
+		expect(entries.map((entry) => entry.content)).toEqual(['local-a', 'cloud-b']);
+		expect(updated.solutions).toEqual({
+			selected: 'local-selected',
+			untouched: 'cloud-untouched'
+		});
 	});
 });
 

--- a/src/lib/cloudFileChange.ts
+++ b/src/lib/cloudFileChange.ts
@@ -512,6 +512,43 @@ export function discardChange(data: ProgressStore, fileId: string, cloudData: Pr
 	return result;
 }
 
+function isOtherChangeFileId(fileId: string): boolean {
+	return (
+		fileId === CHECKBOXES_FILE_ID
+		|| fileId === USER_SETTINGS_FILE_ID
+		|| OTHER_CHANGE_FILE_ID_PREFIXES.some((prefix) => fileId.startsWith(prefix))
+	);
+}
+
+// Copies a group of displayed changes from one snapshot into another. Applying
+// them to a shared result avoids later changes overwriting earlier merges.
+export function applySelectedChanges(
+	targetData: ProgressStore,
+	fileIds: Iterable<string>,
+	sourceData: ProgressStore
+): ProgressStore {
+	let result: ProgressStore = { ...targetData };
+	const sourceFiles = (sourceData['files'] ?? {}) as FileStore;
+
+	for (const fileId of new Set(fileIds)) {
+		if (fileId === WHITEBOARD_FILE_ID) {
+			const sourceBoard = sourceData[WHITEBOARD_BOARD_KEY];
+			if (sourceBoard === undefined) delete result[WHITEBOARD_BOARD_KEY];
+			else result[WHITEBOARD_BOARD_KEY] = sourceBoard;
+			continue;
+		}
+		if (isOtherChangeFileId(fileId)) {
+			result = discardChange(result, fileId, sourceData);
+			continue;
+		}
+
+		const localFiles = (result['files'] ?? {}) as FileStore;
+		result = { ...result, files: discardFile(localFiles, fileId, sourceFiles) };
+	}
+
+	return result;
+}
+
 // Describes whether the whiteboard board differs from the cloud. The board is a
 // JSON payload that can embed base64 images, so the diff is always treated as a
 // blob and no line-wise diff is produced.
@@ -550,7 +587,7 @@ export function discardFile(
 ): FileStore {
 	const result: FileStore = { ...localStore };
 
-	for (const slug of Object.keys(result)) {
+	for (const slug of new Set([...Object.keys(result), ...Object.keys(cloudStore)])) {
 		const entries = parseEntries(result, slug);
 		const localEntries = entries.filter((entry) => entry['fileId'] === fileId);
 		const cloudEntries = parseEntries(cloudStore, slug).filter((entry) => entry['fileId'] === fileId);

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -61,11 +61,7 @@ import {
 	computeWhiteboardChange,
 	computeWorkspaceChanges,
 	CLOUD_FILE_DISCARDED_EVENT,
-	discardChange,
-	discardFile,
-	OTHER_CHANGE_FILE_ID_PREFIXES,
-	CHECKBOXES_FILE_ID,
-	USER_SETTINGS_FILE_ID,
+	applySelectedChanges,
 	WHITEBOARD_BOARD_KEY,
 	WHITEBOARD_FILE_ID,
 	WHITEBOARD_RESTORED_EVENT,
@@ -141,6 +137,8 @@ type LocalSnapshot = {
 	meaningful: boolean;
 	meta: DeviceUserMeta;
 };
+
+type UploadSnapshot = Pick<LocalSnapshot, 'serialized' | 'checksum' | 'meaningful'>;
 
 type RemoteSnapshotMeta = {
 	snapshotId: string;
@@ -376,11 +374,8 @@ function clearCloudClone(): void {
 	if (browser) localStorage.removeItem(CLOUD_CLONE_KEY);
 }
 
-// Collects the IndexedDB-backed pasted images referenced by markdown file
-// contents, as { [id]: dataUrl }. Returns null when none are referenced so the
-// snapshot stays image-free (and checksums unchanged) for image-less documents.
-async function collectReferencedPastedImages(filesValue: unknown): Promise<Record<string, string> | null> {
-	const links = new Set<string>();
+function referencedPastedImageIds(filesValue: unknown): Set<string> {
+	const ids = new Set<string>();
 	if (filesValue && typeof filesValue === 'object' && !Array.isArray(filesValue)) {
 		for (const serialized of Object.values(filesValue)) {
 			if (typeof serialized !== 'string') continue;
@@ -395,21 +390,49 @@ async function collectReferencedPastedImages(filesValue: unknown): Promise<Recor
 				if (!entry || typeof entry !== 'object' || Array.isArray(entry)) continue;
 				const file = entry as Record<string, unknown>;
 				if (file.language !== 'markdown' || typeof file.content !== 'string') continue;
-				for (const link of findPastedImageLinks(file.content)) links.add(link);
+				for (const link of findPastedImageLinks(file.content)) {
+					const id = parsePastedImageLink(link);
+					if (id) ids.add(id);
+				}
 			}
 		}
 	}
-	if (links.size === 0) return null;
+	return ids;
+}
+
+// Collects the IndexedDB-backed pasted images referenced by markdown file
+// contents, as { [id]: dataUrl }. Returns null when none are referenced so the
+// snapshot stays image-free (and checksums unchanged) for image-less documents.
+async function collectReferencedPastedImages(filesValue: unknown): Promise<Record<string, string> | null> {
+	const ids = referencedPastedImageIds(filesValue);
+	if (ids.size === 0) return null;
 
 	const all = await getAllPastedImages();
 	const record: Record<string, string> = {};
-	for (const link of links) {
-		const id = parsePastedImageLink(link);
-		if (!id) continue;
+	for (const id of ids) {
 		const dataUrl = all[id];
 		if (dataUrl) record[id] = dataUrl;
 	}
 	return Object.keys(record).length > 0 ? record : null;
+}
+
+function retainReferencedPastedImages(
+	data: ProgressData,
+	sources: Array<Record<string, string> | null>
+): ProgressData {
+	const result = { ...data };
+	const images: Record<string, string> = {};
+	for (const id of referencedPastedImageIds(result.files)) {
+		for (const source of sources) {
+			const dataUrl = source?.[id];
+			if (!dataUrl) continue;
+			images[id] = dataUrl;
+			break;
+		}
+	}
+	if (Object.keys(images).length > 0) result[PASTED_IMAGES_KEY] = images;
+	else delete result[PASTED_IMAGES_KEY];
+	return result;
 }
 
 async function readLocalSnapshot(
@@ -698,7 +721,7 @@ function makeRevisionId(): string {
 async function uploadSnapshot(
 	db: Firestore,
 	uid: string,
-	local: LocalSnapshot,
+	local: UploadSnapshot,
 	previous: RemoteSnapshotMeta | null
 ): Promise<string> {
 	const { parts, totalBytes } = encodeProgressParts(local.serialized);
@@ -1204,7 +1227,125 @@ export async function fetchCloudFileChanges(): Promise<FileChange[]> {
 	return fileChangesAgainstCloud(local.data, cloudData);
 }
 
-export async function discardLocalFileChange(fileId: string): Promise<void> {
+async function runSelectedFilePush(
+	fileIds: readonly string[],
+	context: OperationContext
+): Promise<void> {
+	if (!browser || !isOperationCurrent(context) || isCloudRestoreInProgress()) return;
+	cloudSyncState.update((state) => ({
+		...state,
+		syncStatus: 'syncing',
+		error: null,
+		progress: { label: 'Preparing selected changes…', value: 10 }
+	}));
+
+	try {
+		if (!navigator.onLine) {
+			throw new Error('Connect to the internet before pushing selected changes.');
+		}
+		const resolution = get(cloudSyncState).resolution;
+		if (resolution === 'account' || resolution === 'conflict') {
+			throw new Error('Resolve the current cloud workspace choice before pushing selected changes.');
+		}
+
+		await coordinateOtherContexts('flush');
+		if (!isOperationCurrent(context)) return;
+		const local = await readLocalSnapshot(context);
+		if (!isOperationCurrent(context)) return;
+
+		setCloudProgress('Reading cloud state…', 30);
+		const { remote, history } = await refreshRemoteState(context.db, context.uid);
+		if (!isOperationCurrent(context)) return;
+		publishHistory(history, remote?.revisionId ?? null);
+
+		let cloudData: ProgressData = {};
+		if (remote) {
+			setCloudProgress('Merging selected changes…', 45);
+			cloudData = await ensureCloudClone(context, remote);
+			if (!isOperationCurrent(context)) return;
+		}
+
+		let mergedData = applySelectedChanges(cloudData, fileIds, local.data) as ProgressData;
+		mergedData = sanitizeCloudFiles(mergedData);
+		mergedData = retainReferencedPastedImages(mergedData, [
+			extractPastedImages(cloudData),
+			extractPastedImages(local.data)
+		]);
+		const serialized = serializeProgressData(mergedData);
+		const upload: UploadSnapshot = {
+			serialized,
+			checksum: await hashProgress(serialized),
+			meaningful: isMeaningfulProgress(mergedData)
+		};
+		if (!isOperationCurrent(context)) return;
+
+		if (remote && upload.checksum === remote.checksum) {
+			writeCloudClone(
+				cloudAccountId(context.projectId, context.uid),
+				remote.checksum,
+				serialized,
+				remote.revisionId
+			);
+			await finalizeCloudRevision(context, remote.checksum);
+			return;
+		}
+
+		setCloudProgress('Uploading selected changes…', 60);
+		const revisionId = await uploadSnapshot(context.db, context.uid, upload, remote);
+		if (!isOperationCurrent(context)) return;
+		setCloudProgress('Finalizing…', 85);
+		const updated = await refreshRemoteState(context.db, context.uid);
+		if (!isOperationCurrent(context)) return;
+		const uploaded = updated.remote;
+		if (!uploaded || uploaded.revisionId !== revisionId) {
+			throw new Error('Cojudge Cloud could not confirm the selected changes.');
+		}
+		writeCloudClone(
+			cloudAccountId(context.projectId, context.uid),
+			uploaded.checksum,
+			serialized,
+			uploaded.revisionId
+		);
+		publishHistory(updated.history, uploaded.revisionId);
+		await finalizeCloudRevision(context, uploaded.checksum);
+	} catch (error) {
+		if (!isOperationCurrent(context)) return;
+		const offline = !navigator.onLine;
+		cloudSyncState.update((state) => ({
+			...state,
+			syncStatus: offline ? 'offline' : 'error',
+			remoteStatus: offline ? state.remoteStatus : 'error',
+			error: offline ? null : errorMessage(error),
+			progress: null
+		}));
+		throw error;
+	}
+}
+
+export function pushLocalFileChanges(fileIds: readonly string[]): Promise<void> {
+	const selectedFileIds = [...new Set(fileIds.filter((fileId) => fileId.length > 0))];
+	const requestedContext = captureOperationContext();
+	if (selectedFileIds.length === 0 || !requestedContext) return Promise.resolve();
+	if (syncPromise) {
+		return syncPromise.catch(() => undefined).then(() => {
+			if (!isOperationCurrent(requestedContext)) return;
+			return pushLocalFileChanges(selectedFileIds);
+		});
+	}
+	const pending = runSelectedFilePush(selectedFileIds, requestedContext).finally(() => {
+		if (syncPromise === pending) {
+			syncPromise = null;
+			syncContext = null;
+		}
+	});
+	syncPromise = pending;
+	syncContext = requestedContext;
+	return pending;
+}
+
+export async function discardLocalFileChanges(fileIds: readonly string[]): Promise<void> {
+	const selectedFileIds = [...new Set(fileIds.filter((fileId) => fileId.length > 0))];
+	if (selectedFileIds.length === 0) return;
 	const context = captureOperationContext();
 	if (!browser || !context || isCloudRestoreInProgress()) return;
 	if (!navigator.onLine) {
@@ -1227,28 +1368,14 @@ export async function discardLocalFileChange(fileId: string): Promise<void> {
 	// before any discard path that rewrites `files` so secrets like `.env` are
 	// never wiped when restoring cloud content.
 	const localDotFiles = extractDotFilesData(localStorage);
-
-	if (fileId === WHITEBOARD_FILE_ID) {
-		const cloudBoard = downloaded[WHITEBOARD_BOARD_KEY];
-		if (cloudBoard === undefined) {
-			localStorage.removeItem(WHITEBOARD_BOARD_KEY);
-		} else {
-			localStorage.setItem(WHITEBOARD_BOARD_KEY, JSON.stringify(cloudBoard));
-		}
-		window.dispatchEvent(new CustomEvent(WHITEBOARD_RESTORED_EVENT));
-	} else if (isOtherChangeFileId(fileId)) {
-		const contextSnapshot = await readLocalSnapshot(context);
-		if (!isOperationCurrent(context)) return;
-		const updated = discardChange(contextSnapshot.data as ProgressStore, fileId, downloaded);
-		applyProgressData(updated, { replace: true });
-	} else {
-		const cloudFiles = (downloaded.files ?? {}) as FileStore;
-		const localStore = readLocalFilesStore();
-		const updated = discardFile(localStore, fileId, cloudFiles);
-		localStorage.setItem('files', JSON.stringify(updated));
-		fileStore.set(updated);
-		fileSyncVersion.update((version) => version + 1);
-	}
+	const contextSnapshot = await readLocalSnapshot(context);
+	if (!isOperationCurrent(context)) return;
+	const localData: ProgressStore = {
+		...contextSnapshot.data,
+		files: readLocalFilesStore()
+	};
+	const updated = applySelectedChanges(localData, selectedFileIds, downloaded);
+	applyProgressData(updated, { replace: true });
 
 	if (localDotFiles !== null) {
 		const merged = mergeDotFilesData(localStorage.getItem('files'), localDotFiles);
@@ -1264,19 +1391,20 @@ export async function discardLocalFileChange(fileId: string): Promise<void> {
 		}
 	}
 
-	// The active editor keeps its own in-memory value. Notify the page after the
-	// restored store is complete so it can reload that value before the next
-	// cloud flush compares local progress.
-	window.dispatchEvent(new CustomEvent(CLOUD_FILE_DISCARDED_EVENT, { detail: { fileId } }));
+	if (selectedFileIds.includes(WHITEBOARD_FILE_ID)) {
+		window.dispatchEvent(new CustomEvent(WHITEBOARD_RESTORED_EVENT));
+	}
+
+	// Active editors keep their own in-memory values. Notify them after every
+	// selected restore is complete and before the next cloud flush compares it.
+	for (const fileId of selectedFileIds) {
+		window.dispatchEvent(new CustomEvent(CLOUD_FILE_DISCARDED_EVENT, { detail: { fileId } }));
+	}
 	await refreshCloudLocalState();
 }
 
-function isOtherChangeFileId(fileId: string): boolean {
-	return (
-		fileId === CHECKBOXES_FILE_ID
-		|| fileId === USER_SETTINGS_FILE_ID
-		|| OTHER_CHANGE_FILE_ID_PREFIXES.some((prefix) => fileId.startsWith(prefix))
-	);
+export function discardLocalFileChange(fileId: string): Promise<void> {
+	return discardLocalFileChanges([fileId]);
 }
 
 async function inspectCloudSignOut(context: OperationContext): Promise<CloudSignOutCheck> {

--- a/src/lib/components/AppDialog.svelte
+++ b/src/lib/components/AppDialog.svelte
@@ -182,6 +182,9 @@
 		background: color-mix(in srgb, var(--color-easy) 14%, transparent);
 		color: var(--color-easy);
 	}
+	.dialog-copy {
+		min-width: 0;
+	}
 	.dialog-copy h2 {
 		margin: 0;
 		font-size: 1.12rem;
@@ -192,6 +195,9 @@
 		color: var(--color-text-secondary);
 		font-size: 0.9rem;
 		line-height: 1.55;
+		max-height: min(50vh, 20rem);
+		overflow-y: auto;
+		overflow-wrap: anywhere;
 		white-space: pre-wrap;
 	}
 	.dialog-actions {

--- a/src/lib/components/CloudSyncModal.svelte
+++ b/src/lib/components/CloudSyncModal.svelte
@@ -8,8 +8,9 @@
         connectCloud,
         deleteCloudRevision,
         disconnectCloud,
-        discardLocalFileChange,
+        discardLocalFileChanges,
         fetchCloudFileChanges,
+        pushLocalFileChanges,
         refreshCloudLocalState,
         resolveCloudProgress,
         restoreCloudRevision,
@@ -34,6 +35,7 @@
     let cloudFileChanges: FileChange[] = [];
     let cloudFileChangesLoading = false;
     let cloudFileChangesError = '';
+    let selectedCloudFileIds = new Set<string>();
     let expandedDiffs = new Set<string>();
     function toggleDiff(key: string) {
         const next = new Set(expandedDiffs);
@@ -92,6 +94,7 @@
 
     async function openModal() {
         showAllCloudHistory = false;
+        selectedCloudFileIds = new Set();
         await refreshCloudLocalState();
         await tick();
         cloudPrimaryButton?.focus();
@@ -109,8 +112,9 @@
         if (shouldLoadFileChanges && !fileChangesLoadArmed) {
             fileChangesLoadArmed = true;
             void loadCloudFileChanges();
-        } else if (!shouldLoadFileChanges) {
+        } else if (!shouldLoadFileChanges && fileChangesLoadArmed) {
             fileChangesLoadArmed = false;
+            selectedCloudFileIds = new Set();
         }
     }
 
@@ -131,27 +135,46 @@
         if ($cloudSyncState.authStatus !== 'signed-in' || $cloudSyncState.resolution !== 'local-changes') {
             cloudFileChanges = [];
             cloudFileChangesError = '';
+            selectedCloudFileIds = new Set();
             return;
         }
         cloudFileChangesLoading = true;
         cloudFileChangesError = '';
         try {
             cloudFileChanges = await fetchCloudFileChanges();
+            const availableIds = new Set(cloudFileChanges.map((change) => change.fileId));
+            selectedCloudFileIds = new Set(
+                [...selectedCloudFileIds].filter((fileId) => availableIds.has(fileId))
+            );
         } catch {
             cloudFileChangesError = 'Could not compare with the cloud. Check your connection and try again.';
             cloudFileChanges = [];
+            selectedCloudFileIds = new Set();
         } finally {
             cloudFileChangesLoading = false;
         }
     }
 
-    async function discardCloudFile(fileId: string) {
-        const change = cloudFileChanges.find((c) => c.fileId === fileId);
+    function cloudFileChangeLabel(change: FileChange): string {
+        return change.fileName ? `${change.slug}/${change.fileName}` : change.slug;
+    }
+
+    function setCloudFileSelected(fileId: string, selected: boolean) {
+        const next = new Set(selectedCloudFileIds);
+        if (selected) next.add(fileId);
+        else next.delete(fileId);
+        selectedCloudFileIds = next;
+    }
+
+    async function discardCloudFiles(changes: FileChange[]) {
+        if (changes.length === 0) return;
+        const labels = changes.map((change) => `- ${cloudFileChangeLabel(change)}`).join('\n');
+        const multiple = changes.length > 1;
         const confirmed = await showConfirm(
-            `Discard the local changes to "${change?.fileName ?? 'this file'}"? The file will be restored to its cloud version, which cannot be undone.`,
+            `The following local ${multiple ? 'changes' : 'change'} will be discarded:\n\n${labels}\n\n${multiple ? 'They will' : 'It will'} be restored from the latest cloud version. This cannot be undone.`,
             {
-                title: 'Discard file changes',
-                confirmLabel: 'Discard changes',
+                title: multiple ? 'Discard selected changes' : 'Discard file changes',
+                confirmLabel: multiple ? `Discard ${changes.length} changes` : 'Discard changes',
                 tone: 'danger'
             }
         );
@@ -159,7 +182,38 @@
 
         cloudActionPending = true;
         try {
-            await discardLocalFileChange(fileId);
+            const discardedIds = new Set(changes.map((change) => change.fileId));
+            await discardLocalFileChanges([...discardedIds]);
+            selectedCloudFileIds = new Set(
+                [...selectedCloudFileIds].filter((fileId) => !discardedIds.has(fileId))
+            );
+            await loadCloudFileChanges();
+        } catch {
+            // The shared cloud state renders the actionable error.
+        } finally {
+            cloudActionPending = false;
+        }
+    }
+
+    function discardSelectedCloudFiles() {
+        return discardCloudFiles(selectedCloudFileChanges());
+    }
+
+    function selectedCloudFileChanges(): FileChange[] {
+        return cloudFileChanges.filter((change) => selectedCloudFileIds.has(change.fileId));
+    }
+
+    async function pushSelectedCloudFiles() {
+        const changes = selectedCloudFileChanges();
+        if (changes.length === 0) return;
+
+        cloudActionPending = true;
+        try {
+            const pushedIds = new Set(changes.map((change) => change.fileId));
+            await pushLocalFileChanges([...pushedIds]);
+            selectedCloudFileIds = new Set(
+                [...selectedCloudFileIds].filter((fileId) => !pushedIds.has(fileId))
+            );
             await loadCloudFileChanges();
         } catch {
             // The shared cloud state renders the actionable error.
@@ -473,7 +527,11 @@
                     <div class="cloud-file-changes">
                         <div class="cloud-file-changes-heading">
                             <strong>Local changes</strong>
-                            <button class="btn cloud-file-reload" type="button" onclick={loadCloudFileChanges} disabled={cloudActionPending}>{cloudFileChangesLoading ? 'Comparing…' : 'Refresh'}</button>
+                            <div class="cloud-file-changes-actions">
+                                <button class="btn cloud-file-reload" type="button" onclick={loadCloudFileChanges} disabled={cloudActionPending}>{cloudFileChangesLoading ? 'Comparing…' : 'Refresh'}</button>
+                                <button class="btn cloud-file-push-selected" type="button" onclick={pushSelectedCloudFiles} disabled={cloudActionPending || cloudFileChangesLoading || selectedCloudFileIds.size === 0}>Push selected{selectedCloudFileIds.size > 0 ? ` (${selectedCloudFileIds.size})` : ''}</button>
+                                <button class="btn cloud-file-discard cloud-file-discard-selected" type="button" onclick={discardSelectedCloudFiles} disabled={cloudActionPending || cloudFileChangesLoading || selectedCloudFileIds.size === 0}>Discard selected{selectedCloudFileIds.size > 0 ? ` (${selectedCloudFileIds.size})` : ''}</button>
+                            </div>
                         </div>
                         {#if cloudFileChangesError}
                             <p class="modal-error" role="alert">{cloudFileChangesError}</p>
@@ -483,10 +541,13 @@
                             <p class="cloud-file-changes-empty">No differences found. Local data matches the latest cloud version.</p>
                         {:else}
                             {#each cloudFileChanges as change}
-                                <div class="cloud-file-change">
+                                <div class:selected={selectedCloudFileIds.has(change.fileId)} class="cloud-file-change">
                                     <div class="cloud-file-change-row">
-                                        <span class="cloud-file-change-name" title={change.fileName ? `${change.slug}/${change.fileName}` : change.slug}><span class="cloud-file-change-slug">{change.slug}</span>{change.fileName ? `/${change.fileName}` : ''}</span>
-                                        <button class="btn cloud-file-discard" type="button" onclick={() => discardCloudFile(change.fileId)} disabled={cloudActionPending}>Discard changes</button>
+                                        <label class="cloud-file-change-selection">
+                                            <input class="cloud-file-change-checkbox" type="checkbox" checked={selectedCloudFileIds.has(change.fileId)} onchange={(event) => setCloudFileSelected(change.fileId, event.currentTarget.checked)} disabled={cloudActionPending} />
+                                            <span class="cloud-file-change-name" title={cloudFileChangeLabel(change)}><span class="cloud-file-change-slug">{change.slug}</span>{change.fileName ? `/${change.fileName}` : ''}</span>
+                                        </label>
+                                        <button class="btn cloud-file-discard" type="button" onclick={() => discardCloudFiles([change])} disabled={cloudActionPending}>Discard changes</button>
                                     </div>
                                     {#each change.languages as lang}
                                         {@const diffKeyValue = diffKey(change.fileId, lang.language)}
@@ -870,8 +931,20 @@
         color: var(--color-text);
         font-size: 0.78rem;
     }
+    .cloud-file-changes-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 0.4rem;
+        flex-wrap: wrap;
+    }
     .cloud-file-reload {
         padding: 0.25rem 0.6rem;
+        font-size: 0.72rem;
+    }
+    .cloud-file-push-selected {
+        padding: 0.25rem 0.6rem;
+        border-color: color-mix(in srgb, var(--color-highlight) 45%, var(--color-border));
+        color: var(--color-highlight);
         font-size: 0.72rem;
     }
     .cloud-file-changes-empty {
@@ -887,13 +960,36 @@
         border-radius: 0.65rem;
         background: var(--color-second-bg);
     }
+    .cloud-file-change.selected {
+        border-color: color-mix(in srgb, var(--color-highlight) 48%, var(--color-border));
+    }
     .cloud-file-change-row {
         display: flex;
         align-items: center;
         justify-content: space-between;
         gap: 0.5rem;
     }
+    .cloud-file-change-selection {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        flex: 1 1 auto;
+        gap: 0.5rem;
+        cursor: pointer;
+    }
+    .cloud-file-change-checkbox {
+        width: 1rem;
+        height: 1rem;
+        margin: 0;
+        flex: 0 0 auto;
+        accent-color: var(--color-highlight);
+        cursor: pointer;
+    }
+    .cloud-file-change-checkbox:disabled {
+        cursor: not-allowed;
+    }
     .cloud-file-change-name {
+        min-width: 0;
         overflow: hidden;
         color: var(--color-text);
         font-size: 0.82rem;
@@ -910,6 +1006,9 @@
         flex: 0 0 auto;
         font-size: 0.72rem;
         border-color: color-mix(in srgb, var(--color-hard) 45%, var(--color-border));
+    }
+    .cloud-file-discard-selected {
+        color: var(--color-hard);
     }
     .cloud-file-diff {
         min-width: 0;

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -2209,6 +2209,8 @@ func main() {
     let wysiwygEl: HTMLDivElement | null = null;
     let wysiwygDebounce: ReturnType<typeof setTimeout> | null = null;
     let wysiwygSourceFileId: string | null = null;
+    // Markdown-to-HTML rendering is lossy, so only serialize after a real edit.
+    let wysiwygDirty = false;
     let lastActiveTabFileId: string | null = null;
     let showLinkInput = false;
     let linkUrl = '';
@@ -2254,6 +2256,7 @@ func main() {
         prepareTaskListCheckboxes(wysiwygEl);
         ensureTrailingEmptyLine(wysiwygEl);
         resolvePastedImages(wysiwygEl);
+        wysiwygDirty = false;
     }
 
     async function enterPreviewEditMode(force = false) {
@@ -2279,6 +2282,7 @@ func main() {
     }
 
     function handleWysiwygInput() {
+        wysiwygDirty = true;
         removeOrphanCodeWrappers();
         healTaskListStructure();
         if (wysiwygEl?.querySelector('li input[type="checkbox"][disabled]')) {
@@ -3291,6 +3295,7 @@ func main() {
             if (fakeLink) deletePastedImage(fakeLink);
             deleteBtn.closest(`.${THUMB_WRAPPER_CLASS}`)?.remove();
             ensureTrailingEmptyLine(wysiwygEl);
+            wysiwygDirty = true;
             commitWysiwygEdits();
             return;
         }
@@ -3352,7 +3357,7 @@ func main() {
             clearTimeout(wysiwygDebounce);
             wysiwygDebounce = null;
         }
-        if (!previewEditMode || !wysiwygEl || !wysiwygSourceFileId) return;
+        if (!previewEditMode || !wysiwygEl || !wysiwygSourceFileId || !wysiwygDirty) return;
         removeOrphanCodeWrappers();
         healTaskListStructure();
         prepareTaskListCheckboxes(wysiwygEl);
@@ -3368,6 +3373,7 @@ func main() {
             }
             return { ...s, [fkey]: JSON.stringify(files) };
         });
+        wysiwygDirty = false;
     }
 
     function handleCloudFileDiscard(event: Event) {


### PR DESCRIPTION
## Summary

- Add checkbox selection with bulk Push selected and Discard selected actions.
- Merge selected changes into cloud without overwriting unselected data.
- Prevent untouched WYSIWYG documents from being rewritten during cloud flushes.
- Add regression coverage for selective sync and WYSIWYG discard.

## Verification

- `npm test -- --run`
- `npm run build`
- `npx playwright test e2e/playground-markdown.test.ts --grep "discarding an active WYSIWYG file"`
- `npm run test:e2e -- e2e/cloud-sync.test.ts`

`npm run check` remains blocked by existing unrelated diagnostics in the repository.