### PR TITLE
fix: preserve Go array inputs

### DIFF
--- a/src/lib/utils/goUtil.test.ts
+++ b/src/lib/utils/goUtil.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// @ts-expect-error SvelteKit's virtual module is not present in plain Vitest.
+vi.mock('$env/dynamic/private', () => ({ env: {} }), { virtual: true });
+
+import { goGetFullParam } from './goUtil';
+
+describe('goGetFullParam', () => {
+  it('serializes int arrays without changing their elements', () => {
+    const params = [{ name: 'nums', type: 'int_array' }];
+    const result = goGetFullParam(params as any, {
+      nums: [100, 4, 200, 1, 3, 2]
+    });
+
+    expect(result).toBe('toIntArray("[100,4,200,1,3,2]")');
+  });
+
+  it('preserves preformatted int array strings', () => {
+    const params = [{ name: 'nums', type: 'int_array' }];
+    const result = goGetFullParam(params as any, { nums: '[1, 2, 3]' });
+
+    expect(result).toBe('toIntArray("[1, 2, 3]")');
+  });
+});

--- a/src/lib/utils/goUtil.ts
+++ b/src/lib/utils/goUtil.ts
@@ -461,7 +461,13 @@ export function goGetFullParam(params: Param[], tc: any): string {
         } else if (p.type === "boolean") {
             parts.push(String(val) === "true" ? "true" : "false");
         } else if (p.type === "int_array") {
-            parts.push(`toIntArray(${goEscapeStringLiteral(val ?? "[]")})`);
+            let strVal: string;
+            if (Array.isArray(val)) {
+                try { strVal = JSON.stringify(val); } catch { strVal = '[]'; }
+            } else {
+                strVal = String(val ?? '[]');
+            }
+            parts.push(`toIntArray(${goEscapeStringLiteral(strVal)})`);
         } else if (p.type === "int_array_2d" || p.type === "int_matrix") {
             let strVal: string;
             if (Array.isArray(val)) {


### PR DESCRIPTION
## Summary
- serialize Go int_array test inputs as JSON when metadata provides arrays
- preserve existing preformatted array strings
- add regression coverage for both input forms

## Verification
- cojudge run longest-consecutive-sequence: 3/3 sample cases passed
- cojudge submit longest-consecutive-sequence: 5/5 official cases passed
- npx vitest run: 123 tests passed
- npm run build passed