### PR TITLE
fix: open WYSIWYG links in browser mode

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -137,6 +137,28 @@ test('WYSIWYG paste turns a URL string into a link', async ({ page }) => {
   await expect.poll(() => getMarkdownContent(page)).toContain('[https://example.com/path](https://example.com/path)');
 });
 
+test('browser WYSIWYG opens external links in a new tab', async ({ page }) => {
+  await page.goto('/playground');
+  await page.evaluate(() => {
+    localStorage.setItem('user-settings', JSON.stringify({ playgroundPreferredLanguage: 'markdown' }));
+    localStorage.setItem('playground-markdown-mode', 'wysiwyg');
+    localStorage.setItem('files', JSON.stringify({
+      playground: JSON.stringify([
+        { fileId: 'linked-note', fileName: 'Linked note', language: 'markdown', content: '[Example](https://example.com/path)', isOpen: true, order: 0, lastUpdated: Date.now() }
+      ])
+    }));
+  });
+  await page.reload();
+  const dismiss = page.getByRole('button', { name: 'Dismiss' });
+  if (await dismiss.isVisible().catch(() => false)) await dismiss.click();
+
+  const link = page.locator('.wysiwyg-editing a[href="https://example.com/path"]');
+  await expect(link).toBeVisible();
+  const popup = page.waitForEvent('popup');
+  await link.click();
+  await expect(await popup).toHaveURL('https://example.com/path');
+});
+
 test('playground markdown preview has a WYSIWYG editing mode', async ({ page }) => {
   await openMarkdownPlayground(page);
 

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -3117,6 +3117,20 @@ func main() {
         return true;
     }
 
+    // Browsers do not consistently activate links inside contenteditable
+    // elements. Desktop mode delegates target=_blank to Tauri's opener hook,
+    // so only provide the explicit browser fallback here.
+    function tryOpenExternalLink(event: MouseEvent, container: HTMLElement | null): boolean {
+        if (isDesktopMode || !container) return false;
+        const anchor = (event.target as HTMLElement).closest('a[href]') as HTMLAnchorElement | null;
+        if (!anchor || !container.contains(anchor) || anchor.target !== '_blank') return false;
+        if (parsePlaygroundFileId(anchor.getAttribute('href') || '')) return false;
+        event.preventDefault();
+        event.stopPropagation();
+        window.open(anchor.href, '_blank', 'noopener,noreferrer');
+        return true;
+    }
+
     // Keep checkbox HTML attributes in sync after native toggle so innerHTML
     // (and turndown) sees the current checked state.
     function handleWysiwygChange(event: Event) {
@@ -3666,6 +3680,7 @@ func main() {
             closeLangPicker();
         }
         if (tryOpenPlaygroundFileLink(event, wysiwygEl)) return;
+        if (tryOpenExternalLink(event, wysiwygEl)) return;
         if (target instanceof HTMLInputElement && target.classList.contains(CODE_LANGUAGE_INPUT_CLASS)) return;
         removeOrphanCodeWrappers();
         if (target instanceof HTMLInputElement && target.type === 'checkbox' && wysiwygEl?.contains(target)) {


### PR DESCRIPTION
## Summary
- explicitly open external links from browser WYSIWYG in a new tab
- preserve Tauri desktop opener behavior and in-app file mentions
- add a browser regression test

## Tests
- `npm test -- --run`
- focused Markdown E2E tests
- `npm run check` reports existing unrelated type errors