### PR TITLE
feat: add optional game mode time limit

### DIFF
--- a/src/lib/components/ExecutionPanel.svelte
+++ b/src/lib/components/ExecutionPanel.svelte
@@ -14,6 +14,7 @@
     export let gameMode = false;
     export let gameStartTime = 0;
     export let gameFinished = false;
+    export let gameCountdownSeconds: number | null = null;
     export let debugBreakpoints: number[] = [];
     export let activeDebugLine: number | null = null;
     export let debugJobId: string | null = null;
@@ -1709,7 +1710,12 @@
         <div class="buttons">
             <div style="display: flex; align-items: center; margin-right: 8px;">
                 {#if gameMode && gameStartTime > 0}
-                    <GameModeTimer startTime={gameStartTime} stopped={gameFinished} />
+                    <GameModeTimer
+                        startTime={gameStartTime}
+                        stopped={gameFinished}
+                        countdownSeconds={gameCountdownSeconds}
+                        onExpired={() => dispatch('gameTimeExpired')}
+                    />
                 {/if}
                 <SaveStatus />
             </div>

--- a/src/lib/components/GameModePopup.svelte
+++ b/src/lib/components/GameModePopup.svelte
@@ -10,10 +10,39 @@
     const dispatch = createEventDispatcher();
 
     let includeSolved = false;
+    const COUNTDOWN_STORAGE_KEY = 'cojudge-game-countdown-settings';
+    let countdownEnabled = false;
+    let countdownMinutes = 15;
+
+    if (typeof window !== 'undefined') {
+        try {
+            const saved = JSON.parse(localStorage.getItem(COUNTDOWN_STORAGE_KEY) || 'null');
+            if (saved && typeof saved === 'object') {
+                countdownEnabled = saved.enabled === true;
+                if (Number.isFinite(saved.minutes)) countdownMinutes = Math.max(1, Math.min(60, Math.round(saved.minutes)));
+            }
+        } catch { /* use defaults */ }
+    }
+
+    function persistCountdownSettings() {
+        if (typeof window !== 'undefined') {
+            localStorage.setItem(COUNTDOWN_STORAGE_KEY, JSON.stringify({ enabled: countdownEnabled, minutes: countdownMinutes }));
+        }
+    }
+
+    function gameUrl(problemId: string) {
+        persistCountdownSettings();
+        const params = new URLSearchParams({ gameMode: '1' });
+        if (countdownEnabled) {
+            params.set('countdown', '1');
+            params.set('minutes', String(countdownMinutes));
+        }
+        return `/problems/${problemId}?${params.toString()}`;
+    }
 
     async function startGame() {
         if (currentProblemId) {
-            window.location.href = `/problems/${currentProblemId}?gameMode=1`;
+            window.location.href = gameUrl(currentProblemId);
             return;
         }
         let pool = problems;
@@ -28,7 +57,7 @@
         }
         const randomIndex = Math.floor(Math.random() * pool.length);
         const chosen = pool[randomIndex];
-        window.location.href = `/problems/${chosen.id}?gameMode=1`;
+        window.location.href = gameUrl(chosen.id);
     }
 
     function handleBackdropClick(e: MouseEvent) {
@@ -67,6 +96,17 @@
             </table>
             <p class="rank-info">Final rank: <strong>S</strong> (best) → <strong>A</strong> → <strong>B</strong> → <strong>C</strong></p>
         </div>
+        <label class="toggle-label">
+            <input type="checkbox" bind:checked={countdownEnabled} on:change={persistCountdownSettings} />
+            Enable Time Limit
+        </label>
+        {#if countdownEnabled}
+            <div class="countdown-control">
+                <button type="button" aria-label="Decrease countdown" on:click={() => { countdownMinutes = Math.max(1, countdownMinutes - 1); persistCountdownSettings(); }}>-</button>
+                <strong>{countdownMinutes} mins</strong>
+                <button type="button" aria-label="Increase countdown" on:click={() => { countdownMinutes = Math.min(60, countdownMinutes + 1); persistCountdownSettings(); }}>+</button>
+            </div>
+        {/if}
         {#if !currentProblemId}
             <label class="toggle-label">
                 <input type="checkbox" bind:checked={includeSolved} />
@@ -155,6 +195,28 @@
         text-align: center;
         margin-top: 0.5rem;
         color: var(--color-text);
+    }
+    .countdown-control {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin: -0.5rem 0 1.25rem 1.65rem;
+        color: var(--color-text);
+    }
+    .countdown-control button {
+        width: 30px;
+        height: 30px;
+        border: 1px solid var(--color-border);
+        border-radius: 6px;
+        background: var(--color-surface);
+        color: var(--color-text);
+        font-size: 1.2rem;
+        cursor: pointer;
+    }
+    .countdown-control strong {
+        min-width: 65px;
+        text-align: center;
+        font-variant-numeric: tabular-nums;
     }
     .toggle-label {
         display: flex;

--- a/src/lib/components/GameModeTimer.svelte
+++ b/src/lib/components/GameModeTimer.svelte
@@ -3,12 +3,19 @@
 
     export let startTime: number;
     export let stopped = false;
+    export let countdownSeconds: number | null = null;
+    export let onExpired: (() => void) | null = null;
 
     let elapsed = 0;
+    let expired = false;
     let interval: ReturnType<typeof setInterval>;
 
     function tick() {
         elapsed = Math.floor((Date.now() - startTime) / 1000);
+        if (countdownSeconds !== null && elapsed >= countdownSeconds && !expired) {
+            expired = true;
+            onExpired?.();
+        }
     }
 
     tick();
@@ -23,8 +30,9 @@
         if (interval) clearInterval(interval);
     });
 
-    $: minutes = Math.floor(elapsed / 60);
-    $: seconds = elapsed % 60;
+    $: remaining = countdownSeconds === null ? elapsed : Math.max(0, countdownSeconds - elapsed);
+    $: minutes = Math.floor(remaining / 60);
+    $: seconds = remaining % 60;
     $: display = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
 </script>
 

--- a/src/lib/components/GameResultPopup.svelte
+++ b/src/lib/components/GameResultPopup.svelte
@@ -7,6 +7,7 @@
     export let runCount: number;
     export let submitCount: number;
     export let timeSpent: number; // in seconds
+    export let expired = false;
 
     function clamp(val: number, min: number, max: number) {
         return Math.max(min, Math.min(max, val));
@@ -41,11 +42,16 @@
 <div class="modal-backdrop" on:click={handleBackdropClick} on:keydown={handleKeydown} role="dialog" aria-modal="true" tabindex="-1" transition:fade={{ duration: 200 }}>
     <div class="modal" transition:scale={{ start: 0.95, duration: 200 }}>
         <button class="close-btn" on:click={() => dispatch('close')} aria-label="Close">&times;</button>
-        <h2>Game Over</h2>
+        <h2>{expired ? 'Time\'s Up' : 'Game Over'}</h2>
 
-        <div class="rank-circle" class:rank-s={rank === 'S'} class:rank-a={rank === 'A'} class:rank-b={rank === 'B'} class:rank-c={rank === 'C'}>
-            {rank}
-        </div>
+        {#if expired}
+            <div class="rank-circle expired">F</div>
+            <p class="encouragement">Keep going — every attempt helps you get closer. Submit again when you’re ready!</p>
+        {:else}
+            <div class="rank-circle" class:rank-s={rank === 'S'} class:rank-a={rank === 'A'} class:rank-b={rank === 'B'} class:rank-c={rank === 'C'}>
+                {rank}
+            </div>
+        {/if}
 
         <table class="stats">
             <tbody>
@@ -67,9 +73,11 @@
             </tbody>
         </table>
 
-        <div class="total">
-            Total Score: <strong>{totalScore}</strong> &rarr; Rank <strong class="rank-label" class:rank-s={rank === 'S'} class:rank-a={rank === 'A'} class:rank-b={rank === 'B'} class:rank-c={rank === 'C'}>{rank}</strong>
-        </div>
+        {#if !expired}
+            <div class="total">
+                Total Score: <strong>{totalScore}</strong> &rarr; Rank <strong class="rank-label" class:rank-s={rank === 'S'} class:rank-a={rank === 'A'} class:rank-b={rank === 'B'} class:rank-c={rank === 'C'}>{rank}</strong>
+            </div>
+        {/if}
 
         <button class="home-btn" on:click={goHome}>Back to Home</button>
     </div>
@@ -129,6 +137,15 @@
         font-size: 2.5rem;
         font-weight: 800;
         color: #fff;
+    }
+    .expired {
+        background: linear-gradient(135deg, #ef4444, #991b1b);
+        box-shadow: 0 4px 15px rgba(239, 68, 68, 0.35);
+    }
+    .encouragement {
+        margin: -0.5rem 0 1.25rem;
+        color: var(--color-text-secondary);
+        line-height: 1.5;
     }
     .rank-s {
         background: linear-gradient(135deg, #ffd700, #f59e0b);

--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -49,6 +49,8 @@
     let isGameMode = false;
     let gameStartTime = 0;
     let gameFinished = false;
+    let gameCountdownSeconds: number | null = null;
+    let gameExpired = false;
     let showGameResult = false;
     let gameResultStats: { runCount: number; submitCount: number; timeSpent: number } | null = null;
     let showGameHistory = false;
@@ -596,6 +598,10 @@
         // Check for game mode
         if (urlParams.get('gameMode') === '1') {
             isGameMode = true;
+            const countdownMinutes = Number(urlParams.get('minutes'));
+            if (urlParams.get('countdown') === '1' && Number.isFinite(countdownMinutes) && countdownMinutes > 0) {
+                gameCountdownSeconds = Math.round(countdownMinutes * 60);
+            }
             gameStartTime = Date.now();
             // Force fresh starter code, ignore saved
             suppressSave = true;
@@ -1319,11 +1325,20 @@
             {language}
             gameMode={isGameMode}
             gameStartTime={gameStartTime}
+            gameCountdownSeconds={gameCountdownSeconds}
             {gameFinished}
             debugBreakpoints={debugBreakpoints}
             bind:activeDebugLine={activeDebugLine}
             bind:debugJobId={debugJobId}
+            on:gameTimeExpired={() => {
+                if (gameFinished || gameResultStats) return;
+                gameExpired = true;
+                gameFinished = true;
+                gameResultStats = { runCount: 0, submitCount: 0, timeSpent: gameCountdownSeconds || 0 };
+                showGameResult = true;
+            }}
             on:gameSubmitSuccess={(e) => {
+                if (gameFinished || gameExpired) return;
                 const { runCount, submitCount, timeSpent } = e.detail;
                 const result = computeGameResult(runCount, submitCount, timeSpent, code, language);
                 gameResultsStore.update((prev) => ({
@@ -1357,6 +1372,7 @@
             runCount={gameResultStats.runCount}
             submitCount={gameResultStats.submitCount}
             timeSpent={gameResultStats.timeSpent}
+            expired={gameExpired}
             on:close={() => { showGameResult = false; gameFinished = true; }}
         />
     {/if}


### PR DESCRIPTION
## Summary\n- add a locally persisted Enable Time Limit option with adjustable minutes\n- show remaining time and an F result when the limit expires\n- prevent expired sessions from producing later rankings\n\n## Validation\n- git diff --check\n- pnpm check (existing unrelated diagnostics remain)