### PR TITLE
fix: call Constructor() in generated Go class runner

### DIFF
--- a/src/lib/utils/goUtil.ts
+++ b/src/lib/utils/goUtil.ts
@@ -570,7 +570,8 @@ func Solve(operations []string, values []string) []string {
     var obj *${className}
     for i, op := range operations {
         if op == "${className}" {
-            obj = &${className}{}
+            __obj := Constructor()
+            obj = &__obj
             result = append(result, "null")
 ${branches}
         }
@@ -586,7 +587,8 @@ func Solve(operations []string, values [][]int) []string {
     var obj *${className}
     for i, op := range operations {
         if op == "${className}" {
-            obj = &${className}{}
+            __obj := Constructor()
+            obj = &__obj
             result = append(result, "null")
 ${branches}
         }


### PR DESCRIPTION
## Problem

For Go class-based problems (e.g. Implement Trie, Word Dictionary, Find Median from Data Stream), the generated runner created the object with a bare struct literal:

```go
obj = &Trie{}
```

This bypasses the user's `Constructor()`, so any state initialized there (like a trie root node) was missing, causing nil pointer dereferences at runtime.

## Fix

Generated code now calls `Constructor()`:

```go
__obj := Constructor()
obj = &__obj
```

Applied to both the string-ops and int-ops branches in `generateGoClassSolution`.

## Verification

All 5 class-based problems verified with `cojudge run` and `cojudge submit`:

- implement-trie-prefix-tree: run PASS, submit 9/9
- design-add-and-search-words-data-structure: run PASS, submit 14/14
- find-median-from-data-stream: run PASS, submit 12/12
- encode-and-decode-strings: run PASS, submit 12/12
- serialize-and-deserialize-binary-tree: run PASS, submit 14/14

The two Codec problems don't use constructors (stateless `var Codec`), matching their starter code. Other languages (Java/C#/C++/TS `new X()`, Python `X()`, Rust `X::new()`) already invoke constructors correctly.