### PR TITLE
fix: clear whiteboard activity state when tab closes

### DIFF
--- a/e2e/playground-tabs.test.ts
+++ b/e2e/playground-tabs.test.ts
@@ -88,3 +88,29 @@ test('recent whiteboards use the whiteboard icon', async ({ page }) => {
   await expect(card).toHaveCount(1);
   await expect(card.locator('svg[viewBox="0 0 24 24"]')).toHaveCount(1);
 });
+
+test('closing the last whiteboard tab clears its activity state', async ({ page }) => {
+  await page.goto('/playground');
+  await page.evaluate(() => {
+    const files = [
+      {
+        fileId: 'whiteboard',
+        fileName: 'Whiteboard',
+        language: 'plaintext',
+        content: '',
+        isActive: false,
+        order: 0,
+        isOpen: true,
+        type: 'whiteboard',
+        lastUpdated: Date.now()
+      }
+    ];
+    localStorage.setItem('files', JSON.stringify({ playground: JSON.stringify(files) }));
+  });
+  await page.reload();
+
+  const whiteboardButton = page.locator('button[aria-label="Whiteboard"]');
+  await expect(whiteboardButton).toHaveClass(/active/);
+  await page.locator('.tab', { hasText: 'Whiteboard' }).locator('.tab-close').click();
+  await expect(whiteboardButton).not.toHaveClass(/active/);
+});

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -4676,7 +4676,7 @@ func main() {
         </Tooltip>
         <Tooltip text="Whiteboard" pos="right">
             <button
-                class="activity-icon {activeTab?.type === 'whiteboard' ? 'active' : ''}"
+                class="activity-icon {activeTab?.type === 'whiteboard' && activeTab.isOpen ? 'active' : ''}"
                 on:click={openWhiteboard}
                 aria-label="Whiteboard"
             >


### PR DESCRIPTION
## Summary
- clear the whiteboard activity icon when the closed whiteboard is the last open tab
- add an end-to-end regression test for the close interaction

## Testing
- `npm run test:e2e -- e2e/playground-tabs.test.ts` (3 passed)
- `npm run check` (existing unrelated TypeScript diagnostics remain)