### PR TITLE
fix(problems): replace pane eye toggles with layout icons

### DIFF
--- a/src/lib/components/ExecutionPanel.svelte
+++ b/src/lib/components/ExecutionPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { onMount, onDestroy, createEventDispatcher } from "svelte";
-    import { execPaneHeightStore } from "$lib/stores/layoutStore";
+    import { execPaneHeightStore, leftPaneWidthStore } from "$lib/stores/layoutStore";
     import testCaseStore from "$lib/stores/testCaseStore";
     import Tooltip from "./Tooltip.svelte";
     import Visualization from "./Visualization.svelte";
@@ -85,6 +85,24 @@
             $execPaneHeightStore = restore;
         }
     }
+
+    // Problem pane (left) visibility memory and toggle - button lives in div.actions row
+    let lastNonZeroLeftWidth = 50; // default width percentage
+    $: if ($leftPaneWidthStore && $leftPaneWidthStore > 0) {
+        lastNonZeroLeftWidth = $leftPaneWidthStore;
+    }
+    function toggleProblemPaneVisibility() {
+        const current = $leftPaneWidthStore === null ? 50 : $leftPaneWidthStore;
+        if (current > 5) {
+            lastNonZeroLeftWidth = current || lastNonZeroLeftWidth || 50;
+            $leftPaneWidthStore = 0;
+        } else {
+            const restore = Math.max(10, Math.min(70, lastNonZeroLeftWidth || 50));
+            $leftPaneWidthStore = restore;
+        }
+    }
+    $: isLeftPaneVisible = ($leftPaneWidthStore === null ? 50 : $leftPaneWidthStore) > 5;
+    $: isBottomPaneVisible = $execPaneHeightStore > minExecPanelHeight;
 
     function statusToString(status: StatusType) {
         switch (status) {
@@ -1756,6 +1774,112 @@
     </div>
 
     <div class="actions">
+        <div class="layout-toggles">
+            <!-- Toggle left (problem pane) - leftmost -->
+            <Tooltip text={isMac ? "Cmd + B" : "Ctrl + B"} pos="right">
+                <button
+                    class="icon-btn"
+                    aria-label={isLeftPaneVisible ? "Hide problem pane" : "Show problem pane"}
+                    on:click={toggleProblemPaneVisibility}
+                >
+                    {#if isLeftPaneVisible}
+                        <!-- Toggle left icon (panel on): split like reference -->
+                        <svg
+                            width="18"
+                            height="18"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
+                        >
+                            <rect
+                                x="3"
+                                y="3"
+                                width="18"
+                                height="18"
+                                rx="4"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            />
+                            <path d="M9.5 3v18" stroke="currentColor" stroke-width="2" />
+                        </svg>
+                    {:else}
+                        <!-- Toggle left icon (panel off) -->
+                        <svg
+                            width="18"
+                            height="18"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
+                        >
+                            <rect
+                                x="3"
+                                y="3"
+                                width="18"
+                                height="18"
+                                rx="4"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            />
+                            <rect x="6.5" y="6.5" width="3" height="11" rx="1.5" fill="currentColor" />
+                        </svg>
+                    {/if}
+                </button>
+            </Tooltip>
+            <!-- Toggle bottom (test case pane) -->
+            <Tooltip text={isMac ? "Cmd + J" : "Ctrl + J"}>
+                <button
+                    class="icon-btn"
+                    aria-label={isBottomPaneVisible ? "Hide panel" : "Show panel"}
+                    on:click={togglePanelVisibility}
+                >
+                    {#if isBottomPaneVisible}
+                        <!-- Toggle bottom icon (panel on): split like reference -->
+                        <svg
+                            width="18"
+                            height="18"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
+                        >
+                            <rect
+                                x="3"
+                                y="3"
+                                width="18"
+                                height="18"
+                                rx="4"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            />
+                            <path d="M3 15h18" stroke="currentColor" stroke-width="2" />
+                        </svg>
+                    {:else}
+                        <!-- Toggle bottom icon (panel off) -->
+                        <svg
+                            width="18"
+                            height="18"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
+                        >
+                            <rect
+                                x="3"
+                                y="3"
+                                width="18"
+                                height="18"
+                                rx="4"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            />
+                            <rect x="6.5" y="15" width="11" height="3" rx="1.5" fill="currentColor" />
+                        </svg>
+                    {/if}
+                </button>
+            </Tooltip>
+        </div>
         <div class="buttons">
             <div style="display: flex; align-items: center; margin-right: 8px;">
                 {#if gameMode && gameStartTime > 0}
@@ -1768,72 +1892,6 @@
                 {/if}
                 <SaveStatus />
             </div>
-            <!-- Show/Hide panel button -->
-            <Tooltip text={isMac ? "Cmd + J" : "Ctrl + J"}>
-                <button
-                    class="icon-btn"
-                    aria-label={$execPaneHeightStore > minExecPanelHeight
-                        ? "Hide panel"
-                        : "Show panel"}
-                    on:click={togglePanelVisibility}
-                >
-                    {#if $execPaneHeightStore > minExecPanelHeight}
-                        <!-- Eye (visible) icon -->
-                        <svg
-                            width="18"
-                            height="18"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            xmlns="http://www.w3.org/2000/svg"
-                        >
-                            <path
-                                d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                fill="none"
-                            />
-                            <circle
-                                cx="12"
-                                cy="12"
-                                r="3"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                fill="none"
-                            />
-                        </svg>
-                    {:else}
-                        <!-- Eye-off (hidden) icon -->
-                        <svg
-                            width="18"
-                            height="18"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            xmlns="http://www.w3.org/2000/svg"
-                        >
-                            <path
-                                d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                fill="none"
-                            />
-                            <circle
-                                cx="12"
-                                cy="12"
-                                r="3"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                fill="none"
-                            />
-                            <path
-                                d="M3 3l18 18"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                stroke-linecap="round"
-                            />
-                        </svg>
-                    {/if}
-                </button>
-            </Tooltip>
             {#if isCheckingDocker}
                 <div class="docker-error-msg">
                     <svg
@@ -2213,9 +2271,14 @@
         align-items: center;
         gap: var(--spacing-2);
     }
+    .layout-toggles {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-2);
+    }
     .actions {
         display: flex;
-        justify-content: flex-end;
+        justify-content: space-between;
         align-items: center;
         padding: var(--spacing-2) var(--spacing-3);
         border-top: 1px solid var(--color-border);

--- a/src/lib/components/PlaygroundExecutionPanel.svelte
+++ b/src/lib/components/PlaygroundExecutionPanel.svelte
@@ -906,56 +906,46 @@
                     on:click={togglePanelVisibility}
                 >
                     {#if $execPaneHeightStore > minExecPanelHeight}
+                        <!-- Toggle bottom icon (panel on): split like reference -->
                         <svg
                             width="18"
                             height="18"
                             viewBox="0 0 24 24"
                             fill="none"
                             xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
                         >
-                            <path
-                                d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z"
+                            <rect
+                                x="3"
+                                y="3"
+                                width="18"
+                                height="18"
+                                rx="4"
                                 stroke="currentColor"
                                 stroke-width="2"
-                                fill="none"
                             />
-                            <circle
-                                cx="12"
-                                cy="12"
-                                r="3"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                fill="none"
-                            />
+                            <path d="M3 15h18" stroke="currentColor" stroke-width="2" />
                         </svg>
                     {:else}
+                        <!-- Toggle bottom icon (panel off) -->
                         <svg
                             width="18"
                             height="18"
                             viewBox="0 0 24 24"
                             fill="none"
                             xmlns="http://www.w3.org/2000/svg"
+                            aria-hidden="true"
                         >
-                            <path
-                                d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z"
+                            <rect
+                                x="3"
+                                y="3"
+                                width="18"
+                                height="18"
+                                rx="4"
                                 stroke="currentColor"
                                 stroke-width="2"
-                                fill="none"
                             />
-                            <circle
-                                cx="12"
-                                cy="12"
-                                r="3"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                fill="none"
-                            />
-                            <path
-                                d="M3 3l18 18"
-                                stroke="currentColor"
-                                stroke-width="2"
-                                stroke-linecap="round"
-                            />
+                            <rect x="6.5" y="15" width="11" height="3" rx="1.5" fill="currentColor" />
                         </svg>
                     {/if}
                 </button>

--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -32,7 +32,6 @@
     export let data;
     const problemId = data.problem.id;
     const isDesktopMode = browser && isDesktopRuntime();
-    let isMac = false;
     let description = '';
     let constraints = '';
 
@@ -645,7 +644,6 @@
     });
 
     onMount(() => {
-        isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
         const handleDocClick = (e: MouseEvent) => {
             if (showSettings && settingsContainer && !settingsContainer.contains(e.target as Node)) {
                 showSettings = false;
@@ -958,28 +956,6 @@
                         </svg>
                     </a>
                 {/if}
-            </Tooltip>
-            <Tooltip text={isMac ? "Cmd + B" : "Ctrl + B"} pos="bottom">
-                <button
-                    class="back-button"
-                    aria-label={($leftPaneWidthStore === null ? 50 : $leftPaneWidthStore) > 5 ? 'Hide problem pane' : 'Show problem pane'}
-                    on:click={toggleProblemPaneVisibility}
-                >
-                    {#if ($leftPaneWidthStore === null ? 50 : $leftPaneWidthStore) > 5}
-                        <!-- Eye icon (visible) -->
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                            <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z" stroke="currentColor" stroke-width="2" fill="none"/>
-                            <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-                        </svg>
-                    {:else}
-                        <!-- Eye-off icon (hidden) -->
-                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-                            <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12Z" stroke="currentColor" stroke-width="2" fill="none"/>
-                            <circle cx="12" cy="12" r="3" stroke="currentColor" stroke-width="2" fill="none"/>
-                            <path d="M3 3l18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-                        </svg>
-                    {/if}
-                </button>
             </Tooltip>
             <div class="title-row">
                 <h1>{data.problem.title}</h1>


### PR DESCRIPTION
Replace visibility eye icons for problem pane (left) and test case pane (bottom) with layout toggle icons.

- Remove left eye toggle from problem-pane header
- Add left + bottom toggles grouped leftmost in ExecutionPanel div.actions row (Ctrl+B / Ctrl+J)
- Panel on: split icon (rect + divider); panel off: filled-bar icon
- Apply same bottom toggle to PlaygroundExecutionPanel for consistency