### PR TITLE
fix: store cloud images outside progress snapshots

### DIFF
--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -37,11 +37,13 @@ For a custom Firebase project:
 3. Put the Google provider's Web OAuth client ID in `VITE_GOOGLE_WEB_CLIENT_ID`. Add each browser origin that hosts Cojudge to that client's authorized JavaScript origins.
 4. Create a Google OAuth client with application type **Desktop app**. Put its client ID in `VITE_GOOGLE_DESKTOP_CLIENT_ID` and its generated client secret in `VITE_GOOGLE_DESKTOP_CLIENT_SECRET` for local/custom builds.
 5. If Identity Platform asks for external Google client IDs, add the desktop client ID there as well.
-6. Deploy the private per-user and sharing rules with `npx firebase-tools deploy --only firestore:rules --project <project-id>`.
+6. Deploy the private per-user and sharing rules with `npx firebase-tools deploy --only firestore:rules --project <project-id>`. Deploy rules before distributing a newer client because cloud schema changes are intentionally rejected until their matching rules are active.
 
 Desktop Google sign-in opens the system browser, listens temporarily on a random `127.0.0.1` port, uses OAuth PKCE, and then closes the local listener. No hosted callback server or VPS is involved. Google calls the native credential a client secret, but installed apps cannot keep embedded values confidential; PKCE and callback validation provide the security boundary.
 
 Cojudge Cloud follows a Git-like synchronization model: login, reconnect, and periodic checks fetch cloud metadata and pull only onto an unchanged local working copy. Local edits and deletions are never pushed by those background checks. **Sync now** explicitly creates a cloud revision, and the five most recent revisions remain available for local restore.
+
+Cloud snapshot schema v2 keeps image payloads in immutable, revision-scoped Firestore sidecars instead of the 6 MiB progress JSON. Pasted Markdown images, inline image data URLs, and whiteboard images are replaced with content-hashed references during upload and restored before local data is applied. Sidecars are integrity checked, limited to 64 MiB per revision, and deleted with expired revisions. Existing schema v1 revisions remain readable and are migrated only when a new revision is pushed.
 
 ## Development
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -25,6 +25,10 @@ service cloud.firestore {
       return revisionId == null || isRevisionId(revisionId);
     }
 
+    function isChecksum(value) {
+      return value is string && value.matches('^[a-f0-9]{64}$');
+    }
+
     function isSnapshotPart(partId, index) {
       return (partId == '0000' && index == 0)
         || (partId == '0001' && index == 1)
@@ -53,39 +57,113 @@ service cloud.firestore {
         || (previousSnapshotId == 'slot-4' && nextSnapshotId == 'slot-0');
     }
 
+    function hasValidLatestBase(data) {
+      return data.snapshotId is string
+        && isSnapshotSlot(data.snapshotId)
+        && isRevisionId(data.revisionId)
+        && isParentRevisionId(data.parentRevisionId)
+        && isChecksum(data.checksum)
+        && data.partCount is int
+        && data.partCount >= 1
+        && data.partCount <= 12
+        && data.totalBytes is int
+        && data.totalBytes >= 0
+        && data.totalBytes <= 6291456
+        && data.meaningful is bool
+        && data.updatedAt == request.time;
+    }
+
+    function hasReadyAssetSet(userId, snapshotId, revisionId, data) {
+      let asset = get(/databases/$(database)/documents/users/$(userId)/snapshots/$(snapshotId)/assetSets/$(revisionId));
+      return asset.data.schemaVersion == 1
+        && asset.data.status == 'ready'
+        && asset.data.snapshotId == snapshotId
+        && asset.data.revisionId == revisionId
+        && asset.data.partCount == data.assetPartCount
+        && asset.data.totalBytes == data.assetBytes
+        && asset.data.checksum == data.assetChecksum;
+    }
+
+    function hasValidV2AssetMetadata(userId, snapshotId, data) {
+      return isChecksum(data.payloadChecksum)
+        && data.assetPartCount is int
+        && data.assetPartCount >= 0
+        && data.assetPartCount <= 96
+        && data.assetBytes is int
+        && data.assetBytes >= 0
+        && data.assetBytes <= 67108864
+        && (
+          (data.assetPartCount == 0
+            && data.assetBytes == 0
+            && data.assetRevisionId == null
+            && data.assetChecksum == null)
+          || (data.assetPartCount > 0
+            && data.assetRevisionId == data.revisionId
+            && isChecksum(data.assetChecksum)
+            && data.assetBytes > (data.assetPartCount - 1) * 716800
+            && data.assetBytes <= data.assetPartCount * 716800
+            && hasReadyAssetSet(userId, snapshotId, data.assetRevisionId, data))
+        );
+    }
+
+    function isValidV1LatestData(data) {
+      return data.keys().hasAll([
+          'schemaVersion', 'snapshotId', 'revisionId', 'parentRevisionId', 'checksum',
+          'partCount', 'totalBytes', 'storageUsed', 'meaningful', 'updatedAt'
+        ])
+        && data.keys().hasOnly([
+          'schemaVersion', 'snapshotId', 'revisionId', 'parentRevisionId', 'checksum',
+          'partCount', 'totalBytes', 'storageUsed', 'meaningful', 'updatedAt'
+        ])
+        && data.schemaVersion == 1
+        && hasValidLatestBase(data)
+        && data.storageUsed == data.totalBytes;
+    }
+
+    function isValidV2LatestData(userId, data) {
+      return data.keys().hasAll([
+          'schemaVersion', 'snapshotId', 'revisionId', 'parentRevisionId', 'checksum',
+          'payloadChecksum', 'assetRevisionId', 'assetPartCount', 'assetBytes', 'assetChecksum',
+          'partCount', 'totalBytes', 'storageUsed', 'meaningful', 'updatedAt'
+        ])
+        && data.keys().hasOnly([
+          'schemaVersion', 'snapshotId', 'revisionId', 'parentRevisionId', 'checksum',
+          'payloadChecksum', 'assetRevisionId', 'assetPartCount', 'assetBytes', 'assetChecksum',
+          'partCount', 'totalBytes', 'storageUsed', 'meaningful', 'updatedAt'
+        ])
+        && data.schemaVersion == 2
+        && hasValidLatestBase(data)
+        && hasValidV2AssetMetadata(userId, data.snapshotId, data)
+        && data.storageUsed == data.totalBytes + data.assetBytes;
+    }
+
+    function latestMatchesSnapshot(userId, data) {
+      let snapshot = getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(data.snapshotId));
+      return snapshot.data.status == 'ready'
+        && snapshot.data.schemaVersion == data.schemaVersion
+        && snapshot.data.revisionId == data.revisionId
+        && snapshot.data.parentRevisionId == data.parentRevisionId
+        && snapshot.data.checksum == data.checksum
+        && snapshot.data.partCount == data.partCount
+        && snapshot.data.totalBytes == data.totalBytes
+        && snapshot.data.meaningful == data.meaningful
+        && (
+          data.schemaVersion == 1
+          || (snapshot.data.payloadChecksum == data.payloadChecksum
+            && snapshot.data.assetRevisionId == data.assetRevisionId
+            && snapshot.data.assetPartCount == data.assetPartCount
+            && snapshot.data.assetBytes == data.assetBytes
+            && snapshot.data.assetChecksum == data.assetChecksum)
+        );
+    }
+
     function isValidLatestWrite(userId) {
       return isCloudUser(userId)
-        && request.resource.data.keys().hasAll([
-          'schemaVersion', 'snapshotId', 'revisionId', 'parentRevisionId', 'checksum',
-          'partCount', 'totalBytes', 'storageUsed', 'meaningful', 'updatedAt'
-        ])
-        && request.resource.data.keys().hasOnly([
-          'schemaVersion', 'snapshotId', 'revisionId', 'parentRevisionId', 'checksum',
-          'partCount', 'totalBytes', 'storageUsed', 'meaningful', 'updatedAt'
-        ])
-        && request.resource.data.schemaVersion == 1
-        && request.resource.data.snapshotId is string
-        && isSnapshotSlot(request.resource.data.snapshotId)
-        && isRevisionId(request.resource.data.revisionId)
-        && isParentRevisionId(request.resource.data.parentRevisionId)
-        && request.resource.data.checksum is string
-        && request.resource.data.checksum.matches('^[a-f0-9]{64}$')
-        && request.resource.data.partCount is int
-        && request.resource.data.partCount >= 1
-        && request.resource.data.partCount <= 12
-        && request.resource.data.totalBytes is int
-        && request.resource.data.totalBytes >= 0
-        && request.resource.data.totalBytes <= 6291456
-        && request.resource.data.storageUsed == request.resource.data.totalBytes
-        && request.resource.data.meaningful is bool
-        && request.resource.data.updatedAt == request.time
-        && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(request.resource.data.snapshotId)).data.status == 'ready'
-        && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(request.resource.data.snapshotId)).data.revisionId == request.resource.data.revisionId
-        && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(request.resource.data.snapshotId)).data.parentRevisionId == request.resource.data.parentRevisionId
-        && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(request.resource.data.snapshotId)).data.checksum == request.resource.data.checksum
-        && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(request.resource.data.snapshotId)).data.partCount == request.resource.data.partCount
-        && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(request.resource.data.snapshotId)).data.totalBytes == request.resource.data.totalBytes
-        && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(request.resource.data.snapshotId)).data.meaningful == request.resource.data.meaningful;
+        && (
+          isValidV1LatestData(request.resource.data)
+          || isValidV2LatestData(userId, request.resource.data)
+        )
+        && latestMatchesSnapshot(userId, request.resource.data);
     }
 
     // storageUsed tracks the current revision; fixed slots bound retained history to five revisions.
