### PR TITLE
docs(meeting-rooms): clarify touching intervals do not overlap

### DIFF
--- a/problems/meeting-rooms/statement.md
+++ b/problems/meeting-rooms/statement.md
@@ -1,5 +1,7 @@
 Determine if a person could attend all meetings given start-end intervals.
 
+Two intervals that only touch at an endpoint are **not** considered overlapping: for interval `i` appearing before interval `j`, `intervals[i].end == intervals[j].start` does not cause overlap (only when `intervals[i].end > intervals[j].start`).
+
 **Constraints:**
 
 - 0 <= intervals.length <= 10^4


### PR DESCRIPTION
For interval i appearing before interval j, `intervals[i].end == intervals[j].start` does **not** cause overlap (only `intervals[i].end > intervals[j].start` does).

- Edits `problems/meeting-rooms/statement.md:3` to add endpoint-touch clarification
- Aligns statement with `Marker.java:6` logic (`intervals[i][0] < intervals[i-1][1]`) and existing `meeting-rooms-ii` wording
- Verifies `official-tests.json:5-6` cases: `[[1,5],[5,6]] -> true` (touch = no overlap), `[[1,5],[4,6]] -> false` (overlap)
