### PR TITLE
fix: keep debug session alive when switching to whiteboard tab

### DIFF
--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -6697,9 +6697,12 @@ func main() {
                 Loading...
             {/if}
         </div>
-        {#if language !== 'plaintext' && language !== 'markdown' && !isSpecialTabType(activeTab?.type)}
+        <div
+            class="exec-panel-host"
+            class:hidden={language === 'plaintext' || language === 'markdown' || isSpecialTabType(activeTab?.type)}
+        >
             <PlaygroundExecutionPanel {code} {language} {isMac} bind:output bind:logs debugBreakpoints={debugBreakpoints} bind:activeDebugLine={activeDebugLine} bind:debugJobId={debugJobId} />
-        {/if}
+        </div>
         {:else}
         <div class="empty-state">
             <div class="empty-state-content">
@@ -7513,6 +7516,13 @@ func main() {
     /* Right Pane Layout */
     .editor-pane {
         padding: 0; /* No padding on the pane itself */
+    }
+
+    .exec-panel-host {
+        display: contents;
+    }
+    .exec-panel-host.hidden {
+        display: none;
     }
 
     .editor-container {


### PR DESCRIPTION
## Problem

In Playground debug mode, switching to the whiteboard tab unmounted `PlaygroundExecutionPanel` (the `{#if}` at src/routes/playground/+page.svelte:6700 excluded special tab types). All debug session state (`debugState`, polling interval) lived inside the panel, so the session disappeared. The page-level `bind:debugJobId` survived, leaving the Run/Debug buttons disabled (`disabled={isLoading || !!debugJobId}`) while the server-side session kept running invisibly.

## Fix

Keep the execution panel mounted and hide it with CSS instead of unmounting:

- Wrapped the panel in a `display: contents` host so its percentage height still resolves against `.editor-pane`.
- Toggled to `display: none` on plaintext/markdown/whiteboard/preview tabs.

The debug session now survives tab switches — switching to the whiteboard and back shows the session exactly where it was, and buttons re-enable only when the session actually ends.

Verified: `npm run check` shows no new errors or warnings (12 errors / 28 warnings, all pre-existing).