### PR TITLE
fix: prevent playground autosave cross-file overwrites

### DIFF
--- a/e2e/playground-markdown.test.ts
+++ b/e2e/playground-markdown.test.ts
@@ -27,6 +27,17 @@ function getMarkdownContent(page: Page): Promise<string | null> {
   });
 }
 
+function getFileContent(page: Page, fileId: string, language: string): Promise<string | null> {
+  return page.evaluate(({ fileId, language }) => {
+    const allFiles = JSON.parse(localStorage.getItem('files') || '{}');
+    const files = JSON.parse(allFiles.playground || '[]');
+    const entry = files.find((file: { fileId: string; language: string }) =>
+      file.fileId === fileId && file.language === language
+    );
+    return entry?.content ?? null;
+  }, { fileId, language });
+}
+
 test('closing the active WYSIWYG tab keeps the other markdown tab in WYSIWYG mode', async ({ page }) => {
   await page.goto('/playground');
   await page.evaluate(() => {
@@ -53,6 +64,67 @@ test('closing the active WYSIWYG tab keeps the other markdown tab in WYSIWYG mod
   await page.locator('.tab:has-text("Tasks") .tab-close').click();
   await expect(page.locator('.wysiwyg-editing')).toBeVisible();
   await expect(page.locator('.wysiwyg-editing h1')).toHaveText('Notes');
+});
+
+test('closing the last WYSIWYG tab does not restore stale source content', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('user-settings', JSON.stringify({ playgroundPreferredLanguage: 'markdown' }));
+    localStorage.setItem('playground-markdown-mode', 'wysiwyg');
+    localStorage.setItem('files', JSON.stringify({
+      playground: JSON.stringify([
+        { fileId: 'note', fileName: 'Note', language: 'markdown', content: '# Original', isOpen: true, order: 0, lastUpdated: Date.now() }
+      ])
+    }));
+  });
+  await page.goto('/playground');
+
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable.locator('h1')).toHaveText('Original');
+  await editable.evaluate((element) => {
+    element.innerHTML = '<h1>Edited in WYSIWYG</h1>';
+    element.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }));
+  });
+  await expect.poll(() => getFileContent(page, 'note', 'markdown')).toContain('Edited in WYSIWYG');
+
+  await page.locator('.tab.active .tab-close').click();
+
+  await expect(page.locator('.empty-state')).toBeVisible();
+  await expect.poll(() => getFileContent(page, 'note', 'markdown')).toContain('Edited in WYSIWYG');
+});
+
+test('WYSIWYG creates a missing markdown source before saving', async ({ page }) => {
+  await page.addInitScript(() => {
+    if (sessionStorage.getItem('missing-markdown-source-seeded')) return;
+    sessionStorage.setItem('missing-markdown-source-seeded', 'true');
+    localStorage.setItem('user-settings', JSON.stringify({ playgroundPreferredLanguage: 'markdown' }));
+    localStorage.setItem('playground-markdown-mode', 'wysiwyg');
+    localStorage.setItem('files', JSON.stringify({
+      playground: JSON.stringify([
+        {
+          fileId: 'new-note',
+          fileName: 'New note',
+          language: 'java',
+          lastLanguage: 'markdown',
+          content: '// Existing language version',
+          isOpen: true,
+          order: 0,
+          lastUpdated: Date.now()
+        }
+      ])
+    }));
+  });
+  await page.goto('/playground');
+
+  const editable = page.locator('.wysiwyg-editing');
+  await expect(editable).toBeVisible();
+  await editable.evaluate((element) => {
+    element.innerHTML = '<p>First saved note</p>';
+    element.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText' }));
+  });
+
+  await expect.poll(() => getFileContent(page, 'new-note', 'markdown')).toContain('First saved note');
+  await page.reload();
+  await expect(page.locator('.wysiwyg-editing')).toContainText('First saved note');
 });
 
 test('discarding an active WYSIWYG file reloads the restored content', async ({ page }) => {

--- a/e2e/playground-tabs.test.ts
+++ b/e2e/playground-tabs.test.ts
@@ -53,6 +53,75 @@ test('closing the active tab keeps the next tab\'s own language', async ({ page 
   await expect(page.locator('.monaco-editor .view-lines')).toContainText('python file B');
 });
 
+test('closing an inactive preview keeps the active file and other contents unchanged', async ({ page }) => {
+  await page.addInitScript(() => {
+    const now = Date.now();
+    localStorage.setItem('user-settings', JSON.stringify({ playgroundPreferredLanguage: 'java' }));
+    localStorage.setItem('playground-markdown-mode', 'source');
+    localStorage.setItem('files', JSON.stringify({
+      playground: JSON.stringify([
+        {
+          fileId: 'preview-a',
+          fileName: 'Notes',
+          language: 'markdown',
+          content: '',
+          isOpen: true,
+          order: 0,
+          lastUpdated: now,
+          type: 'preview',
+          sourceFileId: 'source-a'
+        },
+        {
+          fileId: 'source-a',
+          fileName: 'Notes',
+          language: 'markdown',
+          content: '# Notes',
+          isOpen: false,
+          order: 1,
+          lastUpdated: now
+        },
+        {
+          fileId: 'file-b',
+          fileName: 'FileB',
+          language: 'java',
+          lastLanguage: 'java',
+          content: '// file B',
+          isOpen: true,
+          order: 2,
+          lastUpdated: now + 200
+        },
+        {
+          fileId: 'file-c',
+          fileName: 'FileC',
+          language: 'java',
+          lastLanguage: 'java',
+          content: '// file C',
+          isOpen: true,
+          order: 3,
+          lastUpdated: now + 100
+        }
+      ])
+    }));
+  });
+  await page.goto('/playground');
+  await expect(page.locator('.tab.active .tab-title')).toHaveText('FileB');
+  await expect(page.locator('.monaco-editor .view-lines')).toContainText('file B');
+
+  const notesTab = page.locator('.tab', { hasText: 'Notes' });
+  await notesTab.hover();
+  await notesTab.locator('.tab-close').click();
+
+  await expect.poll(() => page.evaluate(() => {
+    const allFiles = JSON.parse(localStorage.getItem('files') || '{}');
+    const files = JSON.parse(allFiles.playground || '[]');
+    return files.find((file: { fileId: string; language: string }) =>
+      file.fileId === 'file-c' && file.language === 'java'
+    )?.content;
+  })).toBe('// file C');
+  await expect(page.locator('.tab.active .tab-title')).toHaveText('FileB');
+  await expect(page.locator('.monaco-editor .view-lines')).toContainText('file B');
+});
+
 test('recent whiteboards use the whiteboard icon', async ({ page }) => {
   await page.goto('/playground');
   await page.evaluate(() => {

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -295,13 +295,21 @@ func main() {
 
     let suppressSave = true; // prevent save during programmatic loads
     let skipNextSave = false; // prevent save when code was loaded from cross-tab sync
+    // The Monaco buffer belongs to this exact file/language pair. Keeping the
+    // identity with the buffer prevents tab index changes from retargeting it.
+    let editorFileId: string | null = null;
+    let editorLanguage: ProgrammingLanguage | null = null;
 
     async function loadOrInitFile(lang: ProgrammingLanguage) {
         if (activeTabId < 0 || activeTabId >= tabs.length) return;
-        const currentId = tabs[activeTabId].fileId;
+        const currentTab = tabs[activeTabId];
+        if (isSpecialTabType(currentTab.type)) return;
+        const currentId = currentTab.fileId;
         const files = getFiles();
         const entry = files.find((x) => x.fileId === currentId && x.language === lang);
         suppressSave = true;
+        editorFileId = currentId;
+        editorLanguage = lang;
         if (entry) {
             code = entry.content;
             currentViewState = entry.viewState ?? null;
@@ -1713,22 +1721,31 @@ func main() {
         }
         prevCloudLoading = loading;
     }
-    $: if (!suppressSave && !isSpecialTabType(tabs[activeTabId]?.type) && (code !== undefined || output !== undefined || logs !== undefined)) {
+    $: if (
+        !suppressSave &&
+        editorFileId &&
+        editorLanguage &&
+        tabs[activeTabId]?.isOpen &&
+        tabs[activeTabId]?.fileId === editorFileId &&
+        !isSpecialTabType(tabs[activeTabId]?.type) &&
+        language === editorLanguage &&
+        code !== undefined
+    ) {
         if (!skipNextSave && !isPristineStarterTab()) {
             const fkey = fileKey();
             const now = Date.now();
             const latestViewState = editorComponent?.getViewState?.() || currentViewState;
+            const targetFileId = editorFileId;
+            const targetLanguage = editorLanguage;
+            const targetTab = tabs[activeTabId];
 
-            if (activeTabId >= 0 && activeTabId < tabs.length) {
-                 tabs = tabs.map((t, i) => i === activeTabId ? { ...t, lastUpdated: now } : t);
-            }
+            tabs = tabs.map((t) => t.fileId === targetFileId ? { ...t, lastUpdated: now } : t);
 
             fileStore.update((s) => {
                 let files = JSON.parse(s[fkey] || '[]') as FileEntry[];
-                if (activeTabId < 0 || activeTabId >= tabs.length) return s;
                 const existingFile = files.find(x =>
-                    x.fileId === tabs[activeTabId].fileId &&
-                    x.language === language
+                    x.fileId === targetFileId &&
+                    x.language === targetLanguage
                 );
                 if (existingFile) {
                     existingFile.content = code;
@@ -1737,17 +1754,17 @@ func main() {
                     existingFile.logs = logs;
                     existingFile.lastUpdated = now;
                 } else {
-                    const sibling = files.find((x) => x.fileId === tabs[activeTabId].fileId);
+                    const sibling = files.find((x) => x.fileId === targetFileId);
                     files = [...files, {
-                        fileId: tabs[activeTabId].fileId,
-                        fileName: tabs[activeTabId].fileName,
-                        language: language,
+                        fileId: targetFileId,
+                        fileName: targetTab.fileName,
+                        language: targetLanguage,
                         content: code,
                         viewState: latestViewState,
                         output: output,
                         logs: logs,
                         isActive: false,
-                        isOpen: tabs[activeTabId].isOpen,
+                        isOpen: targetTab.isOpen,
                         lastUpdated: now,
                         parentId: sibling?.parentId ?? null,
                         order: sibling?.order
@@ -1787,8 +1804,12 @@ func main() {
         const tabToClose = tabs.find(t => t.fileId === fileId);
         if (tabToClose?.type === 'preview') {
             const closedIdx = tabs.findIndex(t => t.fileId === fileId);
+            const activeFileId = tabs[activeTabId]?.fileId;
             tabs = tabs.filter(t => t.fileId !== fileId);
-            if (!tabs[activeTabId]?.isOpen) {
+            if (activeFileId && activeFileId !== fileId) {
+                const nextActiveIdx = tabs.findIndex((t) => t.fileId === activeFileId);
+                if (nextActiveIdx !== -1) activeTabId = nextActiveIdx;
+            } else {
                 let nextOpenIdx = -1;
                 for (let i = Math.min(closedIdx, tabs.length - 1); i >= 0; i--) {
                     if (tabs[i].isOpen) { nextOpenIdx = i; break; }
@@ -1801,6 +1822,8 @@ func main() {
                 if (nextOpenIdx !== -1) {
                     activeTabId = nextOpenIdx;
                     loadTabContent(tabs[nextOpenIdx]);
+                } else {
+                    activeTabId = Math.max(0, Math.min(closedIdx, tabs.length - 1));
                 }
             }
             persistTabOrder();
@@ -2113,16 +2136,18 @@ func main() {
     });
 
     function saveCurrentViewState() {
-        if (!editorComponent || activeTabId < 0 || activeTabId >= tabs.length) return;
+        if (!editorComponent || !editorFileId || !editorLanguage) return;
         const state = editorComponent.getViewState();
         if (!state) return;
+        const targetFileId = editorFileId;
+        const targetLanguage = editorLanguage;
 
         const fkey = fileKey();
         fileStore.update((s) => {
             let files = JSON.parse(s[fkey] || '[]') as FileEntry[];
             const existingFile = files.find(x =>
-                x.fileId === tabs[activeTabId].fileId &&
-                x.language === language
+                x.fileId === targetFileId &&
+                x.language === targetLanguage
             );
             if (existingFile) {
                 if (existingFile.viewState === state) return s;
@@ -2458,16 +2483,15 @@ func main() {
 
     $: if (mentionQuery !== undefined) mentionSelectedIndex = 0;
 
-    function getActivePreviewSourceContent(): string {
-        if (!activeTab || activeTab.type !== 'preview' || !activeTab.sourceFileId) return '';
+    function getPreviewSourceContent(sourceFileId: string): string {
         const files = getFiles();
-        const sourceEntry = files.find((f) => f.fileId === activeTab.sourceFileId && f.language === 'markdown');
+        const sourceEntry = files.find((f) => f.fileId === sourceFileId && f.language === 'markdown');
         return sourceEntry?.content ?? '';
     }
 
     function renderWysiwygFromStore() {
         if (!wysiwygEl || !wysiwygSourceFileId) return;
-        wysiwygEl.innerHTML = renderMarkdownPlain(getActivePreviewSourceContent(), {
+        wysiwygEl.innerHTML = renderMarkdownPlain(getPreviewSourceContent(wysiwygSourceFileId), {
             resolveFileLanguage: (fileId) => getLanguageForTab(fileId)
         });
         wrapImageThumbnails(wysiwygEl);
@@ -2483,14 +2507,20 @@ func main() {
     }
 
     async function enterPreviewEditMode(force = false) {
-        if (!activeTab?.sourceFileId) return;
-        if (!force && previewEditMode && wysiwygSourceFileId === activeTab.sourceFileId && wysiwygEl) {
+        const sourceFileId = activeTab?.type === 'preview' ? activeTab.sourceFileId : null;
+        if (!sourceFileId) return;
+        if (!force && previewEditMode && wysiwygSourceFileId === sourceFileId && wysiwygEl) {
             return;
         }
-        wysiwygSourceFileId = activeTab.sourceFileId;
+        wysiwygSourceFileId = sourceFileId;
         previewEditMode = true;
         await tick();
-        if (wysiwygEl) {
+        if (
+            wysiwygEl &&
+            wysiwygSourceFileId === sourceFileId &&
+            activeTab?.type === 'preview' &&
+            activeTab.sourceFileId === sourceFileId
+        ) {
             renderWysiwygFromStore();
             wysiwygEl.focus();
         }
@@ -2587,7 +2617,10 @@ func main() {
         rehighlightWysiwygCodeBlocks();
         updateMentionPopup();
         if (wysiwygDebounce) clearTimeout(wysiwygDebounce);
-        wysiwygDebounce = setTimeout(commitWysiwygEdits, 300);
+        const sourceFileId = wysiwygSourceFileId;
+        wysiwygDebounce = setTimeout(() => {
+            if (wysiwygSourceFileId === sourceFileId) commitWysiwygEdits();
+        }, 300);
     }
 
     let applyingHorizontalRule = false;
@@ -3866,16 +3899,41 @@ func main() {
         prepareTaskListCheckboxes(wysiwygEl);
         const markdown = htmlToMarkdown(wysiwygEl.innerHTML);
         const sourceFileId = wysiwygSourceFileId;
+        const sourceTab = tabs.find((tab) => tab.fileId === sourceFileId);
+        const sourceIndex = tabs.findIndex((tab) => tab.fileId === sourceFileId);
+        const now = Date.now();
         const fkey = fileKey();
         fileStore.update((s) => {
-            const files = JSON.parse(s[fkey] || '[]') as FileEntry[];
+            let files = JSON.parse(s[fkey] || '[]') as FileEntry[];
             const sourceEntry = files.find((f) => f.fileId === sourceFileId && f.language === 'markdown');
-            if (sourceEntry && sourceEntry.content !== markdown) {
+            if (sourceEntry) {
+                if (sourceEntry.content === markdown) return s;
                 sourceEntry.content = markdown;
-                sourceEntry.lastUpdated = Date.now();
+                sourceEntry.lastUpdated = now;
+            } else {
+                const sibling = files.find((f) =>
+                    f.fileId === sourceFileId && !isFolderEntry(f) && !isSpecialTabType(f.type)
+                );
+                const previewEntry = files.find((f) => f.type === 'preview' && f.sourceFileId === sourceFileId);
+                files = [...files, {
+                    fileId: sourceFileId,
+                    fileName: sourceTab?.fileName ?? sibling?.fileName ?? previewEntry?.fileName ?? 'Solution',
+                    language: 'markdown',
+                    lastLanguage: 'markdown',
+                    content: markdown,
+                    viewState: null,
+                    output: '',
+                    logs: '',
+                    isActive: false,
+                    isOpen: sourceTab?.isOpen ?? false,
+                    lastUpdated: now,
+                    parentId: sibling?.parentId ?? previewEntry?.parentId ?? null,
+                    order: sibling?.order ?? (sourceIndex >= 0 ? sourceIndex : previewEntry?.order)
+                } as FileEntry];
             }
             return { ...s, [fkey]: JSON.stringify(files) };
         });
+        if (editorFileId === sourceFileId && editorLanguage === 'markdown') code = markdown;
         wysiwygDirty = false;
     }
 


### PR DESCRIPTION
## Summary
- Bind the Monaco autosave buffer to its file and language instead of a mutable tab index.
- Preserve the active file when preview tabs are removed.
- Persist WYSIWYG edits even when the Markdown source entry is created lazily.
- Add regressions for stale WYSIWYG saves, missing Markdown sources, and preview tab removal.

## Verification
- `npm test -- --run`
- Focused Playwright regressions: 9 passed
- `git diff --check`

`npm run check` still reports existing repository-wide type errors unrelated to these changes.