@@ -99,45 +177,146 @@ service cloud.firestore {
         && isNextSnapshotSlot(resource.data.snapshotId, request.resource.data.snapshotId);
     }
 
+    function hasValidSnapshotBase(snapshotId, data) {
+      return data.status == 'ready'
+        && isSnapshotSlot(snapshotId)
+        && isRevisionId(data.revisionId)
+        && isParentRevisionId(data.parentRevisionId)
+        && isChecksum(data.checksum)
+        && data.partCount is int
+        && data.partCount >= 1
+        && data.partCount <= 12
+        && data.totalBytes is int
+        && data.totalBytes >= 0
+        && data.totalBytes <= 6291456
+        && data.meaningful is bool
+        && data.createdAt == request.time;
+    }
+
+    function isValidV1SnapshotData(snapshotId, data) {
+      return data.keys().hasAll([
+          'schemaVersion', 'status', 'revisionId', 'parentRevisionId', 'checksum',
+          'partCount', 'totalBytes', 'meaningful', 'createdAt'
+        ])
+        && data.keys().hasOnly([
+          'schemaVersion', 'status', 'revisionId', 'parentRevisionId', 'checksum',
+          'partCount', 'totalBytes', 'meaningful', 'createdAt'
+        ])
+        && data.schemaVersion == 1
+        && hasValidSnapshotBase(snapshotId, data);
+    }
+
+    function isValidV2SnapshotData(userId, snapshotId, data) {
+      return data.keys().hasAll([
+          'schemaVersion', 'status', 'revisionId', 'parentRevisionId', 'checksum',
+          'payloadChecksum', 'assetRevisionId', 'assetPartCount', 'assetBytes', 'assetChecksum',
+          'partCount', 'totalBytes', 'meaningful', 'createdAt'
+        ])
+        && data.keys().hasOnly([
+          'schemaVersion', 'status', 'revisionId', 'parentRevisionId', 'checksum',
+          'payloadChecksum', 'assetRevisionId', 'assetPartCount', 'assetBytes', 'assetChecksum',
+          'partCount', 'totalBytes', 'meaningful', 'createdAt'
+        ])
+        && data.schemaVersion == 2
+        && hasValidSnapshotBase(snapshotId, data)
+        && hasValidV2AssetMetadata(userId, snapshotId, data);
+    }
+
+    function snapshotMatchesLatest(userId, snapshotId, data) {
+      let latest = getAfter(/databases/$(database)/documents/users/$(userId)/cloud/latest);
+      return latest.data.snapshotId == snapshotId
+        && latest.data.schemaVersion == data.schemaVersion
+        && latest.data.revisionId == data.revisionId
+        && latest.data.parentRevisionId == data.parentRevisionId
+        && latest.data.checksum == data.checksum
+        && latest.data.partCount == data.partCount
+        && latest.data.totalBytes == data.totalBytes
+        && latest.data.meaningful == data.meaningful
+        && latest.data.updatedAt == request.time
+        && (
+          data.schemaVersion == 1
+          || (latest.data.payloadChecksum == data.payloadChecksum
+            && latest.data.assetRevisionId == data.assetRevisionId
+            && latest.data.assetPartCount == data.assetPartCount
+            && latest.data.assetBytes == data.assetBytes
+            && latest.data.assetChecksum == data.assetChecksum)
+        );
+    }
+
+    function isValidSnapshotWrite(userId, snapshotId) {
+      return isCloudUser(userId)
+        && (
+          isValidV1SnapshotData(snapshotId, request.resource.data)
+          || isValidV2SnapshotData(userId, snapshotId, request.resource.data)
+        )
+        && snapshotMatchesLatest(userId, snapshotId, request.resource.data);
+    }
+
+    function isAssetSetReferenced(userId, snapshotId, assetRevisionId) {
+      let snapshot = get(/databases/$(database)/documents/users/$(userId)/snapshots/$(snapshotId));
+      return exists(/databases/$(database)/documents/users/$(userId)/snapshots/$(snapshotId))
+        && snapshot.data.schemaVersion == 2
+        && snapshot.data.revisionId == assetRevisionId
+        && snapshot.data.assetRevisionId == assetRevisionId;
+    }
+
+    function isValidAssetSetCreate(snapshotId, assetRevisionId) {
+      return request.resource.data.keys().hasAll([
+          'schemaVersion', 'status', 'snapshotId', 'revisionId', 'partCount',
+          'totalBytes', 'checksum', 'createdAt'
+        ])
+        && request.resource.data.keys().hasOnly([
+          'schemaVersion', 'status', 'snapshotId', 'revisionId', 'partCount',
+          'totalBytes', 'checksum', 'createdAt'
+        ])
+        && request.resource.data.schemaVersion == 1
+        && request.resource.data.status == 'staging'
+        && request.resource.data.snapshotId == snapshotId
+        && request.resource.data.revisionId == assetRevisionId
+        && isSnapshotSlot(snapshotId)
+        && isRevisionId(assetRevisionId)
+        && request.resource.data.partCount is int
+        && request.resource.data.partCount >= 1
+        && request.resource.data.partCount <= 96
+        && request.resource.data.totalBytes is int
+        && request.resource.data.totalBytes > (request.resource.data.partCount - 1) * 716800
+        && request.resource.data.totalBytes <= request.resource.data.partCount * 716800
+        && request.resource.data.totalBytes <= 67108864
+        && isChecksum(request.resource.data.checksum)
+        && request.resource.data.createdAt == request.time;
+    }
+
+    function isValidAssetSetReadyUpdate(snapshotId, assetRevisionId) {
+      return resource.data.status == 'staging'
+        && request.resource.data.status == 'ready'
+        && request.resource.data.schemaVersion == resource.data.schemaVersion
+        && request.resource.data.snapshotId == snapshotId
+        && request.resource.data.snapshotId == resource.data.snapshotId
+        && request.resource.data.revisionId == assetRevisionId
+        && request.resource.data.revisionId == resource.data.revisionId
+        && request.resource.data.partCount == resource.data.partCount
+        && request.resource.data.totalBytes == resource.data.totalBytes
+        && request.resource.data.checksum == resource.data.checksum
+        && request.resource.data.createdAt == resource.data.createdAt
+        && request.resource.data.keys().hasOnly([
+          'schemaVersion', 'status', 'snapshotId', 'revisionId', 'partCount',
+          'totalBytes', 'checksum', 'createdAt'
+        ]);
+    }
+
     match /users/{userId}/snapshots/{snapshotId} {
       allow read: if isCloudUser(userId);
       allow delete: if isCloudUser(userId)
         && isSnapshotSlot(snapshotId)
         && existsAfter(/databases/$(database)/documents/users/$(userId)/cloud/latest)
         && getAfter(/databases/$(database)/documents/users/$(userId)/cloud/latest).data.snapshotId != snapshotId;
-      allow create, update: if isCloudUser(userId)
-        && isSnapshotSlot(snapshotId)
-        && request.resource.data.keys().hasAll([
-          'schemaVersion', 'status', 'revisionId', 'parentRevisionId', 'checksum',
-          'partCount', 'totalBytes', 'meaningful', 'createdAt'
-        ])
-        && request.resource.data.keys().hasOnly([
-          'schemaVersion', 'status', 'revisionId', 'parentRevisionId', 'checksum',
-          'partCount', 'totalBytes', 'meaningful', 'createdAt'
-        ])
-        && request.resource.data.schemaVersion == 1
-        && request.resource.data.status == 'ready'
-        && isRevisionId(request.resource.data.revisionId)
-        && isParentRevisionId(request.resource.data.parentRevisionId)
-        && request.resource.data.checksum is string
-        && request.resource.data.checksum.matches('^[a-f0-9]{64}$')
-        && request.resource.data.partCount is int
-        && request.resource.data.partCount >= 1
-        && request.resource.data.partCount <= 12
-        && request.resource.data.totalBytes is int
-        && request.resource.data.totalBytes >= 0
-        && request.resource.data.totalBytes <= 6291456
-        && request.resource.data.meaningful is bool
-        && request.resource.data.createdAt == request.time
-        && getAfter(/databases/$(database)/documents/users/$(userId)/cloud/latest).data.snapshotId == snapshotId
-        && getAfter(/databases/$(database)/documents/users/$(userId)/cloud/latest).data.revisionId == request.resource.data.revisionId
-        && getAfter(/databases/$(database)/documents/users/$(userId)/cloud/latest).data.updatedAt == request.time;
+      allow create, update: if isValidSnapshotWrite(userId, snapshotId);
 
       match /parts/{partId} {
         allow read: if isCloudUser(userId);
         // Deleting a manifest orphans its parts in the same transaction. The current slot's
-        // manifest can never be deleted (see the manifest rule above), which also protects
-        // its parts. The second branch keeps upload shrink-deletes for the current slot.
+        // manifest can never be deleted, which also protects its parts. The second branch
+        // keeps upload shrink-deletes for the current slot.
         allow delete: if isCloudUser(userId)
           && isSnapshotSlot(snapshotId)
           && resource.data.index is int
@@ -160,6 +339,35 @@ service cloud.firestore {
           && getAfter(/databases/$(database)/documents/users/$(userId)/cloud/latest).data.partCount > request.resource.data.index
           && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(snapshotId)).data.revisionId == getAfter(/databases/$(database)/documents/users/$(userId)/cloud/latest).data.revisionId
           && getAfter(/databases/$(database)/documents/users/$(userId)/snapshots/$(snapshotId)).data.createdAt == request.time;
+      }
+
+      match /assetSets/{assetRevisionId} {
+        allow read: if isCloudUser(userId);
+        allow create: if isCloudUser(userId)
+          && isValidAssetSetCreate(snapshotId, assetRevisionId);
+        allow update: if isCloudUser(userId)
+          && isValidAssetSetReadyUpdate(snapshotId, assetRevisionId);
+        allow delete: if isCloudUser(userId)
+          && !isAssetSetReferenced(userId, snapshotId, assetRevisionId);
+
+        match /parts/{partId} {
+          allow read: if isCloudUser(userId);
+          allow create: if isCloudUser(userId)
+            && isSnapshotSlot(snapshotId)
+            && isRevisionId(assetRevisionId)
+            && partId.matches('^[0-9]{4}$')
+            && request.resource.data.keys().hasOnly(['index', 'data'])
+            && request.resource.data.index is int
+            && request.resource.data.index >= 0
+            && request.resource.data.index < 96
+            && request.resource.data.data is bytes
+            && request.resource.data.data.size() > 0
+            && request.resource.data.data.size() <= 716800
+            && get(/databases/$(database)/documents/users/$(userId)/snapshots/$(snapshotId)/assetSets/$(assetRevisionId)).data.status == 'staging'
+            && get(/databases/$(database)/documents/users/$(userId)/snapshots/$(snapshotId)/assetSets/$(assetRevisionId)).data.partCount > request.resource.data.index;
+          allow delete: if isCloudUser(userId)
+            && !isAssetSetReferenced(userId, snapshotId, assetRevisionId);
+        }
       }
     }
   }

