### PR TITLE
fix: opt-in folder reveal and unique download filenames

### DIFF
--- a/src/routes/api/export-file/+server.ts
+++ b/src/routes/api/export-file/+server.ts
@@ -4,6 +4,23 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
 
+async function uniqueFilePath(targetDir: string, filename: string): Promise<string> {
+    const ext = path.extname(filename);
+    const stem = path.basename(filename, ext);
+    let n = 0;
+    while (n < 10000) {
+        const name = n === 0 ? filename : `${stem}-${n}${ext}`;
+        const filePath = path.join(targetDir, name);
+        try {
+            await fs.access(filePath);
+            n += 1;
+        } catch {
+            return filePath;
+        }
+    }
+    throw new Error('Could not allocate a unique filename');
+}
+
 export const POST: RequestHandler = async ({ request }) => {
     try {
         const { base64Data, textData, filename } = await request.json();
@@ -26,7 +43,7 @@ export const POST: RequestHandler = async ({ request }) => {
                 .replace(/[<>:"/\\|?*\x00-\x1F]/g, '_')
                 .trim()
                 .slice(0, 200) || 'export.json';
-        const filePath = path.join(targetDir, safeFilename);
+        const filePath = await uniqueFilePath(targetDir, safeFilename);
 
         if (textData !== undefined) {
             await fs.writeFile(filePath, textData, 'utf8');

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -8,7 +8,7 @@
     import Tooltip from '$lib/components/Tooltip.svelte';
     import WhiteboardIcon from '$lib/components/WhiteboardIcon.svelte';
     import Whiteboard from '$lib/components/Whiteboard.svelte';
-    import { showAlert, showConfirm } from '$lib/dialogs';
+    import { showAlert, showChoice, showConfirm } from '$lib/dialogs';
     import { consumeForkTransfer } from '$lib/forkTransfer';
     import { ensureAuthenticated, initFirebase } from '$lib/firebase';
     import { isDesktopRuntime } from '$lib/firebaseSettings';
@@ -1012,8 +1012,13 @@ func main() {
                 });
                 const result = await response.json();
                 if (result.success) {
-                    void revealExportedFile(result.filePath);
-                    await showAlert(`Saved to ${result.filePath}`, { title: successTitle });
+                    const openFolder = await showChoice(`Saved to ${result.filePath}`, {
+                        title: successTitle,
+                        confirmLabel: 'Open Containing Folder',
+                        cancelLabel: 'Close',
+                        tone: 'success'
+                    });
+                    if (openFolder) await revealExportedFile(result.filePath);
                 } else {
                     await showAlert(result.error || 'Failed to save file', { title: 'Download failed' });
                 }


### PR DESCRIPTION
## Summary
- Desktop playground downloads no longer auto-open the containing folder; the success dialog offers **Open Containing Folder** instead.
- Export filenames that already exist get `-1`, `-2`, … suffixes before the extension so prior downloads are not overwritten.

## Test plan
- [ ] In desktop mode, download a playground file and confirm the folder does not open automatically
- [ ] Click **Open Containing Folder** and confirm the file is revealed
- [ ] Download the same file again and confirm a `name-1.ext` file is created beside the original
- [ ] Dismiss with **Close** / Escape and confirm no reveal occurs