### PR TITLE
fix(problems): stop monaco editor flicker when typing fast

### DIFF
--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -25,6 +25,7 @@
     import { renderMarkdown } from '$lib/utils/markdown';
     import QRCode from 'qrcode';
     import { onMount, tick } from 'svelte';
+    import { get } from 'svelte/store';
     import { v4 as uuidv4 } from 'uuid';
     import gameResultsStore, { computeGameResult } from '$lib/stores/gameResultsStore';
 
@@ -77,7 +78,8 @@
 
     function getFiles(): FileEntry[] {
         try {
-            return JSON.parse($fileStore[fileKey()] || '[]') as FileEntry[];
+            const s = get(fileStore);
+            return JSON.parse(s[fileKey()] || '[]') as FileEntry[];
         } catch (err) {
             return [];
         }


### PR DESCRIPTION
Autosave on the problem editor subscribed to `$fileStore`, so Svelte 5 retriggered `loadOrInitFile` on every keystroke and reset Monaco. Playground already avoided this by reading with `get(fileStore)`.

Use the same non-reactive read on the problems page so fast typing no longer flickers.