### PR TITLE
fix: fade recent-file dotfiles and limit WYSIWYG select-all to code blocks

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -599,6 +599,40 @@ test('WYSIWYG Enter stays inside a code block and only exits on an empty line', 
   await expect.poll(async () => (await getMarkdownContent(page))?.match(/^```$/gm)?.length ?? 0).toBe(4);
 });
 
+test('WYSIWYG Ctrl+A inside a code block selects only the code', async ({ page }) => {
+  await openMarkdownPlayground(page);
+
+  await page.locator('.monaco-editor .view-lines').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type('before');
+  await expect.poll(() => getMarkdownContent(page)).toBe('before');
+
+  await page.getByRole('button', { name: 'WYSIWYG' }).click();
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+
+  await editable.locator('> p:last-child').click();
+  await page.keyboard.press('Enter');
+  await page.keyboard.type('```');
+  await page.keyboard.type('old code');
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('Enter');
+  await page.keyboard.type('after');
+  await expect.poll(async () => (await getMarkdownContent(page)) ?? '').toContain('```\nold code\n```');
+  await expect.poll(async () => (await getMarkdownContent(page)) ?? '').toContain('after');
+
+  await editable.locator('pre').click();
+  await page.keyboard.press('ControlOrMeta+a');
+  const selected = await page.evaluate(() => (window.getSelection()?.toString() ?? '').replace(/\u200B/g, ''));
+  expect(selected).toBe('old code');
+
+  await page.keyboard.type('new code');
+  await expect.poll(async () => (await getMarkdownContent(page)) ?? '').toContain('before');
+  await expect.poll(async () => (await getMarkdownContent(page)) ?? '').toContain('```\nnew code\n```');
+  await expect.poll(async () => (await getMarkdownContent(page)) ?? '').toContain('after');
+  await expect.poll(async () => (await getMarkdownContent(page)) ?? '').not.toContain('old code');
+});
+
 test('WYSIWYG removes the copy button when the code block is deleted', async ({ page }) => {
   await openMarkdownPlayground(page);
 

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -2702,6 +2702,16 @@ func main() {
         return { start, end, total: total.length };
     }
 
+    function selectAllInWysiwygCodeBlock(pre: HTMLElement) {
+        const selection = window.getSelection();
+        if (!selection) return;
+        const range = document.createRange();
+        const code = pre.firstElementChild?.tagName === 'CODE' ? pre.firstElementChild : pre;
+        range.selectNodeContents(code);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+
     // Enter inside a code block: insert a real newline so the line stays part
     // of the same code block.
     function insertNewlineInPre() {
@@ -4255,6 +4265,18 @@ func main() {
 
         if (!e.metaKey && !e.ctrlKey) return;
         const key = e.key.toLowerCase();
+        if (key === 'a' && !e.shiftKey && !e.altKey) {
+            if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+            const pre = getPreFromSelection();
+            if (!pre) return;
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount === 0) return;
+            const end = selection.getRangeAt(0).endContainer;
+            if (end !== pre && !pre.contains(end)) return;
+            e.preventDefault();
+            selectAllInWysiwygCodeBlock(pre);
+            return;
+        }
         if (key === 'b' && !e.shiftKey && !e.altKey) {
             e.preventDefault();
             applyWysiwygCommand('bold');
@@ -5897,7 +5919,7 @@ func main() {
                             {#each recentFiles as file}
                                 <!-- svelte-ignore a11y-click-events-have-key-events -->
                                 <div
-                                    class="recent-file-card"
+                                    class="recent-file-card {isDotFileName(file.fileName) ? 'dotfile' : ''}"
                                     role="button"
                                     tabindex="0"
                                     on:click={() => activateTab(file.fileId)}
@@ -7155,6 +7177,9 @@ func main() {
     .recent-file-card:hover {
         background-color: rgba(255, 255, 255, 0.06);
         border-color: var(--color-text-secondary);
+    }
+    .recent-file-card.dotfile {
+        opacity: 0.6;
     }
     .recent-file-card-header {
         display: flex;


### PR DESCRIPTION
## Summary
- Fade dotfiles like `.keys` in the playground Recent Files grid to match Explorer opacity.
- Make Cmd/Ctrl+A inside a WYSIWYG code block select only that block's text instead of the whole document.

## Test plan
- [x] Open playground empty state with a recent `.keys` file and confirm it is faded like Explorer.
- [x] In WYSIWYG markdown, place the caret in a fenced code block and press Cmd/Ctrl+A — only the code is selected; surrounding markdown is unchanged.
- [ ] Run `e2e/playground-markdown.test.ts` coverage for the new select-all case.