### PR TITLE
fix: disable macOS desktop trackpad zoom

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -93,7 +93,9 @@ fn create_window(app: &tauri::AppHandle, url: tauri::Url) -> tauri::Result<()> {
         .inner_size(1400.0, 900.0)
         .min_inner_size(300.0, 300.0)
         .center()
-        .zoom_hotkeys_enabled(true)
+        // The macOS polyfill also treats trackpad pinch events as page zoom.
+        // Whiteboard provides its own canvas zoom handling.
+        .zoom_hotkeys_enabled(!cfg!(target_os = "macos"))
         .on_navigation(move |url| {
             if url.origin().ascii_serialization() == allowed_origin {
                 true

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,15 +3,54 @@
 	import { onMount } from 'svelte';
 	import AppDialog from '$lib/components/AppDialog.svelte';
 	import { startCloudSync, stopCloudSync } from '$lib/cloudSync';
+	import { isDesktopRuntime } from '$lib/firebaseSettings';
 	import favicon from '$lib/assets/favicon.svg';
 	import DemoBanner from '$lib/components/DemoBanner.svelte';
 	import '../app.css';
 
 	let { children, data } = $props();
 
+	let zoom = 1;
+
+	function isMacOS(): boolean {
+		return /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+	}
+
+	async function handleZoomShortcut(event: KeyboardEvent): Promise<void> {
+		if (!event.metaKey || event.ctrlKey || event.altKey) return;
+
+		const zoomIn = event.key === '+' || event.key === '=' || event.code === 'Equal';
+		const zoomOut = event.key === '-' || event.code === 'Minus';
+		const resetZoom = event.key === '0' || event.code === 'Digit0';
+		if (!zoomIn && !zoomOut && !resetZoom) return;
+
+		event.preventDefault();
+		event.stopPropagation();
+
+		if (resetZoom) {
+			zoom = 1;
+		} else if (zoomIn) {
+			zoom = Math.min(10, zoom + 0.2);
+		} else {
+			zoom = Math.max(0.2, zoom - 0.2);
+		}
+
+		const { getCurrentWebview } = await import('@tauri-apps/api/webview');
+		await getCurrentWebview().setZoom(zoom);
+	}
+
 	onMount(() => {
 		void startCloudSync();
 		return stopCloudSync;
+	});
+
+	onMount(() => {
+		if (!isDesktopRuntime() || !isMacOS()) return;
+
+		// Tauri disables its native mousewheel zoom polyfill on macOS. Keep the
+		// keyboard shortcut available without affecting Whiteboard's canvas zoom.
+		window.addEventListener('keydown', handleZoomShortcut, true);
+		return () => window.removeEventListener('keydown', handleZoomShortcut, true);
 	});
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -207,47 +207,8 @@
             }
         }
 
-        let zoom = 1;
-    
-        const handleZoomShortcut = async (event: KeyboardEvent) => {
-          if (!event.metaKey || event.ctrlKey || event.altKey) return;
-    
-          const zoomIn =
-            event.key === '+' ||
-            event.key === '=' ||
-            event.code === 'Equal';
-    
-          const zoomOut =
-            event.key === '-' ||
-            event.code === 'Minus';
-    
-          const resetZoom = event.key === '0' || event.code === 'Digit0';
-    
-          if (!zoomIn && !zoomOut && !resetZoom) return;
-    
-          event.preventDefault();
-          event.stopPropagation();
-    
-          if (resetZoom) {
-            zoom = 1;
-          } else if (zoomIn) {
-            zoom = Math.min(10, zoom + 0.2);
-          } else {
-            zoom = Math.max(0.2, zoom - 0.2);
-          }
-    
-          const { getCurrentWebview } =
-            await import('@tauri-apps/api/webview');
-    
-          await getCurrentWebview().setZoom(zoom);
-        };
-    
-        // Capture phase helps when editors/components intercept the shortcut.
-        window.addEventListener('keydown', handleZoomShortcut, true);
-
         return () => {
             window.removeEventListener("click", handleClickOutside);
-            window.removeEventListener('keydown', handleZoomShortcut, true);
         };
     });
 


### PR DESCRIPTION
## Summary
- disable Tauri's macOS page-zoom polyfill so trackpad pinch does not zoom the desktop UI
- preserve Cmd +/-/0 keyboard zoom shortcuts across desktop routes
- retain Whiteboard's canvas wheel and gesture zoom behavior

## Validation
- `cargo check`
- `npm test -- --run`
- `npm run build`
- targeted Whiteboard Playwright test