--- a/src/lib/cloudAssets.test.ts
+++ b/src/lib/cloudAssets.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+	decodeCloudAssetParts,
+	encodeCloudAssetParts,
+	extractCloudAssets,
+	hydrateCloudAssets
+} from './cloudAssets';
+import { hashProgress, serializeProgressData } from './progressBackup';
+
+describe('cloud image sidecars', () => {
+	it('extracts and exactly restores every supported embedded image location', async () => {
+		const png = `data:image/png;base64,${'A'.repeat(2048)}`;
+		const jpeg = 'data:image/jpeg;charset=utf-8;base64,AQIDBA==';
+		const data = {
+			files: {
+				playground: JSON.stringify([
+					{
+						fileId: 'notes',
+						fileName: 'Notes',
+						language: 'markdown',
+						content: `# Unicode 你好\n![inline](${png})`
+					}
+				])
+			},
+			'pasted-images': { pasted: png },
+			'cojudge-whiteboard-v1': {
+				version: 1,
+				elements: [{ id: 'image', type: 'image', imageData: jpeg }]
+			},
+			'cojudge-whiteboard-v1:share:abc': {
+				version: 1,
+				elements: [{ id: 'duplicate', type: 'image', imageData: jpeg }]
+			}
+		};
+
+		const extracted = await extractCloudAssets(data);
+
+		expect(extracted.count).toBe(2);
+		expect(JSON.stringify(extracted.data)).not.toContain('data:image');
+		expect(JSON.stringify(extracted.data)).toContain('cojudge-cloud-asset://');
+		expect(extracted.bytes.length).toBeLessThan(JSON.stringify(data).length);
+		const hydrated = await hydrateCloudAssets(extracted.data, extracted.bytes);
+		expect(hydrated).toEqual(data);
+		expect(serializeProgressData(hydrated)).toBe(serializeProgressData(data));
+		expect(await hashProgress(serializeProgressData(hydrated))).toBe(
+			await hashProgress(serializeProgressData(data))
+		);
+	});
+
+	it('leaves image-free snapshots unchanged without creating a sidecar', async () => {
+		const data = {
+			files: { playground: JSON.stringify([{ content: 'plain text', language: 'markdown' }]) },
+			solutions: { sample: 'return 1;' }
+		};
+
+		const extracted = await extractCloudAssets(data);
+
+		expect(extracted.count).toBe(0);
+		expect(extracted.bytes).toHaveLength(0);
+		expect(extracted.data).toEqual(data);
+		expect(await hydrateCloudAssets(extracted.data, extracted.bytes)).toEqual(data);
+	});
+
+	it('moves an image larger than the old snapshot limit out of progress JSON', async () => {
+		const image = `data:image/png;base64,${'A'.repeat(6 * 1024 * 1024 + 1)}`;
+		const data = { 'pasted-images': { large: image } };
+
+		const extracted = await extractCloudAssets(data);
+
+		expect(new TextEncoder().encode(JSON.stringify(data)).length).toBeGreaterThan(6 * 1024 * 1024);
+		expect(new TextEncoder().encode(JSON.stringify(extracted.data)).length).toBeLessThan(1024);
+		expect(extracted.bytes.length).toBeGreaterThan(6 * 1024 * 1024);
+	});
+
+	it('rejects corrupt or incomplete image payloads before restore', async () => {
+		const data = {
+			'cojudge-whiteboard-v1': {
+				version: 1,
+				elements: [{ id: 'image', type: 'image', imageData: 'data:image/png;base64,AQIDBA==' }]
+			}
+		};
+		const extracted = await extractCloudAssets(data);
+		const corrupt = extracted.bytes.slice();
+		corrupt[corrupt.length - 1] ^= 1;
+
+		await expect(hydrateCloudAssets(extracted.data, corrupt)).rejects.toThrow(
+			'Cloud image failed its integrity check.'
+		);
+		await expect(hydrateCloudAssets(extracted.data, corrupt.slice(1))).rejects.toThrow(
+			'Cloud image download is incomplete.'
+		);
+	});
+
+	it('round-trips binary Firestore chunks', () => {
+		const bytes = new TextEncoder().encode('image-one\0image-two\0你好');
+		const parts = encodeCloudAssetParts(bytes, 7);
+
+		expect(parts.length).toBeGreaterThan(1);
+		expect(decodeCloudAssetParts(parts, bytes.length)).toEqual(bytes);
+		expect(() => decodeCloudAssetParts(parts.slice(1), bytes.length)).toThrow(
+			'Cloud image download is incomplete.'
+		);
+	});
+});

