### PR TITLE
fix(whiteboard): preserve consecutive and leading spaces in text elements

### DIFF
--- a/src/lib/components/Whiteboard.svelte
+++ b/src/lib/components/Whiteboard.svelte
@@ -2098,9 +2098,15 @@
 								fill={resolvedStroke(element.stroke, isDark)}
 								font-size={element.fontSize}
 								font-family="'Comic Sans MS', 'Bradley Hand', cursive"
+								xml:space="preserve"
+								style="white-space: pre;"
 							>
 								{#each (element.text ?? '').split('\n') as line, index}
-									<tspan x={element.x} y={element.y + element.fontSize + index * element.fontSize * 1.25}
+									<tspan
+										x={element.x}
+										y={element.y + element.fontSize + index * element.fontSize * 1.25}
+										xml:space="preserve"
+										style="white-space: pre;"
 										>{line || ' '}</tspan
 									>
 								{/each}


### PR DESCRIPTION
### Problem
Whiteboard text collapses leading spaces and consecutive spaces after exiting edit mode (reported with screenshots).

- `textarea` editor uses `white-space: pre` so spaces are visible while editing.
- Rendered SVG used `<text><tspan>{line}</tspan></text>` without `xml:space`.
  SVG 1.1 defaults to `xml:space="default"` which trims leading spaces and compresses `  ` to ` `.
- `textDimensions()` measures via `canvas.measureText()` (preserves spaces), causing bounds / selection width mismatch seen in Image 2.

### Fix
- `src/lib/components/Whiteboard.svelte:2097-2104`: add `xml:space="preserve"` and `style="white-space: pre;"` to both `<text>` and `<tspan>`.
- Verified with `npm run build`; compiled chunk contains `<tspan xml:space="preserve" style="white-space: pre;">` and `<text … xml:space="preserve">`.

Resolves: leading-space and consecutive-space compression.
