### PR TITLE
Fix playground language picker and game mode settings

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -490,7 +490,7 @@
   position: fixed;
   z-index: 10000;
   width: 220px;
-  background-color: var(--color-surface);
+  background-color: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: 8px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18), 0 2px 6px rgba(0, 0, 0, 0.08);

--- a/src/lib/components/GameModePopup.svelte
+++ b/src/lib/components/GameModePopup.svelte
@@ -9,6 +9,7 @@
 
     const dispatch = createEventDispatcher();
 
+    const INCLUDE_SOLVED_STORAGE_KEY = 'cojudge-game-include-solved';
     let includeSolved = false;
     const COUNTDOWN_STORAGE_KEY = 'cojudge-game-countdown-settings';
     let countdownEnabled = false;
@@ -16,12 +17,19 @@
 
     if (typeof window !== 'undefined') {
         try {
+            includeSolved = localStorage.getItem(INCLUDE_SOLVED_STORAGE_KEY) === 'true';
             const saved = JSON.parse(localStorage.getItem(COUNTDOWN_STORAGE_KEY) || 'null');
             if (saved && typeof saved === 'object') {
                 countdownEnabled = saved.enabled === true;
                 if (Number.isFinite(saved.minutes)) countdownMinutes = Math.max(1, Math.min(60, Math.round(saved.minutes)));
             }
         } catch { /* use defaults */ }
+    }
+
+    function persistIncludeSolved() {
+        if (typeof window !== 'undefined') {
+            localStorage.setItem(INCLUDE_SOLVED_STORAGE_KEY, String(includeSolved));
+        }
     }
 
     function persistCountdownSettings() {
@@ -109,7 +117,7 @@
         {/if}
         {#if !currentProblemId}
             <label class="toggle-label">
-                <input type="checkbox" bind:checked={includeSolved} />
+                <input type="checkbox" bind:checked={includeSolved} on:change={persistIncludeSolved} />
                 Include already solved problems
             </label>
         {/if}

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -2584,8 +2584,10 @@ func main() {
     function selectCodeLanguage(langValue: string) {
         if (!activeLangPicker) return;
         const { wrapper, historyBefore } = activeLangPicker;
+        const scrollX = window.scrollX;
+        const scrollY = window.scrollY;
         if (historyBefore && wysiwygEl) {
-            wysiwygEl.focus();
+            wysiwygEl.focus({ preventScroll: true });
             restoreWysiwygSelection(historyBefore);
         }
         setCodeBlockLanguage(wrapper, langValue);
@@ -2598,7 +2600,8 @@ func main() {
         }, 2500);
         handleWysiwygInput();
         finishWysiwygHistoryEntry(historyBefore);
-        wysiwygEl?.focus();
+        wysiwygEl?.focus({ preventScroll: true });
+        window.scrollTo(scrollX, scrollY);
     }
 
     function handleLangSearchKeyDown(e: KeyboardEvent) {


### PR DESCRIPTION
## Summary
- preserve scroll position when changing a WYSIWYG code block language
- persist the Game Mode “Include already solved problems” toggle
- use the theme background for the picker surface

## Validation
- `git diff --check`
- `npm run check` (existing unrelated diagnostics remain)