--- a/src/lib/cloudAssets.ts
+++ b/src/lib/cloudAssets.ts
@@ -1,0 +1,265 @@
+import type { ProgressData } from '$lib/progressBackup';
+
+export const CLOUD_ASSET_CHUNK_BYTES = 700 * 1024;
+export const MAX_CLOUD_ASSET_BYTES = 64 * 1024 * 1024;
+export const MAX_CLOUD_ASSET_PARTS = 96;
+export const MAX_CLOUD_ASSET_COUNT = 512;
+
+const CLOUD_ASSET_MANIFEST_KEY = 'cojudge-cloud-assets-v1';
+const CLOUD_ASSET_REFERENCE_PREFIX = 'cojudge-cloud-asset://';
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const DATA_IMAGE_URL_SOURCE = String.raw`data:image\/[a-z0-9.+-]+(?:;[^,;"'\s)]+)*;base64,[a-z0-9+/]+={0,2}`;
+const CLOUD_ASSET_REFERENCE_SOURCE = String.raw`cojudge-cloud-asset:\/\/([a-f0-9]{64})`;
+
+type CloudAssetDescriptor = {
+	id: string;
+	offset: number;
+	length: number;
+};
+
+type CloudAssetManifest = {
+	version: 1;
+	assets: CloudAssetDescriptor[];
+};
+
+export type ExtractedCloudAssets = {
+	data: ProgressData;
+	bytes: Uint8Array;
+	count: number;
+};
+
+function dataImagePattern(): RegExp {
+	return new RegExp(DATA_IMAGE_URL_SOURCE, 'gi');
+}
+
+function cloudAssetReferencePattern(): RegExp {
+	return new RegExp(CLOUD_ASSET_REFERENCE_SOURCE, 'g');
+}
+
+function collectDataImages(value: unknown, images: Set<string>): void {
+	if (typeof value === 'string') {
+		for (const match of value.matchAll(dataImagePattern())) images.add(match[0]);
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (const entry of value) collectDataImages(entry, images);
+		return;
+	}
+	if (!value || typeof value !== 'object') return;
+	for (const entry of Object.values(value as Record<string, unknown>)) {
+		collectDataImages(entry, images);
+	}
+}
+
+function cloneReplacingDataImages(value: unknown, references: Map<string, string>): unknown {
+	if (typeof value === 'string') {
+		return value.replace(dataImagePattern(), (image) => {
+			const id = references.get(image);
+			if (!id) throw new Error('Cloud image extraction is incomplete.');
+			return `${CLOUD_ASSET_REFERENCE_PREFIX}${id}`;
+		});
+	}
+	if (Array.isArray(value)) return value.map((entry) => cloneReplacingDataImages(entry, references));
+	if (!value || typeof value !== 'object') return value;
+
+	const result: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+		result[key] = cloneReplacingDataImages(entry, references);
+	}
+	return result;
+}
+
+function cloneReplacingAssetReferences(
+	value: unknown,
+	assets: Map<string, string>,
+	used: Set<string>
+): unknown {
+	if (typeof value === 'string') {
+		return value.replace(cloudAssetReferencePattern(), (_reference, id: string) => {
+			const image = assets.get(id);
+			if (!image) throw new Error('Cloud snapshot references a missing image.');
+			used.add(id);
+			return image;
+		});
+	}
+	if (Array.isArray(value)) {
+		return value.map((entry) => cloneReplacingAssetReferences(entry, assets, used));
+	}
+	if (!value || typeof value !== 'object') return value;
+
+	const result: Record<string, unknown> = {};
+	for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+		if (key === CLOUD_ASSET_MANIFEST_KEY) continue;
+		result[key] = cloneReplacingAssetReferences(entry, assets, used);
+	}
+	return result;
+}
+
+export async function hashCloudAssetBytes(bytes: Uint8Array): Promise<string> {
+	const digestBytes = new Uint8Array(bytes.length);
+	digestBytes.set(bytes);
+	const digest = await crypto.subtle.digest('SHA-256', digestBytes);
+	return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+async function hashCloudAssetValue(value: string): Promise<string> {
+	return hashCloudAssetBytes(new TextEncoder().encode(value));
+}
+
+function parseManifest(value: unknown): CloudAssetManifest {
+	if (!value || typeof value !== 'object' || Array.isArray(value)) {
+		throw new Error('Cloud image manifest is invalid.');
+	}
+	const manifest = value as Partial<CloudAssetManifest>;
+	if (manifest.version !== 1 || !Array.isArray(manifest.assets)) {
+		throw new Error('Cloud image manifest is invalid.');
+	}
+	if (manifest.assets.length === 0 || manifest.assets.length > MAX_CLOUD_ASSET_COUNT) {
+		throw new Error('Cloud image manifest has an invalid image count.');
+	}
+
+	const descriptors: CloudAssetDescriptor[] = [];
+	let expectedOffset = 0;
+	const ids = new Set<string>();
+	for (const candidate of manifest.assets) {
+		if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+			throw new Error('Cloud image manifest is invalid.');
+		}
+		const descriptor = candidate as Partial<CloudAssetDescriptor>;
+		if (
+			typeof descriptor.id !== 'string'
+			|| !SHA256_PATTERN.test(descriptor.id)
+			|| ids.has(descriptor.id)
+			|| !Number.isSafeInteger(descriptor.offset)
+			|| descriptor.offset !== expectedOffset
+			|| !Number.isSafeInteger(descriptor.length)
+			|| (descriptor.length as number) <= 0
+		) {
+			throw new Error('Cloud image manifest is invalid.');
+		}
+		ids.add(descriptor.id);
+		descriptors.push(descriptor as CloudAssetDescriptor);
+		expectedOffset += descriptor.length as number;
+		if (!Number.isSafeInteger(expectedOffset) || expectedOffset > MAX_CLOUD_ASSET_BYTES) {
+			throw new Error('Cloud image manifest exceeds the supported size.');
+		}
+	}
+	return { version: 1, assets: descriptors };
+}
+
+function isCompleteDataImage(value: string): boolean {
+	const matches = [...value.matchAll(dataImagePattern())];
+	return matches.length === 1 && matches[0][0] === value;
+}
+
+export async function extractCloudAssets(data: ProgressData): Promise<ExtractedCloudAssets> {
+	if (CLOUD_ASSET_MANIFEST_KEY in data) {
+		throw new Error('Progress data contains a reserved cloud image key.');
+	}
+
+	const imageValues = new Set<string>();
+	collectDataImages(data, imageValues);
+	if (imageValues.size === 0) {
+		return {
+			data: cloneReplacingDataImages(data, new Map()) as ProgressData,
+			bytes: new Uint8Array(),
+			count: 0
+		};
+	}
+	if (imageValues.size > MAX_CLOUD_ASSET_COUNT) {
+		throw new Error(`A cloud snapshot can contain at most ${MAX_CLOUD_ASSET_COUNT} images.`);
+	}
+
+	const values = [...imageValues];
+	const ids = await Promise.all(values.map(hashCloudAssetValue));
+	const valueById = new Map<string, string>();
+	const idByValue = new Map<string, string>();
+	for (let index = 0; index < values.length; index++) {
+		const value = values[index];
+		const id = ids[index];
+		const collision = valueById.get(id);
+		if (collision !== undefined && collision !== value) {
+			throw new Error('Two cloud images produced the same content hash.');
+		}
+		valueById.set(id, value);
+		idByValue.set(value, id);
+	}
+
+	const encoder = new TextEncoder();
+	const encoded = [...valueById.entries()]
+		.sort(([first], [second]) => first.localeCompare(second))
+		.map(([id, value]) => ({ id, bytes: encoder.encode(value) }));
+	const totalBytes = encoded.reduce((total, asset) => total + asset.bytes.length, 0);
+	if (!Number.isSafeInteger(totalBytes) || totalBytes > MAX_CLOUD_ASSET_BYTES) {
+		throw new Error('Cloud images exceed the 64 MB limit.');
+	}
+
+	const bytes = new Uint8Array(totalBytes);
+	const descriptors: CloudAssetDescriptor[] = [];
+	let offset = 0;
+	for (const asset of encoded) {
+		bytes.set(asset.bytes, offset);
+		descriptors.push({ id: asset.id, offset, length: asset.bytes.length });
+		offset += asset.bytes.length;
+	}
+
+	const result = cloneReplacingDataImages(data, idByValue) as ProgressData;
+	result[CLOUD_ASSET_MANIFEST_KEY] = { version: 1, assets: descriptors } satisfies CloudAssetManifest;
+	return { data: result, bytes, count: descriptors.length };
+}
+
+export async function hydrateCloudAssets(data: ProgressData, bytes: Uint8Array): Promise<ProgressData> {
+	const manifestValue = data[CLOUD_ASSET_MANIFEST_KEY];
+	if (manifestValue === undefined) {
+		if (bytes.length !== 0) throw new Error('Cloud snapshot has images but no image manifest.');
+		return cloneReplacingAssetReferences(data, new Map(), new Set()) as ProgressData;
+	}
+	const manifest = parseManifest(manifestValue);
+	const expectedBytes = manifest.assets.reduce((total, asset) => total + asset.length, 0);
+	if (bytes.length !== expectedBytes) throw new Error('Cloud image download is incomplete.');
+
+	const decoder = new TextDecoder('utf-8', { fatal: true });
+	const assets = new Map<string, string>();
+	for (const descriptor of manifest.assets) {
+		const value = decoder.decode(bytes.subarray(descriptor.offset, descriptor.offset + descriptor.length));
+		if (!isCompleteDataImage(value) || (await hashCloudAssetValue(value)) !== descriptor.id) {
+			throw new Error('Cloud image failed its integrity check.');
+		}
+		assets.set(descriptor.id, value);
+	}
+
+	const used = new Set<string>();
+	const hydrated = cloneReplacingAssetReferences(data, assets, used) as ProgressData;
+	if (used.size !== assets.size) throw new Error('Cloud snapshot contains an unreferenced image.');
+	return hydrated;
+}
+
+export function encodeCloudAssetParts(
+	bytes: Uint8Array,
+	chunkBytes = CLOUD_ASSET_CHUNK_BYTES
+): Uint8Array[] {
+	if (!Number.isSafeInteger(chunkBytes) || chunkBytes <= 0) {
+		throw new Error('Cloud image chunk size must be a positive integer.');
+	}
+	const parts: Uint8Array[] = [];
+	for (let offset = 0; offset < bytes.length; offset += chunkBytes) {
+		parts.push(bytes.slice(offset, offset + chunkBytes));
+	}
+	return parts;
+}
+
+export function decodeCloudAssetParts(parts: readonly Uint8Array[], totalBytes: number): Uint8Array {
+	if (!Number.isSafeInteger(totalBytes) || totalBytes < 0 || totalBytes > MAX_CLOUD_ASSET_BYTES) {
+		throw new Error('Cloud images have an invalid size.');
+	}
+	const actualBytes = parts.reduce((total, part) => total + part.length, 0);
+	if (actualBytes !== totalBytes) throw new Error('Cloud image download is incomplete.');
+
+	const combined = new Uint8Array(actualBytes);
+	let offset = 0;
+	for (const part of parts) {
+		combined.set(part, offset);
+		offset += part.length;
+	}
+	return combined;
+}

