### PR TITLE
feat: add Notion-style code block actions with undoable delete

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -411,6 +411,7 @@ test('WYSIWYG code blocks have a working copy button', async ({ page }) => {
   await page.getByRole('button', { name: 'WYSIWYG' }).click();
   const editable = page.locator('.wysiwyg-editing');
   const copyButton = editable.locator('.md-code-copy .copy-code-button');
+  await editable.locator('.code-block-wrapper').first().hover();
   await expect(copyButton).toBeVisible();
 
   // Copying must not modify the stored markdown
@@ -431,20 +432,25 @@ test('WYSIWYG code blocks have a language autocomplete and syntax highlighting',
 
   await page.getByRole('button', { name: 'WYSIWYG' }).click();
   const editable = page.locator('.wysiwyg-editing');
-  const languageInput = editable.locator('.code-language-input');
-  await expect(languageInput).toHaveValue('python');
-  await expect(languageInput).toHaveAttribute('list', 'wysiwyg-code-languages');
+
+  const wrapper = editable.locator('.code-block-wrapper').first();
+  await wrapper.hover();
+
+  const langBtn = wrapper.locator('.code-lang-btn');
+  await expect(langBtn).toContainText('Python');
   await expect(editable.locator('.hl-keyword')).toContainText('if');
   await expect(editable.locator('.hl-string').filter({ hasText: '"ok"' })).toBeVisible();
 
-  const languageOptions = await page.locator('#wysiwyg-code-languages option').evaluateAll((options) =>
-    options.map((option) => option.getAttribute('value'))
-  );
-  expect(languageOptions).toEqual(expect.arrayContaining(['javascript', 'typescript', 'python', 'java', 'cpp', 'rust', 'go', 'sql', 'bash']));
+  await langBtn.click();
+  const popover = page.locator('.lang-picker-popover');
+  await expect(popover).toBeVisible();
 
-  await languageInput.fill('javascript');
+  const searchInput = popover.locator('.lang-search-input');
+  await searchInput.fill('javascript');
+  await page.keyboard.press('Enter');
+
   await expect.poll(() => getMarkdownContent(page)).toContain('```javascript');
-  await expect(languageInput).toHaveValue('javascript');
+  await expect(langBtn).toContainText('JavaScript');
   await expect(editable.locator('.hl-keyword')).toContainText('if');
 });
 
@@ -466,6 +472,8 @@ test('WYSIWYG turns an exact three-backtick line into a code block', async ({ pa
   await page.keyboard.press('Enter');
   await page.keyboard.type('```');
   await expect(editable.locator('pre')).toHaveCount(1);
+  const codeBlockWrapper = editable.locator('.code-block-wrapper').first();
+  await codeBlockWrapper.hover();
   await expect(editable.locator('.md-code-copy .copy-code-button')).toBeVisible();
   await expect.poll(async () => (await getMarkdownContent(page))?.match(/^```$/gm)?.length ?? 0).toBe(2);
 
@@ -475,6 +483,7 @@ test('WYSIWYG turns an exact three-backtick line into a code block', async ({ pa
   await expect.poll(async () => (await getMarkdownContent(page))?.match(/^```$/gm)?.length ?? 0).toBe(2);
 
   // The copy button copies the bare <pre> content (no <code> child in WYSIWYG blocks)
+  await codeBlockWrapper.hover();
   await editable.locator('.md-code-copy .copy-code-button').click();
   await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).toContain('const y = 2;');
   await expect.poll(() => page.evaluate(() => navigator.clipboard.readText())).not.toContain('\u200B');
@@ -482,6 +491,53 @@ test('WYSIWYG turns an exact three-backtick line into a code block', async ({ pa
   await page.getByRole('button', { name: 'Preview' }).click();
   const preview = page.locator('.markdown-preview:not(.wysiwyg-editing)');
   await expect(preview.locator('code')).toHaveText('const y = 2;');
+});
+
+test('WYSIWYG deletes a code block from the trash button and ctrl+z restores it', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('```js\nconst a = 1;\n```');
+  await expect.poll(() => getMarkdownContent(page)).toContain('```js');
+
+  await page.getByRole('button', { name: 'WYSIWYG' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  const wrapper = editable.locator('.code-block-wrapper').first();
+  await wrapper.hover();
+  await expect(editable.locator('.delete-code-button')).toBeVisible();
+
+  // The trash button removes the block immediately (no confirmation dialog)
+  await editable.locator('.delete-code-button').click();
+  await expect(editable.locator('pre')).toHaveCount(0);
+  await expect.poll(() => getMarkdownContent(page)).not.toContain('```js');
+
+  // ctrl+z (undo) restores the code block and its markdown
+  await editable.locator('> p:last-child').click();
+  await page.keyboard.press('ControlOrMeta+z');
+  await expect(editable.locator('pre')).toHaveCount(1);
+  await expect(editable.locator('pre')).toContainText('const a = 1');
+  await expect.poll(() => getMarkdownContent(page)).toContain('```js');
+
+  // Recreate a code block so the preview can be checked too
+  await editable.locator('> p:last-child').click();
+  await page.keyboard.press('Enter');
+  await page.keyboard.type('```');
+  await page.keyboard.type('const b = 2;');
+  await expect.poll(() => getMarkdownContent(page)).toMatch(/^```\nconst b = 2;\n```$/m);
+
+  // The trash button also works from the read-only preview (now 2 blocks)
+  await page.getByRole('button', { name: 'Preview' }).click();
+  const preview = page.locator('.markdown-preview:not(.wysiwyg-editing)');
+  await expect(preview.locator('code')).toHaveCount(2);
+  await preview.locator('.code-block-wrapper').first().hover();
+  await preview.locator('.delete-code-button').first().click();
+  const dialog = page.locator('.dialog-card');
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: 'Delete' }).click();
+  await expect(preview.locator('code')).toHaveCount(1);
+  await expect.poll(() => getMarkdownContent(page)).not.toContain('const a = 1');
+  await expect.poll(() => getMarkdownContent(page)).toContain('const b = 2');
 });
 
 test('WYSIWYG Enter stays inside a code block and only exits on an empty line', async ({ page }) => {

--- a/src/app.css
+++ b/src/app.css
@@ -374,49 +374,186 @@
 
 /* WYSIWYG code blocks keep their language outside the editable <pre>. */
 .md-code-copy > pre {
-  padding-top: 44px;
-}
-
-.md-code-copy .code-block-language {
-  position: absolute;
-  top: 8px;
-  left: 8px;
-  z-index: 10;
-  display: inline-flex;
-  align-items: center;
-}
-
-.md-code-copy .code-language-input {
-  width: 118px;
-  height: 28px;
-  padding: 2px 8px;
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  background: var(--color-surface);
-  color: var(--color-text-secondary);
-  font-family: var(--font-mono);
-  font-size: 0.75rem;
-  outline: none;
-}
-
-.md-code-copy .code-language-input::placeholder {
-  color: var(--color-text-secondary);
-  opacity: 0.8;
-}
-
-.md-code-copy .code-language-input:focus {
-  border-color: var(--color-highlight);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-highlight) 20%, transparent);
+  padding-top: 36px;
 }
 
 .code-block-actions {
   position: absolute;
   top: 8px;
   right: 8px;
-  display: flex;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px 4px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  z-index: 2;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease, background-color 0.15s ease;
+}
+
+.code-block-wrapper:hover .code-block-actions,
+.code-block-wrapper:focus-within .code-block-actions,
+.code-block-wrapper.lang-picker-active .code-block-actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.code-lang-picker {
+  display: inline-flex;
+  align-items: center;
+}
+
+.code-lang-btn {
+  display: inline-flex;
   align-items: center;
   gap: 4px;
-  z-index: 10;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 3px 6px;
+  color: var(--color-text-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.75rem;
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 1;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.code-lang-btn:hover {
+  background-color: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.code-lang-chevron {
+  opacity: 0.7;
+}
+
+.code-action-divider {
+  width: 1px;
+  height: 14px;
+  background-color: var(--color-border);
+  margin: 0 2px;
+}
+
+.copy-code-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 4px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  line-height: 1;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.copy-code-button:hover {
+  background-color: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+.delete-code-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  padding: 4px;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  line-height: 1;
+  transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.delete-code-button:hover {
+  background-color: color-mix(in srgb, var(--color-hard) 14%, transparent);
+  color: var(--color-hard);
+}
+
+/* Notion-style Language Picker Popover */
+.lang-picker-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: transparent;
+}
+
+.lang-picker-popover {
+  position: fixed;
+  z-index: 10000;
+  width: 220px;
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.08);
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.lang-picker-search {
+  padding: 2px;
+}
+
+.lang-search-input {
+  width: 100%;
+  padding: 6px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  outline: none;
+  box-sizing: border-box;
+}
+
+.lang-search-input:focus {
+  border-color: var(--color-highlight);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--color-highlight) 20%, transparent);
+}
+
+.lang-picker-list {
+  max-height: 220px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.lang-picker-option {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 6px 10px;
+  background: transparent;
+  border: none;
+  border-radius: 6px;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.82rem;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background-color 0.1s ease;
+}
+
+.lang-picker-option:hover {
+  background-color: var(--color-surface-hover);
+}
+
+.lang-check-icon {
+  color: var(--color-text);
 }
 
 .code-block-lang-label {

--- a/src/lib/utils/markdown.test.ts
+++ b/src/lib/utils/markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, highlightCodeHtml, isUrlLike, normalizeUrl, linkHtml, parsePlaygroundFileId, playgroundFileHref } from './markdown';
+import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, highlightCodeHtml, removeFencedCodeBlock, isUrlLike, normalizeUrl, linkHtml, parsePlaygroundFileId, playgroundFileHref } from './markdown';
 
 describe('markdown utils', () => {
     it('renders markdown with the interactive code-block renderer', () => {
@@ -117,6 +117,22 @@ describe('markdown utils', () => {
         expect(back).toContain('| A | B |');
         // Round-tripping is stable: md -> html -> md -> html -> md converges
         expect(htmlToMarkdown(renderMarkdownPlain(back))).toBe(back);
+    });
+
+    it('removes a matching fenced code block from markdown', () => {
+        const md = ['before', '', '```python', 'if True:', '    print("ok")', '```', '', 'after'].join('\n');
+        expect(removeFencedCodeBlock(md, 'python', 'if True:\n    print("ok")')).toBe('before\n\nafter');
+        // Non-matching language or content leaves the block untouched
+        expect(removeFencedCodeBlock(md, 'js', 'if True:\n    print("ok")')).toBe(md);
+        expect(removeFencedCodeBlock(md, 'python', 'else')).toBe(md);
+        // Longer fences (content containing backticks) still match
+        const backticks = ['a', '', '````', 'x`y', '````', '', 'b'].join('\n');
+        expect(removeFencedCodeBlock(backticks, '', 'x`y')).toBe('a\n\nb');
+        // Tilde fences and language-less blocks match too
+        const tilde = ['a', '', '~~~', 'z', '~~~', '', 'b'].join('\n');
+        expect(removeFencedCodeBlock(tilde, '', 'z')).toBe('a\n\nb');
+        // No fence at all returns the input unchanged
+        expect(removeFencedCodeBlock('plain text', '', 'plain')).toBe('plain text');
     });
 
     it('round-trips bare <pre> elements (WYSIWYG code-block button) to fenced code', () => {

--- a/src/lib/utils/markdown.ts
+++ b/src/lib/utils/markdown.ts
@@ -583,6 +583,14 @@ export function getCodeBlockLanguage(pre: HTMLElement): string {
     return normalizeCodeLanguage(languageClass?.slice('language-'.length));
 }
 
+export function getLanguageLabel(language: string | null | undefined): string {
+    const normalized = normalizeCodeLanguage(language);
+    if (!normalized) return 'Plain text';
+    const found = CODE_LANGUAGE_OPTIONS.find((opt) => opt.value === normalized);
+    if (found) return found.label;
+    return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
 /** Set a WYSIWYG block's language without changing its source text. */
 export function setCodeBlockLanguage(wrapper: HTMLElement, language: string): string {
     const normalized = normalizeCodeLanguage(language);
@@ -605,6 +613,10 @@ export function setCodeBlockLanguage(wrapper: HTMLElement, language: string): st
         }
     }
 
+    const langNameEl = wrapper.querySelector('.code-lang-name');
+    if (langNameEl) {
+        langNameEl.textContent = getLanguageLabel(normalized);
+    }
     const input = wrapper.querySelector(`.${CODE_LANGUAGE_INPUT_CLASS}`) as HTMLInputElement | null;
     if (input) {
         input.value = normalized;
@@ -623,9 +635,9 @@ export function highlightCodeBlocks(root: HTMLElement) {
     });
 }
 
-// Wraps every <pre> under root with a copy button. The button is
-// contenteditable="false" controls so they stay out of the editable content;
-// the <pre> itself remains editable.
+// Wraps every <pre> under root with a copy button and language selector. The
+// controls are contenteditable="false" so they stay out of the editable
+// content; the <pre> itself remains editable.
 export function wrapCodeBlocksWithCopy(root: HTMLElement) {
     const preElements = Array.from(root.querySelectorAll('pre'));
     for (const pre of preElements) {
@@ -643,41 +655,33 @@ export function wrapCodeBlocksWithCopy(root: HTMLElement) {
         if (language) wrapper.dataset.language = language;
         else delete wrapper.dataset.language;
 
-        if (!wrapper.querySelector(`.${CODE_LANGUAGE_WRAPPER_CLASS}`)) {
-            const languageWrapper = document.createElement('label');
-            languageWrapper.className = CODE_LANGUAGE_WRAPPER_CLASS;
-            languageWrapper.setAttribute('contenteditable', 'false');
-            languageWrapper.title = 'Code language';
-
-            const languageInput = document.createElement('input');
-            languageInput.type = 'text';
-            languageInput.className = CODE_LANGUAGE_INPUT_CLASS;
-            languageInput.setAttribute('contenteditable', 'false');
-            languageInput.setAttribute('autocomplete', 'off');
-            languageInput.setAttribute('spellcheck', 'false');
-            languageInput.setAttribute('aria-label', 'Code language');
-            languageInput.setAttribute('list', CODE_LANGUAGE_DATALIST_ID);
-            languageInput.placeholder = 'Language';
-            languageWrapper.appendChild(languageInput);
-            wrapper.insertBefore(languageWrapper, pre);
-        }
-        setCodeBlockLanguage(wrapper, language);
-
         let actions = wrapper.querySelector('.code-block-actions') as HTMLElement | null;
         if (!actions) {
             actions = document.createElement('div');
             actions.className = 'code-block-actions';
+            actions.setAttribute('contenteditable', 'false');
             wrapper.appendChild(actions);
         }
-        if (actions.querySelector('.copy-code-button')) continue;
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.className = 'copy-code-button';
-        btn.title = 'Copy code';
-        btn.setAttribute('aria-label', 'Copy code');
-        btn.setAttribute('contenteditable', 'false');
-        btn.innerHTML = '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>';
-        actions.appendChild(btn);
+
+        if (!actions.querySelector('.code-lang-btn')) {
+            actions.innerHTML = `
+                <div class="code-lang-picker">
+                    <button type="button" class="code-lang-btn" title="Select language" aria-label="Select language" contenteditable="false">
+                        <span class="code-lang-name">${getLanguageLabel(language)}</span>
+                        <svg class="code-lang-chevron" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="6 9 12 15 18 9"></polyline></svg>
+                    </button>
+                </div>
+                <div class="code-action-divider"></div>
+                <button type="button" class="copy-code-button" title="Copy code" aria-label="Copy code" contenteditable="false">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path></svg>
+                </button>
+                <div class="code-action-divider"></div>
+                <button type="button" class="delete-code-button" title="Delete code block" aria-label="Delete code block" contenteditable="false">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg>
+                </button>
+            `;
+        }
+        setCodeBlockLanguage(wrapper, language);
     }
     highlightCodeBlocks(root);
 }
@@ -724,6 +728,13 @@ export function getMarkdownRenderer(options?: MarkdownRenderOptions) {
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                         <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
                         <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                    </svg>
+                </button>
+                <div class="code-action-divider"></div>
+                <button class="delete-code-button" title="Delete code block" aria-label="Delete code block">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                        <polyline points="3 6 5 6 21 6"></polyline>
+                        <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
                     </svg>
                 </button>
             </div>
@@ -878,4 +889,56 @@ export function htmlToMarkdown(html: string): string {
     // keep repeated WYSIWYG round-trips stable. Also strip ZWSP caret anchors
     // inserted after contenteditable=false file mentions.
     return getTurndownService().turndown(html).replace(/\u200B/g, '').replace(/\s+$/, '');
+}
+
+// Removes the first fenced code block whose language and (trailing-newline
+// trimmed) content match, e.g. when the user deletes a code block from the
+// read-only preview. Longer fences (``` vs ````) and tilde fences are handled;
+// non-matching blocks are left untouched. Returns the original string when no
+// block matched.
+export function removeFencedCodeBlock(markdown: string, language: string, content: string): string {
+    const normalizedLang = normalizeCodeLanguage(language);
+    const normalizedContent = (content || '').replace(/\u200B/g, '').replace(/\n$/, '');
+    const lines = markdown.split('\n');
+    const kept: string[] = [];
+    let fenceChar = '';
+    let fenceLen = 0;
+    let blockLang = '';
+    let start = -1;
+    const body: string[] = [];
+    let removed = false;
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        const m = /^ {0,3}(`{3,}|~{3,})\s*([^\s`]*)\s*$/.exec(line);
+        if (start < 0) {
+            if (m) {
+                fenceChar = m[1][0];
+                fenceLen = m[1].length;
+                blockLang = normalizeCodeLanguage(m[2]);
+                start = i;
+                body.length = 0;
+            } else {
+                kept.push(line);
+            }
+            continue;
+        }
+        if (m && m[1][0] === fenceChar && m[1].length >= fenceLen) {
+            const blockContent = body.join('\n').replace(/\n$/, '');
+            const matches = blockLang === normalizedLang && blockContent === normalizedContent;
+            if (matches && !removed) {
+                removed = true;
+                // Also drop a single following blank line to avoid double spacing.
+                if (lines[i + 1] === '') i += 1;
+            } else {
+                kept.push(...lines.slice(start, i + 1));
+            }
+            start = -1;
+            body.length = 0;
+            continue;
+        }
+        body.push(line);
+    }
+    if (start >= 0) kept.push(...lines.slice(start));
+    return (removed ? kept.join('\n') : markdown).replace(/\n{3,}/g, '\n\n');
 }

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -19,7 +19,7 @@
     import fileStore, { isDotFileName, type FileEntry, fileSyncVersion } from '$lib/stores/fileStore.js';
     import userSettingsStorage, { type ThemeChoice, type ActivePanel } from '$lib/stores/userSettingsStorage';
     import { type ProgrammingLanguage } from '$lib/utils/util.js';
-    import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, wrapImageThumbnails, wrapCodeBlocksWithCopy, highlightCodeBlocks, setCodeBlockLanguage, ensureTrailingEmptyLine, ensureFileMentionCarets, prepareTaskListCheckboxes, isTaskListItem, isEmptyTaskListItem, createTaskCheckbox, ensureTaskCheckbox, ensureTaskItemCaretAnchor, removeTaskCheckbox, inlineCodeSpanHtml, INLINE_CODE_STYLE_MARKER, THUMB_WRAPPER_CLASS, THUMB_DELETE_CLASS, CODE_COPY_WRAPPER_CLASS, CODE_LANGUAGE_INPUT_CLASS, CODE_LANGUAGE_DATALIST_ID, CODE_LANGUAGE_OPTIONS, resolvePastedImages, isUrlLike, normalizeUrl, linkHtml, parsePlaygroundFileId, playgroundFileHref, fileMentionHtml, FILE_MENTION_CLASS } from '$lib/utils/markdown';
+    import { renderMarkdown, renderMarkdownPlain, htmlToMarkdown, removeFencedCodeBlock, wrapImageThumbnails, wrapCodeBlocksWithCopy, highlightCodeBlocks, getCodeBlockLanguage, setCodeBlockLanguage, normalizeCodeLanguage, ensureTrailingEmptyLine, ensureFileMentionCarets, prepareTaskListCheckboxes, isTaskListItem, isEmptyTaskListItem, createTaskCheckbox, ensureTaskCheckbox, ensureTaskItemCaretAnchor, removeTaskCheckbox, inlineCodeSpanHtml, INLINE_CODE_STYLE_MARKER, THUMB_WRAPPER_CLASS, THUMB_DELETE_CLASS, CODE_COPY_WRAPPER_CLASS, CODE_LANGUAGE_INPUT_CLASS, CODE_LANGUAGE_DATALIST_ID, CODE_LANGUAGE_OPTIONS, resolvePastedImages, isUrlLike, normalizeUrl, linkHtml, parsePlaygroundFileId, playgroundFileHref, fileMentionHtml, FILE_MENTION_CLASS } from '$lib/utils/markdown';
     import { storePastedImage, deletePastedImage, inlinePastedImageLinks } from '$lib/utils/imageStore';
     import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore/lite';
     import QRCode from 'qrcode';
@@ -2257,6 +2257,9 @@ func main() {
         ensureTrailingEmptyLine(wysiwygEl);
         resolvePastedImages(wysiwygEl);
         wysiwygDirty = false;
+        // A full re-render rebuilds the editor, so a snapshot of a deleted
+        // block's position is no longer valid.
+        deletedCodeBlockUndo = null;
     }
 
     async function enterPreviewEditMode(force = false) {
@@ -2281,7 +2284,72 @@ func main() {
         await enterPreviewEditMode(true);
     }
 
+    let activeLangPicker: {
+        wrapper: HTMLElement;
+        button: HTMLElement;
+        currentLang: string;
+        rect: DOMRect;
+    } | null = null;
+    let langSearchQuery = '';
+    let langSearchInputEl: HTMLInputElement | null = null;
+
+    $: filteredLanguages = CODE_LANGUAGE_OPTIONS.filter((opt) => {
+        if (!langSearchQuery.trim()) return true;
+        const q = langSearchQuery.trim().toLowerCase();
+        return opt.label.toLowerCase().includes(q) || opt.value.toLowerCase().includes(q);
+    });
+
+    function openLangPicker(btn: HTMLElement, wrapper: HTMLElement) {
+        const pre = wrapper.querySelector('pre');
+        const currentLang = pre ? getCodeBlockLanguage(pre) : (wrapper.dataset.language || '');
+        const rect = btn.getBoundingClientRect();
+        langSearchQuery = '';
+        activeLangPicker = { wrapper, button: btn, currentLang, rect };
+        wrapper.classList.add('lang-picker-active');
+        setTimeout(() => {
+            if (langSearchInputEl) langSearchInputEl.focus();
+        }, 20);
+    }
+
+    function closeLangPicker() {
+        if (activeLangPicker) {
+            activeLangPicker.wrapper.classList.remove('lang-picker-active');
+            activeLangPicker = null;
+        }
+    }
+
+    function selectCodeLanguage(langValue: string) {
+        if (!activeLangPicker) return;
+        const { wrapper } = activeLangPicker;
+        setCodeBlockLanguage(wrapper, langValue);
+        closeLangPicker();
+        // Keep the action bar visible for a moment after picking a language so
+        // the user can see the result, then fade back to hover-only.
+        wrapper.classList.add('lang-picker-active');
+        setTimeout(() => {
+            if (wrapper.isConnected) wrapper.classList.remove('lang-picker-active');
+        }, 2500);
+        handleWysiwygInput();
+    }
+
+    function handleLangSearchKeyDown(e: KeyboardEvent) {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            closeLangPicker();
+        } else if (e.key === 'Enter') {
+            e.preventDefault();
+            if (filteredLanguages.length > 0) {
+                selectCodeLanguage(filteredLanguages[0].value);
+            } else if (langSearchQuery.trim()) {
+                selectCodeLanguage(langSearchQuery.trim());
+            }
+        }
+    }
+
     function handleWysiwygInput(event?: Event) {
+        // Any real edit supersedes the last code-block deletion, so the
+        // one-level undo no longer applies (native undo takes over).
+        deletedCodeBlockUndo = null;
         const target = event?.target;
         if (target instanceof HTMLInputElement && target.classList.contains(CODE_LANGUAGE_INPUT_CLASS)) {
             const wrapper = target.closest(`.${CODE_COPY_WRAPPER_CLASS}`) as HTMLElement | null;
@@ -2579,6 +2647,7 @@ func main() {
                 wrapper.remove();
                 return;
             }
+            if (activeLangPicker && wrapper === activeLangPicker.wrapper) return;
             if (focusedLanguageInput && wrapper.contains(focusedLanguageInput)) return;
             if (caretNode && wrapper.contains(caretNode)) return;
             const hasText = Array.from(pres).some((p) => (p.textContent || '').replace(/\u200B/g, '').trim() !== '');
@@ -3341,8 +3410,32 @@ func main() {
     // clicking the thumbnail opens the full-size lightbox. Checkboxes toggle
     // via the native control + change handler.
     function handleWysiwygClick(event: MouseEvent) {
-        if (tryOpenPlaygroundFileLink(event, wysiwygEl)) return;
         const target = event.target as HTMLElement;
+        const langBtn = target.closest('.code-lang-btn') as HTMLElement | null;
+        if (langBtn) {
+            event.preventDefault();
+            event.stopPropagation();
+            const wrapper = langBtn.closest(`.${CODE_COPY_WRAPPER_CLASS}`) as HTMLElement | null;
+            if (wrapper) {
+                if (activeLangPicker && activeLangPicker.button === langBtn) {
+                    closeLangPicker();
+                } else {
+                    openLangPicker(langBtn, wrapper);
+                }
+            }
+            return;
+        }
+        const deleteCodeBtn = target.closest('.delete-code-button') as HTMLElement | null;
+        if (deleteCodeBtn && wysiwygEl?.contains(deleteCodeBtn)) {
+            event.preventDefault();
+            const wrapper = deleteCodeBtn.closest(`.${CODE_COPY_WRAPPER_CLASS}`) as HTMLElement | null;
+            if (wrapper) deleteWysiwygCodeBlock(wrapper);
+            return;
+        }
+        if (activeLangPicker && !target.closest('.lang-picker-popover')) {
+            closeLangPicker();
+        }
+        if (tryOpenPlaygroundFileLink(event, wysiwygEl)) return;
         if (target instanceof HTMLInputElement && target.classList.contains(CODE_LANGUAGE_INPUT_CLASS)) return;
         removeOrphanCodeWrappers();
         if (target instanceof HTMLInputElement && target.type === 'checkbox' && wysiwygEl?.contains(target)) {
@@ -3371,8 +3464,32 @@ func main() {
     // Click handling in the read-only markdown preview.
     function handlePreviewClick(event: MouseEvent) {
         const container = event.currentTarget as HTMLElement;
-        if (tryOpenPlaygroundFileLink(event, container)) return;
         const target = event.target as HTMLElement;
+        const langBtn = target.closest('.code-lang-btn') as HTMLElement | null;
+        if (langBtn) {
+            event.preventDefault();
+            event.stopPropagation();
+            const wrapper = langBtn.closest(`.${CODE_COPY_WRAPPER_CLASS}`) as HTMLElement | null;
+            if (wrapper) {
+                if (activeLangPicker && activeLangPicker.button === langBtn) {
+                    closeLangPicker();
+                } else {
+                    openLangPicker(langBtn, wrapper);
+                }
+            }
+            return;
+        }
+        const deleteCodeBtn = target.closest('.delete-code-button') as HTMLElement | null;
+        if (deleteCodeBtn && container.contains(deleteCodeBtn)) {
+            event.preventDefault();
+            const wrapper = deleteCodeBtn.closest('.code-block-wrapper') as HTMLElement | null;
+            if (wrapper) void deletePreviewCodeBlock(wrapper);
+            return;
+        }
+        if (activeLangPicker && !target.closest('.lang-picker-popover')) {
+            closeLangPicker();
+        }
+        if (tryOpenPlaygroundFileLink(event, container)) return;
         const deleteBtn = target.closest(`.${THUMB_DELETE_CLASS}`) as HTMLElement | null;
         if (deleteBtn && container.contains(deleteBtn)) {
             event.preventDefault();
@@ -3406,6 +3523,85 @@ func main() {
                 .replace(pattern, '')
                 .replace(/[ \t]+\n/g, '\n')
                 .replace(/\n{3,}/g, '\n\n');
+            if (next !== sourceEntry.content) {
+                sourceEntry.content = next;
+                sourceEntry.lastUpdated = Date.now();
+            }
+            return { ...s, [fkey]: JSON.stringify(files) };
+        });
+    }
+
+    // Deletes a code block from the WYSIWYG editor. The removed wrapper is
+    // snapshotted so a single ctrl/cmd+z (handleWysiwygKeydown) restores the
+    // block; the browser's native undo stack can't restore a block removed by
+    // JS, so this is a one-level undo that mirrors a manual delete.
+    let deletedCodeBlockUndo: { html: string; index: number } | null = null;
+    function deleteWysiwygCodeBlock(wrapper: HTMLElement) {
+        if (!wysiwygEl || !wrapper.isConnected) return;
+        if (activeLangPicker && activeLangPicker.wrapper === wrapper) closeLangPicker();
+        const children = Array.from(wysiwygEl.children);
+        deletedCodeBlockUndo = {
+            html: wrapper.outerHTML,
+            index: children.indexOf(wrapper)
+        };
+        wrapper.remove();
+        ensureTrailingEmptyLine(wysiwygEl);
+        wysiwygDirty = true;
+        commitWysiwygEdits();
+        // Bring focus back to the editor so the next ctrl/cmd+z is handled
+        // here (the trash button is contenteditable=false and would keep it).
+        wysiwygEl.focus();
+    }
+
+    // Restores the most recently deleted code block. Returns true when a
+    // block was restored (and the native undo must not run).
+    function undoWysiwygCodeBlockDelete(): boolean {
+        if (!wysiwygEl || !deletedCodeBlockUndo) return false;
+        const { html, index } = deletedCodeBlockUndo;
+        deletedCodeBlockUndo = null;
+        const holder = document.createElement('div');
+        holder.innerHTML = html;
+        const el = holder.firstElementChild as HTMLElement | null;
+        if (!el) return false;
+        wysiwygEl.insertBefore(el, wysiwygEl.children[index] ?? null);
+        wrapCodeBlocksWithCopy(wysiwygEl);
+        const pre = el.querySelector('pre');
+        if (pre) {
+            const range = document.createRange();
+            range.selectNodeContents(pre);
+            range.collapse(false);
+            const selection = window.getSelection();
+            selection?.removeAllRanges();
+            selection?.addRange(range);
+        }
+        wysiwygEl.focus();
+        handleWysiwygInput();
+        return true;
+    }
+
+    // Deletes a code block from the source markdown when its trash button is
+    // clicked in the read-only preview.
+    async function deletePreviewCodeBlock(wrapper: HTMLElement) {
+        const sourceFileId = activeTab?.type === 'preview' ? activeTab.sourceFileId : null;
+        if (!sourceFileId) return;
+        const confirmed = await showConfirm('Delete this code block? This action cannot be undone.', {
+            title: 'Delete code block',
+            confirmLabel: 'Delete',
+            tone: 'danger'
+        });
+        if (!confirmed) return;
+        const pre = wrapper.querySelector('pre');
+        const code = pre?.firstElementChild?.tagName === 'CODE' ? (pre.firstElementChild as HTMLElement) : null;
+        const language = code
+            ? (Array.from(code.classList).find((name) => name.startsWith('language-'))?.slice('language-'.length) ?? '')
+            : '';
+        const content = code ? (code.textContent || '') : (pre?.textContent || '');
+        const fkey = fileKey();
+        fileStore.update((s) => {
+            const files = JSON.parse(s[fkey] || '[]') as FileEntry[];
+            const sourceEntry = files.find((f) => f.fileId === sourceFileId && f.language === 'markdown');
+            if (!sourceEntry) return s;
+            const next = removeFencedCodeBlock(sourceEntry.content, language, content);
             if (next !== sourceEntry.content) {
                 sourceEntry.content = next;
                 sourceEntry.lastUpdated = Date.now();
@@ -3801,6 +3997,14 @@ func main() {
     // code, Ctrl/Cmd+K insert link. Also navigates the @-mention popup and
     // deletes file mentions atomically on Backspace/Delete.
     function handleWysiwygKeydown(e: KeyboardEvent) {
+        // ctrl/cmd+z after a code-block deletion restores the block (one
+        // level, before the browser's own undo stack gets a chance to undo
+        // the earlier typing instead).
+        if ((e.metaKey || e.ctrlKey) && !e.shiftKey && e.key.toLowerCase() === 'z' && deletedCodeBlockUndo) {
+            e.preventDefault();
+            undoWysiwygCodeBlockDelete();
+            return;
+        }
         if (showMentionPopup) {
             if (e.key === 'ArrowDown') {
                 e.preventDefault();
@@ -5481,6 +5685,54 @@ func main() {
                     <!-- svelte-ignore a11y-no-static-element-interactions -->
                     <div class="markdown-preview markdown-body" bind:this={previewEl} on:click={handlePreviewClick}>
                         {@html previewHtml}
+                    </div>
+                {/if}
+
+                {#if activeLangPicker}
+                    <!-- svelte-ignore a11y-click-events-have-key-events -->
+                    <!-- svelte-ignore a11y-no-static-element-interactions -->
+                    <div class="lang-picker-backdrop" on:click={closeLangPicker}></div>
+                    <div
+                        class="lang-picker-popover"
+                        style="position: fixed; top: {activeLangPicker.rect.bottom + 4}px; left: {Math.max(8, Math.min((typeof window !== 'undefined' ? window.innerWidth : 1000) - 230, activeLangPicker.rect.right - 220))}px;"
+                        role="dialog"
+                        aria-label="Select code block language"
+                    >
+                        <div class="lang-picker-search">
+                            <input
+                                type="text"
+                                class="lang-search-input"
+                                placeholder="Search for a language..."
+                                bind:value={langSearchQuery}
+                                bind:this={langSearchInputEl}
+                                on:keydown={handleLangSearchKeyDown}
+                            />
+                        </div>
+                        <div class="lang-picker-list">
+                            {#each filteredLanguages as option}
+                                <button
+                                    type="button"
+                                    class="lang-picker-option {normalizeCodeLanguage(option.value) === normalizeCodeLanguage(activeLangPicker.currentLang) ? 'selected' : ''}"
+                                    on:click={() => selectCodeLanguage(option.value)}
+                                >
+                                    <span class="lang-option-label">{option.label}</span>
+                                    {#if normalizeCodeLanguage(option.value) === normalizeCodeLanguage(activeLangPicker.currentLang)}
+                                        <svg class="lang-check-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                            <polyline points="20 6 9 17 4 12"></polyline>
+                                        </svg>
+                                    {/if}
+                                </button>
+                            {/each}
+                            {#if filteredLanguages.length === 0 && langSearchQuery.trim()}
+                                <button
+                                    type="button"
+                                    class="lang-picker-option custom-lang"
+                                    on:click={() => selectCodeLanguage(langSearchQuery.trim())}
+                                >
+                                    <span class="lang-option-label">Use "{langSearchQuery.trim()}"</span>
+                                </button>
+                            {/if}
+                        </div>
                     </div>
                 {/if}
             {:else if CodeEditor}


### PR DESCRIPTION
## Summary
Redesigns the WYSIWYG code-block action bar in the Notion style (language picker + copy + delete in a top-right pill, shown on hover/focus) and makes deletion undoable via Ctrl/Cmd+Z instead of a confirmation dialog.

## Changes
- **Notion-style action bar**: language button, copy, and trash buttons grouped in a hover-only pill (`.code-block-actions`) with a custom searchable language popover (replaces the free-form input + datalist)
- **Undoable delete**: trash button snapshots the wrapper HTML and removes it instantly; Ctrl/Cmd+Z restores the block (one-level undo, cleared on any other edit or re-render). Preview mode keeps the confirmation dialog since it has no undo
- **Post-pick popover**: the action bar stays visible ~2.5s after selecting a language, then fades back to hover-only
- Added `removeFencedCodeBlock` + `getLanguageLabel` in markdown.ts; `getCodeBlockLanguage`/code-language cleanup

## Tests
- 6 code-block Playwright e2e tests pass (incl. new delete + Ctrl+Z undo test)
- 115 unit tests pass
- `npm run build` clean