### PR TITLE
fix(playground): keep multiline paste inside single WYSIWYG code block

### DIFF
--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -5131,10 +5131,28 @@ func main() {
 
         // Code blocks are plain-text editing surfaces. Handling this ourselves
         // avoids rich clipboard HTML and keeps highlighting in one undo step.
+        // `execCommand('insertText')` with a multiline string splits the <pre>
+        // into multiple <pre> elements (one per line) inside the same wrapper,
+        // which then round-trips to multiple fenced blocks (see reproduction).
+        // Insert via Range as a single TextNode so newlines stay inside one <pre>.
         if (getPreFromSelection()) {
             event.preventDefault();
             runWysiwygHistoryTransaction(() => {
-                document.execCommand('insertText', false, pasted);
+                const selection = window.getSelection();
+                if (!selection || selection.rangeCount === 0) return;
+                const range = selection.getRangeAt(0);
+                if (!range.collapsed) range.deleteContents();
+                const normalized = pasted.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+                if (normalized.length === 0) {
+                    handleWysiwygInput();
+                    return;
+                }
+                const textNode = document.createTextNode(normalized);
+                range.insertNode(textNode);
+                range.setStartAfter(textNode);
+                range.collapse(true);
+                selection.removeAllRanges();
+                selection.addRange(range);
                 handleWysiwygInput();
             }, historyBefore, 'insertFromPaste');
             return;


### PR DESCRIPTION
When pasting multiline plain text into an empty WYSIWYG code block, `execCommand('insertText')` splits the `<pre>` into one `<pre>` per line inside the same wrapper (see reproduction: 8 `<pre>` for 8 lines), which then round-trips to multiple fenced blocks.

Reproduced via Playwright: create empty code block via ```, paste `#include <bits/stdc++.h>\nusing namespace std;\n\nclass MoBase { ...`, observed 8 `<pre>` inside single `.code-block-wrapper`.

Fix `src/routes/playground/+page.svelte:5131` `handleWysiwygPaste` code-block branch to insert via `Range` as a single `TextNode` (normalize `\r\n`→`\n`), preserving newlines inside one `<pre>` and keeping undo history.

Verified: empty/non-empty, Windows line endings, mid-block paste, and `Ctrl+z`/`Shift+z` all keep `preCount=1`/`wrapperCount=1`; existing WYSIWYG code-block e2e tests still pass.