--- a/src/lib/cloudSync.ts
+++ b/src/lib/cloudSync.ts
@@ -2,7 +2,9 @@ import { browser } from '$app/environment';
 import { get, writable } from 'svelte/store';
 import { onIdTokenChanged, type Auth, type Unsubscribe, type User } from 'firebase/auth';
 import {
+	Bytes,
 	collection,
+	deleteDoc,
 	doc,
 	getDoc,
 	getDocs,
@@ -11,6 +13,9 @@ import {
 	query,
 	runTransaction,
 	serverTimestamp,
+	setDoc,
+	updateDoc,
+	writeBatch,
 	type Firestore
 } from 'firebase/firestore/lite';
 import { initFirebase, signInWithGoogle, signOutFirebase } from '$lib/firebase';
@@ -32,6 +37,7 @@ import {
 	CLOUD_RESTORE_COMPLETE_KEY,
 	CLOUD_RESTORE_LOCK_KEY,
 	CLOUD_RESTORE_SESSION_KEY,
+	CLOUD_SNAPSHOT_LEGACY_VERSION,
 	CLOUD_SNAPSHOT_VERSION,
 	decodeProgressParts,
 	encodeProgressParts,
@@ -44,6 +50,16 @@ import {
 	serializeProgressData,
 	type ProgressData
 } from '$lib/progressBackup';
+import {
+	CLOUD_ASSET_CHUNK_BYTES,
+	MAX_CLOUD_ASSET_BYTES,
+	MAX_CLOUD_ASSET_PARTS,
+	decodeCloudAssetParts,
+	encodeCloudAssetParts,
+	extractCloudAssets,
+	hashCloudAssetBytes,
+	hydrateCloudAssets
+} from '$lib/cloudAssets';
 import { applyProgressData } from '$lib/progressBackupClient';
 import {
 	PASTED_IMAGES_KEY,
@@ -76,6 +92,8 @@ const LOCAL_CLEAR_COMPLETE_KEY = 'cojudge-cloud-local-clear-complete';
 const SYNC_INTERVAL_MS = 5 * 60 * 1000;
 const MAX_SNAPSHOT_BYTES = 6 * 1024 * 1024;
 const MAX_SNAPSHOT_PARTS = 12;
+const CLOUD_ASSET_SET_VERSION = 1;
+const CLOUD_ASSET_BATCH_PARTS = 8;
 const CLOUD_RESTORE_WEB_LOCK = 'cojudge-cloud-restore';
 
 type CloudAuthStatus = 'initializing' | 'unavailable' | 'signed-out' | 'signing-in' | 'signed-in';
@@ -138,17 +156,31 @@ type LocalSnapshot = {
 	meta: DeviceUserMeta;
 };
 
-type UploadSnapshot = Pick<LocalSnapshot, 'serialized' | 'checksum' | 'meaningful'>;
+type UploadSnapshot = Pick<LocalSnapshot, 'data' | 'checksum' | 'meaningful'>;
 
 type RemoteSnapshotMeta = {
+	schemaVersion: number;
 	snapshotId: string;
 	revisionId: string;
 	parentRevisionId: string | null;
 	checksum: string;
+	payloadChecksum: string;
 	partCount: number;
 	totalBytes: number;
+	assetRevisionId: string | null;
+	assetPartCount: number;
+	assetBytes: number;
+	assetChecksum: string | null;
 	updatedAt: number;
 	meaningful: boolean;
+};
+
+type CloudAssetSet = {
+	snapshotId: string;
+	revisionId: string;
+	partCount: number;
+	totalBytes: number;
+	checksum: string;
 };
 
 type CloudCloneRecord = {
@@ -409,9 +441,16 @@ async function collectReferencedPastedImages(filesValue: unknown): Promise<Recor
 
 	const all = await getAllPastedImages();
 	const record: Record<string, string> = {};
+	const missing: string[] = [];
 	for (const id of ids) {
 		const dataUrl = all[id];
 		if (dataUrl) record[id] = dataUrl;
+		else missing.push(id);
+	}
+	if (missing.length > 0) {
+		throw new Error(
+			`${missing.length} pasted ${missing.length === 1 ? 'image is' : 'images are'} unavailable locally. Remove or paste ${missing.length === 1 ? 'it' : 'them'} again before syncing.`
+		);
 	}
 	return Object.keys(record).length > 0 ? record : null;
 }
@@ -590,6 +629,23 @@ function partsRef(db: Firestore, uid: string, snapshotId: string) {
 	return collection(db, 'users', uid, 'snapshots', snapshotId, 'parts');
 }
 
+function assetSetRef(db: Firestore, uid: string, snapshotId: string, revisionId: string) {
+	return doc(db, 'users', uid, 'snapshots', snapshotId, 'assetSets', revisionId);
+}
+
+function assetPartsRef(db: Firestore, uid: string, snapshotId: string, revisionId: string) {
+	return collection(
+		db,
+		'users',
+		uid,
+		'snapshots',
+		snapshotId,
+		'assetSets',
+		revisionId,
+		'parts'
+	);
+}
+
 function integer(value: unknown, minimum: number, maximum: number, label: string): number {
 	if (!Number.isSafeInteger(value) || (value as number) < minimum || (value as number) > maximum) {
 		throw new Error(`Cloud snapshot has an invalid ${label}.`);
@@ -614,13 +670,17 @@ function validRevisionId(value: string): boolean {
 	return /^[a-z0-9-]{8,100}$/i.test(value);
 }
 
-function parseRemoteMeta(data: Record<string, unknown>): RemoteSnapshotMeta {
-	const snapshotId = typeof data.snapshotId === 'string' ? data.snapshotId : '';
+function parseSnapshotMeta(
+	snapshotId: string,
+	data: Record<string, unknown>,
+	timestampKey: 'updatedAt' | 'createdAt'
+): RemoteSnapshotMeta {
+	const schemaVersion = data.schemaVersion;
 	const revisionId = typeof data.revisionId === 'string' ? data.revisionId : snapshotId;
 	const parentRevisionId = typeof data.parentRevisionId === 'string' ? data.parentRevisionId : null;
 	const checksum = typeof data.checksum === 'string' ? data.checksum : '';
 	if (
-		data.schemaVersion !== CLOUD_SNAPSHOT_VERSION ||
+		(schemaVersion !== CLOUD_SNAPSHOT_LEGACY_VERSION && schemaVersion !== CLOUD_SNAPSHOT_VERSION) ||
 		!validSnapshotId(snapshotId) ||
 		!validRevisionId(revisionId) ||
 		(parentRevisionId !== null && !validRevisionId(parentRevisionId)) ||
@@ -629,43 +689,56 @@ function parseRemoteMeta(data: Record<string, unknown>): RemoteSnapshotMeta {
 		throw new Error('Cloud snapshot metadata is invalid.');
 	}
 
+	let payloadChecksum = checksum;
+	let assetRevisionId: string | null = null;
+	let assetPartCount = 0;
+	let assetBytes = 0;
+	let assetChecksum: string | null = null;
+	if (schemaVersion === CLOUD_SNAPSHOT_VERSION) {
+		payloadChecksum = typeof data.payloadChecksum === 'string' ? data.payloadChecksum : '';
+		assetRevisionId = typeof data.assetRevisionId === 'string' ? data.assetRevisionId : null;
+		assetPartCount = integer(data.assetPartCount, 0, MAX_CLOUD_ASSET_PARTS, 'image part count');
+		assetBytes = integer(data.assetBytes, 0, MAX_CLOUD_ASSET_BYTES, 'image size');
+		assetChecksum = typeof data.assetChecksum === 'string' ? data.assetChecksum : null;
+		const expectedPartCount = assetBytes === 0 ? 0 : Math.ceil(assetBytes / CLOUD_ASSET_CHUNK_BYTES);
+		if (
+			!/^[a-f0-9]{64}$/.test(payloadChecksum)
+			|| assetPartCount !== expectedPartCount
+			|| (assetPartCount === 0
+				? assetRevisionId !== null || assetChecksum !== null
+				: assetRevisionId !== revisionId || !assetChecksum || !/^[a-f0-9]{64}$/.test(assetChecksum))
+		) {
+			throw new Error('Cloud snapshot image metadata is invalid.');
+		}
+	}
+
 	return {
+		schemaVersion: schemaVersion as number,
 		snapshotId,
 		revisionId,
 		parentRevisionId,
 		checksum,
+		payloadChecksum,
 		partCount: integer(data.partCount, 1, MAX_SNAPSHOT_PARTS, 'part count'),
 		totalBytes: integer(data.totalBytes, 0, MAX_SNAPSHOT_BYTES, 'size'),
-		updatedAt: timestampMillis(data, 'updatedAt'),
+		assetRevisionId,
+		assetPartCount,
+		assetBytes,
+		assetChecksum,
+		updatedAt: timestampMillis(data, timestampKey),
 		meaningful: data.meaningful === true
 	};
 }
 
+function parseRemoteMeta(data: Record<string, unknown>): RemoteSnapshotMeta {
+	const snapshotId = typeof data.snapshotId === 'string' ? data.snapshotId : '';
+	return parseSnapshotMeta(snapshotId, data, 'updatedAt');
+}
+
 function parseHistoryMeta(snapshotId: string, data: Record<string, unknown>): RemoteSnapshotMeta | null {
 	try {
-		const revisionId = typeof data.revisionId === 'string' ? data.revisionId : '';
-		const parentRevisionId = typeof data.parentRevisionId === 'string' ? data.parentRevisionId : null;
-		const checksum = typeof data.checksum === 'string' ? data.checksum : '';
-		if (
-			data.schemaVersion !== CLOUD_SNAPSHOT_VERSION ||
-			data.status !== 'ready' ||
-			!validSnapshotId(snapshotId) ||
-			!validRevisionId(revisionId) ||
-			(parentRevisionId !== null && !validRevisionId(parentRevisionId)) ||
-			!/^[a-f0-9]{64}$/.test(checksum)
-		) {
-			return null;
-		}
-		return {
-			snapshotId,
-			revisionId,
-			parentRevisionId,
-			checksum,
-			partCount: integer(data.partCount, 1, MAX_SNAPSHOT_PARTS, 'part count'),
-			totalBytes: integer(data.totalBytes, 0, MAX_SNAPSHOT_BYTES, 'size'),
-			updatedAt: timestampMillis(data, 'createdAt'),
-			meaningful: data.meaningful === true
-		};
+		if (data.status !== 'ready') return null;
+		return parseSnapshotMeta(snapshotId, data, 'createdAt');
 	} catch {
 		return null;
 	}
@@ -708,7 +781,7 @@ function publishHistory(history: RemoteSnapshotMeta[], currentRevisionId: string
 			revisionId: revision.revisionId,
 			createdAt: revision.updatedAt,
 			current: revision.revisionId === currentRevisionId,
-			totalBytes: revision.totalBytes
+			totalBytes: revision.totalBytes + revision.assetBytes
 		}))
 	}));
 }
@@ -718,67 +791,231 @@ function makeRevisionId(): string {
 	return `${Date.now().toString(36)}-${random.replaceAll('-', '')}`;
 }
 
+function cloudAssetSet(meta: RemoteSnapshotMeta | null): CloudAssetSet | null {
+	if (!meta?.assetRevisionId || meta.assetPartCount === 0 || !meta.assetChecksum) return null;
+	return {
+		snapshotId: meta.snapshotId,
+		revisionId: meta.assetRevisionId,
+		partCount: meta.assetPartCount,
+		totalBytes: meta.assetBytes,
+		checksum: meta.assetChecksum
+	};
+}
+
+async function deleteCloudAssetSet(db: Firestore, uid: string, assetSet: CloudAssetSet): Promise<void> {
+	const result = await getDocs(
+		query(assetPartsRef(db, uid, assetSet.snapshotId, assetSet.revisionId), orderBy('index'))
+	);
+	for (let offset = 0; offset < result.docs.length; offset += CLOUD_ASSET_BATCH_PARTS) {
+		const batch = writeBatch(db);
+		for (const part of result.docs.slice(offset, offset + CLOUD_ASSET_BATCH_PARTS)) {
+			batch.delete(part.ref);
+		}
+		await batch.commit();
+	}
+	await deleteDoc(assetSetRef(db, uid, assetSet.snapshotId, assetSet.revisionId));
+}
+
+async function deleteCloudAssetSetQuietly(
+	db: Firestore,
+	uid: string,
+	assetSet: CloudAssetSet,
+	label: string
+): Promise<void> {
+	try {
+		await deleteCloudAssetSet(db, uid, assetSet);
+	} catch (error) {
+		console.warn(`Cojudge Cloud could not clean up ${label} image data:`, error);
+	}
+}
+
+async function stageCloudAssetSet(
+	db: Firestore,
+	uid: string,
+	assetSet: CloudAssetSet,
+	parts: readonly Uint8Array[]
+): Promise<void> {
+	// Asset chunks are immutable once marked ready. The later snapshot transaction
+	// can publish only a ready set, so interrupted uploads are never visible.
+	const reference = assetSetRef(db, uid, assetSet.snapshotId, assetSet.revisionId);
+	try {
+		await setDoc(reference, {
+			schemaVersion: CLOUD_ASSET_SET_VERSION,
+			status: 'staging',
+			snapshotId: assetSet.snapshotId,
+			revisionId: assetSet.revisionId,
+			partCount: assetSet.partCount,
+			totalBytes: assetSet.totalBytes,
+			checksum: assetSet.checksum,
+			createdAt: serverTimestamp()
+		});
+		for (let offset = 0; offset < parts.length; offset += CLOUD_ASSET_BATCH_PARTS) {
+			const batch = writeBatch(db);
+			for (let index = offset; index < Math.min(parts.length, offset + CLOUD_ASSET_BATCH_PARTS); index++) {
+				batch.set(
+					doc(
+						assetPartsRef(db, uid, assetSet.snapshotId, assetSet.revisionId),
+						index.toString().padStart(4, '0')
+					),
+					{ index, data: Bytes.fromUint8Array(parts[index]) }
+				);
+			}
+			await batch.commit();
+		}
+		await updateDoc(reference, { status: 'ready' });
+	} catch (error) {
+		await deleteCloudAssetSetQuietly(db, uid, assetSet, 'an incomplete upload');
+		throw error;
+	}
+}
+
 async function uploadSnapshot(
 	db: Firestore,
 	uid: string,
 	local: UploadSnapshot,
 	previous: RemoteSnapshotMeta | null
 ): Promise<string> {
-	const { parts, totalBytes } = encodeProgressParts(local.serialized);
+	const extracted = await extractCloudAssets(local.data);
+	const payloadSerialized = serializeProgressData(extracted.data);
+	const payloadChecksum = await hashProgress(payloadSerialized);
+	const { parts, totalBytes } = encodeProgressParts(payloadSerialized);
 	if (totalBytes > MAX_SNAPSHOT_BYTES || parts.length > MAX_SNAPSHOT_PARTS) {
-		throw new Error('This progress snapshot is too large for Cojudge Cloud.');
+		throw new Error('Progress text is too large for Cojudge Cloud even after images were separated.');
+	}
+	const assetParts = encodeCloudAssetParts(extracted.bytes);
+	if (extracted.bytes.length > MAX_CLOUD_ASSET_BYTES || assetParts.length > MAX_CLOUD_ASSET_PARTS) {
+		throw new Error('Cloud images exceed the 64 MB limit.');
 	}
 
 	const snapshotId = nextCloudSnapshotSlot(previous?.snapshotId ?? null);
 	const revisionId = makeRevisionId();
 	const parentRevisionId = previous?.revisionId ?? null;
 	const manifest = snapshotRef(db, uid, snapshotId);
-	await runTransaction(db, async (transaction) => {
-		const reference = latestRef(db, uid);
-		const current = await transaction.get(reference);
-		const previousManifest = await transaction.get(manifest);
-		const previousPartCount = previousManifest.exists()
-			? integer(previousManifest.data().partCount, 1, MAX_SNAPSHOT_PARTS, 'part count')
-			: 0;
-		const currentData = current.exists() ? current.data() : null;
-		const currentSnapshotId = typeof currentData?.snapshotId === 'string' ? currentData.snapshotId : null;
-		const currentRevisionId = typeof currentData?.revisionId === 'string'
-			? currentData.revisionId
-			: currentSnapshotId;
-		if (currentRevisionId !== parentRevisionId) {
-			throw new Error('Cloud progress changed on another device. Sync again.');
-		}
+	const assetChecksum = extracted.bytes.length > 0
+		? await hashCloudAssetBytes(extracted.bytes)
+		: null;
+	const stagedAssetSet: CloudAssetSet | null = assetChecksum
+		? {
+				snapshotId,
+				revisionId,
+				partCount: assetParts.length,
+				totalBytes: extracted.bytes.length,
+				checksum: assetChecksum
+			}
+		: null;
+	if (stagedAssetSet) await stageCloudAssetSet(db, uid, stagedAssetSet, assetParts);
 
-		transaction.set(manifest, {
-			schemaVersion: CLOUD_SNAPSHOT_VERSION,
-			status: 'ready',
-			revisionId,
-			parentRevisionId,
-			checksum: local.checksum,
-			partCount: parts.length,
-			totalBytes,
-			meaningful: local.meaningful,
-			createdAt: serverTimestamp()
+	let replacedAssetSet: CloudAssetSet | null = null;
+	try {
+		replacedAssetSet = await runTransaction(db, async (transaction) => {
+			const reference = latestRef(db, uid);
+			const current = await transaction.get(reference);
+			const previousManifest = await transaction.get(manifest);
+			const previousPartCount = previousManifest.exists()
+				? integer(previousManifest.data().partCount, 1, MAX_SNAPSHOT_PARTS, 'part count')
+				: 0;
+			const previousMeta = previousManifest.exists()
+				? parseHistoryMeta(previousManifest.id, previousManifest.data())
+				: null;
+			const currentData = current.exists() ? current.data() : null;
+			const currentSnapshotId = typeof currentData?.snapshotId === 'string' ? currentData.snapshotId : null;
+			const currentRevisionId = typeof currentData?.revisionId === 'string'
+				? currentData.revisionId
+				: currentSnapshotId;
+			if (currentRevisionId !== parentRevisionId) {
+				throw new Error('Cloud progress changed on another device. Sync again.');
+			}
+
+			const assetMetadata = {
+				payloadChecksum,
+				assetRevisionId: stagedAssetSet?.revisionId ?? null,
+				assetPartCount: stagedAssetSet?.partCount ?? 0,
+				assetBytes: stagedAssetSet?.totalBytes ?? 0,
+				assetChecksum: stagedAssetSet?.checksum ?? null
+			};
+			transaction.set(manifest, {
+				schemaVersion: CLOUD_SNAPSHOT_VERSION,
+				status: 'ready',
+				revisionId,
+				parentRevisionId,
+				checksum: local.checksum,
+				...assetMetadata,
+				partCount: parts.length,
+				totalBytes,
+				meaningful: local.meaningful,
+				createdAt: serverTimestamp()
+			});
+			for (let index = 0; index < MAX_SNAPSHOT_PARTS; index++) {
+				const part = doc(partsRef(db, uid, snapshotId), index.toString().padStart(4, '0'));
+				if (index < parts.length) transaction.set(part, { index, data: parts[index] });
+				else if (index < previousPartCount) transaction.delete(part);
+			}
+			transaction.set(reference, {
+				schemaVersion: CLOUD_SNAPSHOT_VERSION,
+				snapshotId,
+				revisionId,
+				parentRevisionId,
+				checksum: local.checksum,
+				...assetMetadata,
+				partCount: parts.length,
+				totalBytes,
+				storageUsed: totalBytes + (stagedAssetSet?.totalBytes ?? 0),
+				meaningful: local.meaningful,
+				updatedAt: serverTimestamp()
+			});
+			return cloudAssetSet(previousMeta);
 		});
-		for (let index = 0; index < MAX_SNAPSHOT_PARTS; index++) {
-			const part = doc(partsRef(db, uid, snapshotId), index.toString().padStart(4, '0'));
-			if (index < parts.length) transaction.set(part, { index, data: parts[index] });
-			else if (index < previousPartCount) transaction.delete(part);
+	} catch (error) {
+		if (stagedAssetSet) {
+			await deleteCloudAssetSetQuietly(db, uid, stagedAssetSet, 'the rejected upload');
 		}
-		transaction.set(reference, {
-			schemaVersion: CLOUD_SNAPSHOT_VERSION,
-			snapshotId,
-			revisionId,
-			parentRevisionId,
-			checksum: local.checksum,
-			partCount: parts.length,
-			totalBytes,
-			storageUsed: totalBytes,
-			meaningful: local.meaningful,
-			updatedAt: serverTimestamp()
-		});
-	});
+		throw error;
+	}
+	if (replacedAssetSet && replacedAssetSet.revisionId !== revisionId) {
+		await deleteCloudAssetSetQuietly(db, uid, replacedAssetSet, 'an expired revision');
+	}
 	return revisionId;
+}
+
+async function downloadCloudAssetSet(
+	db: Firestore,
+	uid: string,
+	meta: RemoteSnapshotMeta
+): Promise<Uint8Array> {
+	const assetSet = cloudAssetSet(meta);
+	if (!assetSet) return new Uint8Array();
+
+	const manifest = await getDoc(assetSetRef(db, uid, assetSet.snapshotId, assetSet.revisionId));
+	const manifestData = manifest.exists() ? manifest.data() : null;
+	if (
+		!manifestData
+		|| manifestData.schemaVersion !== CLOUD_ASSET_SET_VERSION
+		|| manifestData.status !== 'ready'
+		|| manifestData.snapshotId !== assetSet.snapshotId
+		|| manifestData.revisionId !== assetSet.revisionId
+		|| manifestData.partCount !== assetSet.partCount
+		|| manifestData.totalBytes !== assetSet.totalBytes
+		|| manifestData.checksum !== assetSet.checksum
+	) {
+		throw new Error('Cloud image metadata is invalid.');
+	}
+
+	const result = await getDocs(
+		query(assetPartsRef(db, uid, assetSet.snapshotId, assetSet.revisionId), orderBy('index'))
+	);
+	if (result.size !== assetSet.partCount) throw new Error('Cloud image download is incomplete.');
+	const parts = result.docs.map((part, index) => {
+		const data = part.data();
+		if (data.index !== index || !(data.data instanceof Bytes)) {
+			throw new Error('Cloud image download contains an invalid part.');
+		}
+		return data.data.toUint8Array();
+	});
+	const bytes = decodeCloudAssetParts(parts, assetSet.totalBytes);
+	if ((await hashCloudAssetBytes(bytes)) !== assetSet.checksum) {
+		throw new Error('Cloud images failed their integrity check.');
+	}
+	return bytes;
 }
 
 async function downloadSnapshot(
@@ -796,16 +1033,26 @@ async function downloadSnapshot(
 		}
 		return data.data;
 	});
-	const serialized = decodeProgressParts(parts, meta.totalBytes);
-	if ((await hashProgress(serialized)) !== meta.checksum) {
+	const payloadSerialized = decodeProgressParts(parts, meta.totalBytes);
+	if ((await hashProgress(payloadSerialized)) !== meta.payloadChecksum) {
 		throw new Error('Cloud snapshot failed its integrity check.');
 	}
 
-	const parsed = JSON.parse(serialized);
+	const parsed = JSON.parse(payloadSerialized);
 	if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
 		throw new Error('Cloud snapshot has an invalid format.');
 	}
-	return { data: parsed as ProgressData, serialized };
+	if (meta.schemaVersion === CLOUD_SNAPSHOT_LEGACY_VERSION) {
+		return { data: parsed as ProgressData, serialized: payloadSerialized };
+	}
+
+	const assetBytes = await downloadCloudAssetSet(db, uid, meta);
+	const data = await hydrateCloudAssets(parsed as ProgressData, assetBytes);
+	const serialized = serializeProgressData(data);
+	if ((await hashProgress(serialized)) !== meta.checksum) {
+		throw new Error('Cloud snapshot failed its hydrated integrity check.');
+	}
+	return { data, serialized };
 }
 
 async function ensureCloudClone(
@@ -1273,7 +1520,7 @@ async function runSelectedFilePush(
 		]);
 		const serialized = serializeProgressData(mergedData);
 		const upload: UploadSnapshot = {
-			serialized,
+			data: mergedData,
 			checksum: await hashProgress(serialized),
 			meaningful: isMeaningfulProgress(mergedData)
 		};
@@ -1551,7 +1798,7 @@ async function runRevisionDelete(
 			throw new Error('The latest cloud revision cannot be deleted.');
 		}
 
-		await runTransaction(context.db, async (transaction) => {
+		const deletedMeta = await runTransaction(context.db, async (transaction) => {
 			const reference = latestRef(context.db, context.uid);
 			const manifest = snapshotRef(context.db, context.uid, selected.snapshotId);
 			const latestResult = await transaction.get(reference);
@@ -1577,7 +1824,12 @@ async function runRevisionDelete(
 				);
 			}
 			transaction.delete(manifest);
+			return currentSlot;
 		});
+		const deletedAssetSet = cloudAssetSet(deletedMeta);
+		if (deletedAssetSet) {
+			await deleteCloudAssetSetQuietly(context.db, context.uid, deletedAssetSet, 'the deleted revision');
+		}
 		if (!isOperationCurrent(context)) return;
 		const updated = await refreshRemoteState(context.db, context.uid);
 		if (!isOperationCurrent(context)) return;

--- a/src/lib/components/CloudSyncModal.svelte
+++ b/src/lib/components/CloudSyncModal.svelte
@@ -85,7 +85,8 @@
 
     function formatCloudRevisionSize(value: number): string {
         if (value < 1024) return `${value} B`;
-        return `${Math.ceil(value / 1024)} KB`;
+        if (value < 1024 * 1024) return `${Math.ceil(value / 1024)} KB`;
+        return `${(value / (1024 * 1024)).toFixed(1)} MB`;
     }
 
     function close() {

--- a/src/lib/progressBackup.ts
+++ b/src/lib/progressBackup.ts
@@ -26,7 +26,8 @@ const CLOUD_KEYS = new Set([
 ]);
 const CLOUD_KEY_PREFIXES = ['cojudge-whiteboard-v1:share:'];
 
-export const CLOUD_SNAPSHOT_VERSION = 1;
+export const CLOUD_SNAPSHOT_LEGACY_VERSION = 1;
+export const CLOUD_SNAPSHOT_VERSION = 2;
 export const CLOUD_SNAPSHOT_CHUNK_BYTES = 600 * 1024;
 export const CLOUD_RESTORE_SESSION_KEY = 'cojudge-cloud-restoring';
 export const CLOUD_FLUSH_EVENT = 'cojudge:cloud-flush';

--- a/src/lib/utils/imageStore.ts
+++ b/src/lib/utils/imageStore.ts
@@ -193,8 +193,10 @@ export async function importPastedImages(records: Record<string, string>): Promi
             tx.onerror = () => reject(tx.error);
             tx.onabort = () => reject(tx.error);
         });
-    } catch {
-        // ignore
+    } catch (error) {
+        throw new Error(
+            `Pasted images could not be saved locally: ${error instanceof Error ? error.message : String(error)}`
+        );
     }
 }
 


### PR DESCRIPTION
## Summary
- move pasted Markdown, inline data URL, and whiteboard image payloads into immutable revision-scoped Firestore sidecars
- add cloud snapshot schema v2 with staged uploads, checksums, bounded chunking, and cleanup for expired revisions
- preserve schema v1 restore compatibility and exact logical checksums so existing images and sync ancestry continue to work
- update Firestore rules, cloud history sizing, restore failure handling, tests, and deployment documentation

## Verification
- `npm test -- --run` (120 tests)
- `npm run build`
- `npm run test:e2e -- e2e/cloud-sync.test.ts` (4 tests)
- `firebase deploy --only firestore:rules --dry-run --project cojudge-4c7c9`

## Deployment
Deploy `firestore.rules` before releasing the v2 client. The rules continue to accept existing schema v1 revisions.

## Known baseline
`npm run check` still reports the repository's existing unrelated Svelte/TypeScript diagnostics; this change adds no new diagnostics.