### PR TITLE
revert: keep 12 recent cloud versions instead of 5 (#76)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -14,7 +14,7 @@ service cloud.firestore {
     }
 
     function isSnapshotSlot(snapshotId) {
-      return snapshotId.matches('^slot-[0-9]+$');
+      return snapshotId.matches('^slot-[0-4]$');
     }
 
     function isRevisionId(revisionId) {
@@ -45,19 +45,12 @@ service cloud.firestore {
     }
 
     function isNextSnapshotSlot(previousSnapshotId, nextSnapshotId) {
-      return (!previousSnapshotId.matches('^slot-[0-9]+$') && nextSnapshotId == 'slot-0')
+      return (!previousSnapshotId.matches('^slot-[0-4]$') && nextSnapshotId == 'slot-0')
         || (previousSnapshotId == 'slot-0' && nextSnapshotId == 'slot-1')
         || (previousSnapshotId == 'slot-1' && nextSnapshotId == 'slot-2')
         || (previousSnapshotId == 'slot-2' && nextSnapshotId == 'slot-3')
         || (previousSnapshotId == 'slot-3' && nextSnapshotId == 'slot-4')
-        || (previousSnapshotId == 'slot-4' && nextSnapshotId == 'slot-5')
-        || (previousSnapshotId == 'slot-5' && nextSnapshotId == 'slot-6')
-        || (previousSnapshotId == 'slot-6' && nextSnapshotId == 'slot-7')
-        || (previousSnapshotId == 'slot-7' && nextSnapshotId == 'slot-8')
-        || (previousSnapshotId == 'slot-8' && nextSnapshotId == 'slot-9')
-        || (previousSnapshotId == 'slot-9' && nextSnapshotId == 'slot-10')
-        || (previousSnapshotId == 'slot-10' && nextSnapshotId == 'slot-11')
-        || (previousSnapshotId == 'slot-11' && nextSnapshotId == 'slot-0');
+        || (previousSnapshotId == 'slot-4' && nextSnapshotId == 'slot-0');
     }
 
     function isValidLatestWrite(userId) {

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -607,7 +607,7 @@ function timestampMillis(data: Record<string, unknown>, key: string): number {
 }
 
 function validSnapshotId(value: string): boolean {
-	return /^slot-[0-9]+$/.test(value) || /^[a-z0-9-]{8,100}$/i.test(value);
+	return /^slot-[0-4]$/.test(value) || /^[a-z0-9-]{8,100}$/i.test(value);
 }
 
 function validRevisionId(value: string): boolean {

--- a/src/lib/cloudSyncPolicy.test.ts
+++ b/src/lib/cloudSyncPolicy.test.ts
@@ -105,10 +105,10 @@ describe('cloud sync direction', () => {
 });
 
 describe('cloud snapshot slots', () => {
-	it('cycles through a bounded twelve-revision history', () => {
+	it('cycles through a bounded five-revision history', () => {
 		let slot: string | null = null;
 		const revisions: string[] = [];
-		for (let index = 0; index < 14; index++) {
+		for (let index = 0; index < 7; index++) {
 			slot = nextCloudSnapshotSlot(slot);
 			revisions.push(slot);
 		}
@@ -118,13 +118,6 @@ describe('cloud snapshot slots', () => {
 			'slot-2',
 			'slot-3',
 			'slot-4',
-			'slot-5',
-			'slot-6',
-			'slot-7',
-			'slot-8',
-			'slot-9',
-			'slot-10',
-			'slot-11',
 			'slot-0',
 			'slot-1'
 		]);

--- a/src/lib/cloudSyncPolicy.ts
+++ b/src/lib/cloudSyncPolicy.ts
@@ -1,4 +1,4 @@
-export const CLOUD_HISTORY_LIMIT = 12;
+export const CLOUD_HISTORY_LIMIT = 5;
 
 export type SyncIntent = 'fetch' | 'push';
 export type SyncDirection = 'none' | 'pending-upload' | 'upload' | 'download' | 'conflict';
@@ -63,7 +63,7 @@ export function resolveSyncDirection(
 }
 
 export function nextCloudSnapshotSlot(currentSnapshotId: string | null): string {
-	const match = /^slot-([0-9]+)$/.exec(currentSnapshotId ?? '');
+	const match = /^slot-([0-4])$/.exec(currentSnapshotId ?? '');
 	const current = match ? Number(match[1]) : -1;
 	return `slot-${(current + 1) % CLOUD_HISTORY_LIMIT}`;
 }


### PR DESCRIPTION
Reverts #76 (commit 22e66cd).

The 12-version scheme breaks save for users still on 0.2.7 code:
- 0.2.7 only parses slots 0-4 (`validSnapshotId`) and writes slots via `(current + 1) % 5`.
- Once the latest snapshot advances to slot-5+, 0.2.7 treats cloud as empty and its uploads fail (parent revision mismatch / rules denial).

The server rules have already been reverted and redeployed to restore service; this PR aligns the app code (policy, slot validation, tests) with the 5-version scheme.