### PR TITLE
fix(playground): Cmd+B toggles sidebar when no WYSIWYG text selected

### DIFF
--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -5685,6 +5685,22 @@ func main() {
             return;
         }
         if (key === 'b' && !e.shiftKey && !e.altKey) {
+            const selection = window.getSelection();
+            const hasTextSelection =
+                !!selection &&
+                !selection.isCollapsed &&
+                selection.rangeCount > 0 &&
+                !!wysiwygEl &&
+                !!selection.anchorNode &&
+                !!selection.focusNode &&
+                wysiwygEl.contains(selection.anchorNode) &&
+                wysiwygEl.contains(selection.focusNode) &&
+                selection.toString().replace(/\u200B/g, '').trim().length > 0;
+            if (!hasTextSelection) {
+                // No text selected inside the WYSIWYG editor — let the global
+                // Cmd/Ctrl+B handler toggle the sidebar instead of applying bold.
+                return;
+            }
             e.preventDefault();
             applyWysiwygCommand('bold');
         } else if (key === 'i' && !e.shiftKey && !e.altKey) {


### PR DESCRIPTION
When WYSIWYG is focused without a text selection, Cmd/Ctrl+B previously always applied bold formatting and prevented the global shortcut from toggling the sidebar.

Check for a non-collapsed selection inside the editor before handling bold; otherwise let the event bubble to the window handler that toggles the explorer sidebar.

Fixes: Cmd+B should still toggle sidebar if not selecting at least some text on WYSIWYG.