### PR TITLE
fix: flush WYSIWYG edits reliably when closing the app

### DIFF
--- a/src/lib/components/Whiteboard.svelte
+++ b/src/lib/components/Whiteboard.svelte
@@ -288,7 +288,7 @@
 		window.addEventListener('keydown', handleKeyDown);
 		window.addEventListener('keyup', handleKeyUp);
 		window.addEventListener('hashchange', handleHashChange);
-		window.addEventListener('pagehide', saveBoardNow);
+		window.addEventListener('pagehide', handleBoardPageHide);
 		window.addEventListener(CLOUD_FLUSH_EVENT, saveBoardNow);
 		window.addEventListener('storage', reloadBoardFromStorage);
 		window.addEventListener(WHITEBOARD_RESTORED_EVENT, reloadBoardFromStorage);
@@ -310,7 +310,7 @@
 			window.removeEventListener('keydown', handleKeyDown);
 			window.removeEventListener('keyup', handleKeyUp);
 			window.removeEventListener('hashchange', handleHashChange);
-			window.removeEventListener('pagehide', saveBoardNow);
+			window.removeEventListener('pagehide', handleBoardPageHide);
 			window.removeEventListener(CLOUD_FLUSH_EVENT, saveBoardNow);
 			window.removeEventListener('storage', reloadBoardFromStorage);
 			window.removeEventListener(WHITEBOARD_RESTORED_EVENT, reloadBoardFromStorage);
@@ -510,8 +510,19 @@
 	}
 
 	function saveBoardNow(): void {
+		saveBoardImpl(false);
+	}
+
+	// pagehide is the one teardown event that fires reliably when the app
+	// window closes; force the save even during a cloud-restore window, since
+	// the restore's deferred-write resume never runs once the page is gone.
+	function handleBoardPageHide(): void {
+		saveBoardImpl(true);
+	}
+
+	function saveBoardImpl(force: boolean): void {
 		if (!mounted) return;
-		if (isCloudRestoreInProgress()) return;
+		if (isCloudRestoreInProgress() && !force) return;
 		if (saveTimer) clearTimeout(saveTimer);
 		saveTimer = undefined;
 		const board: StoredBoard = {

--- a/src/lib/progressBackup.ts
+++ b/src/lib/progressBackup.ts
@@ -95,6 +95,16 @@ export function resumeProgressStorageWrites(): void {
 	deferredStorageWrites.clear();
 }
 
+// Writes deferred storage writes straight to localStorage, bypassing the
+// cloud-restore guard. Used during page teardown (beforeunload/pagehide):
+// the restore window can never resume once the page is gone, so deferring
+// would silently drop the freshest edits.
+export function flushProgressStorageWrites(): void {
+	if (typeof window === 'undefined') return;
+	for (const [key, value] of deferredStorageWrites) localStorage.setItem(key, value);
+	deferredStorageWrites.clear();
+}
+
 function parseStoredValue(value: string): unknown {
 	try {
 		return JSON.parse(value);

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -14,7 +14,7 @@
     import { isDesktopRuntime } from '$lib/firebaseSettings';
     import { cloudSyncState } from '$lib/cloudSync';
     import { CLOUD_FILE_DISCARDED_EVENT, WHITEBOARD_FILE_ID, WORKSPACE_FILE_ID_PREFIX } from '$lib/cloudFileChange';
-    import { CLOUD_FLUSH_EVENT, isCloudRestoreInProgress, writeProgressStorageItem } from '$lib/progressBackup';
+    import { CLOUD_FLUSH_EVENT, isCloudRestoreInProgress, flushProgressStorageWrites, writeProgressStorageItem } from '$lib/progressBackup';
     import codeStore from '$lib/stores/codeStore.js';
     import fileStore, { isDotFileName, type FileEntry, fileSyncVersion } from '$lib/stores/fileStore.js';
     import userSettingsStorage, { type ThemeChoice, type ActivePanel } from '$lib/stores/userSettingsStorage';
@@ -5117,9 +5117,13 @@ func main() {
             }
         };
         const handleUnload = () => {
-            if (isCloudRestoreInProgress()) return;
+            // Never skip the final flush, even during a cloud-restore window:
+            // the restore defers storage writes until it resumes, which never
+            // happens once the page is torn down. Dropping the freshest edits
+            // is worse than re-serializing them.
             commitWysiwygEdits();
             saveCurrentViewState();
+            flushProgressStorageWrites();
         };
         const handleCloudFlush = () => {
             if (isCloudRestoreInProgress()) return;
@@ -5129,12 +5133,14 @@ func main() {
         document.addEventListener('click', handleDocClick);
         window.addEventListener('keydown', handleKeyDown);
         window.addEventListener('beforeunload', handleUnload);
+        window.addEventListener('pagehide', handleUnload);
         window.addEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
         window.addEventListener(CLOUD_FILE_DISCARDED_EVENT, handleCloudFileDiscard);
         return () => {
             document.removeEventListener('click', handleDocClick);
             window.removeEventListener('keydown', handleKeyDown);
             window.removeEventListener('beforeunload', handleUnload);
+            window.removeEventListener('pagehide', handleUnload);
             window.removeEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
             window.removeEventListener(CLOUD_FILE_DISCARDED_EVENT, handleCloudFileDiscard);
         };

--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -13,7 +13,7 @@
     import { consumeForkTransfer } from '$lib/forkTransfer';
     import { initFirebase, ensureAuthenticated } from '$lib/firebase';
     import { isDesktopRuntime } from '$lib/firebaseSettings';
-    import { CLOUD_FLUSH_EVENT, isCloudRestoreInProgress } from '$lib/progressBackup';
+    import { CLOUD_FLUSH_EVENT, isCloudRestoreInProgress, flushProgressStorageWrites } from '$lib/progressBackup';
     import codeStore from '$lib/stores/codeStore.js';
     import fileStore, { type FileEntry, fileSyncVersion } from '$lib/stores/fileStore.js';
     import { leftPaneWidthStore } from '$lib/stores/layoutStore';
@@ -685,8 +685,11 @@
             }
         };
         const handleUnload = () => {
-            if (isCloudRestoreInProgress()) return;
+            // Flush even during a cloud-restore window: deferred storage
+            // writes are only resumed while the page stays alive, so they
+            // would be silently dropped when the app closes.
             saveCurrentViewState();
+            flushProgressStorageWrites();
         };
         const handleCloudFlush = () => {
             if (!isCloudRestoreInProgress()) saveCurrentViewState();
@@ -696,6 +699,7 @@
         document.addEventListener('contextmenu', handleDocContextMenu);
         document.addEventListener('keydown', handleKeyDown);
         window.addEventListener('beforeunload', handleUnload);
+        window.addEventListener('pagehide', handleUnload);
         window.addEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
         window.addEventListener('resize', handleResize);
         return () => {
@@ -703,6 +707,7 @@
             document.removeEventListener('contextmenu', handleDocContextMenu);
             document.removeEventListener('keydown', handleKeyDown);
             window.removeEventListener('beforeunload', handleUnload);
+            window.removeEventListener('pagehide', handleUnload);
             window.removeEventListener(CLOUD_FLUSH_EVENT, handleCloudFlush);
             window.removeEventListener('resize', handleResize);
         };


### PR DESCRIPTION
## Problem

Occasionally, WYSIWYG content is lost when closing the app. Two bugs combine:

1. **`beforeunload` is unreliable in the Tauri webview (macOS WKWebView).** WYSIWYG edits live in the DOM until a 300ms debounce commits them, and `beforeunload` was the only close-time flush. The Whiteboard already used `pagehide` (the reliable teardown event); the playground did not.

2. **The cloud-restore window silently drops saves.** During a cloud restore, the unload handler skipped the commit entirely and `writeProgressStorageItem` deferred localStorage writes into an in-memory map that is only flushed if the page stays alive. Closing the app within that window lost everything typed during it.

## Fix

- Commit WYSIWYG edits + view state on `pagehide` (fires reliably on webview teardown), keeping `beforeunload` for browser contexts (idempotent, so double-fire is harmless)
- Added `flushProgressStorageWrites()` to bypass the cloud-restore deferral on teardown and flush the freshest edits straight to localStorage
- Same treatment for the problems page (Monaco view state)
- Whiteboard now force-saves on `pagehide` during a restore window

## Verification

- `svelte-check`: 12 errors, all pre-existing (verified against pristine tree via stash)
- `progressBackup` + `progressValidation` vitest suites pass (18/18)