### PR TITLE
feat: user-editable ~/cojudge content and desktop CLI install

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,17 @@ Cojudge is an offline-first code judge built with SvelteKit and Docker. It provi
 
 When asked to add a new problem, follow the detailed guide in [`docs/ADD_PROBLEMS.md`](docs/ADD_PROBLEMS.md). In general, you should:
 
-1. Create folder: `problems/<slug>/`
+1. Create folder: `~/cojudge/problems/<slug>/` (seeded from the repo's `problems/` on first start; user copy overrides bundled content)
 2. Add required files:
    - `statement.md` - Problem description
    - `metadata.json` - Problem metadata and function signature
    - `official-tests.json` - Test inputs
    - `Marker.java` - Solution and validation logic
    - `solution.md` - Optional solution walkthrough (see `docs/ADD_PROBLEMS.md`)
-3. Update `courses/blind75/courseinfo.json`
+3. Update `~/cojudge/courses/blind75/courseinfo.json`
 4. Use the `cojudge` CLI to verify the problems
+
+Note: for repo contributions, edit `problems/` / `courses/` in the repo; at runtime the server and CLI read from `~/cojudge` first with the bundled copy as fallback. Override with `COJUDGE_CONTENT_DIR`.
 
 ## Adding Languages
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - Debugger support (Java/C++/Python/Typescript/Rust/C#/Go)
 - Multiple languages support for all problems (Java/C++/Python/Typescript/Rust/C#/Go)
 - Code Playground: Run code snippets in Java, C++, Python, Typescript, Rust, C# or Go without a problem context
-- Extensible: add new problems by dropping folders in `problems/`
+- Extensible: add new problems by dropping folders in `~/cojudge/problems/` (auto-seeded from bundled `problems/` on first start)
 - Persistent Code & Progress Tracking via Local Storage
 - Optional Cojudge Cloud sync through Google sign-in; local storage remains the source of truth offline
 - Browser-like tabs to organize your local solutions
@@ -42,10 +42,10 @@
 ### 1. Installation
 
 #### Desktop app
-Download the latest installer for macOS, Windows, or Linux from [GitHub Releases](https://github.com/cojudge/cojudge/releases). Desktop builds bundle Node.js; Docker is only required when running, submitting, or debugging code.
+Download the latest installer for macOS, Windows, or Linux from [GitHub Releases](https://github.com/cojudge/cojudge/releases). Desktop builds bundle Node.js; Docker is only required when running, submitting, or debugging code. After installing the app, open the homepage menu and choose **CLI** to put `cojudge` on your PATH (no separate Node.js install).
 
 #### CLI
-The easiest way to install the `cojudge` CLI without dealing with NPM permission issues is to run our install script:
+If you are not using the desktop app, the easiest way to install the `cojudge` CLI without dealing with NPM permission issues is to run our install script:
 
 #### Mac / Linux
 ```bash
@@ -153,6 +153,8 @@ npm run dev
 
 ## Add a problem
 
+Local content lives in `~/cojudge` (auto-seeded from the repo's bundled `problems/` + `courses/` on first start; your copy overrides bundled content — edit / add / delete files there, changes apply immediately). Override the location with `COJUDGE_CONTENT_DIR`.
+
 See [`docs/ADD_PROBLEMS.md`](docs/ADD_PROBLEMS.md) for a comprehensive guide covering:
 
 - Required files (`statement.md`, `metadata.json`, `official-tests.json`, `Marker.java`)
@@ -160,10 +162,10 @@ See [`docs/ADD_PROBLEMS.md`](docs/ADD_PROBLEMS.md) for a comprehensive guide cov
 - Supported parameter/output types
 - Starter code conventions for all 7 languages (Java, Python, C++, C#, Rust, Go, Typescript)
 - How to write `Marker.java` with the reference solution and `isCorrect` validator
-- Registration in `courses/blind75/courseinfo.json`
+- Registration in `~/cojudge/courses/blind75/courseinfo.json`
 - Verification checklist (`cojudge init`/`run`/`submit`)
 
-Refer to `problems/two-sum` for a minimal example.
+Refer to `~/cojudge/problems/two-sum` (seeded from `problems/two-sum`) for a minimal example.
 
 #### Note on problems
 
@@ -187,7 +189,7 @@ This is a more complicated process but it is definitely doable.
 
 7. Create a new class that extends `PlaygroundRunner` (e.g. `PlaygroundJavascriptRunner`) in `src/lib/runners/PlaygroundRunners.ts` and add the instantiation logic in `src/routes/api/playground/run/+server.ts`.
 
-Refer to `javaUtil.ts`, `JavaRunner.ts` and `problems/two-sum` for a detailed example.
+Refer to `javaUtil.ts`, `JavaRunner.ts` and `problems/two-sum` (runtime copy: `~/cojudge/problems/two-sum`) for a detailed example.
 
 ## Troubleshooting
 

--- a/bin/cojudge
+++ b/bin/cojudge
@@ -2,7 +2,8 @@
 
 import path from "path";
 import fs from "fs";
-import { rootDir, getPort, getPIDs, openBrowser, printVersion, updateRepo } from "./lib/utils.js";
+import { rootDir, getPort, getPIDs, openBrowser, printVersion, updateRepo, isDesktopCli } from "./lib/utils.js";
+import { ensureUserContentSeededSync, resolveProblemDirSync } from "./lib/contentPaths.js";
 import { showHelp } from "./lib/help.js";
 import { startServer, streamLogs, killServer, restartServer } from "./lib/server.js";
 import { markProblem } from "./lib/progress.js";
@@ -82,6 +83,10 @@ async function main() {
   }
 
   if (!action || action === "-p" || action === "--port") {
+    if (isDesktopCli && !action) {
+      showHelp();
+      return;
+    }
     const pids = getPIDs(PORT);
     if (pids.length > 0) {
       console.log(
@@ -119,10 +124,9 @@ async function main() {
     showHelp();
   } else {
     if (action && !action.startsWith("-")) {
+      ensureUserContentSeededSync();
       const isFile = fs.existsSync(action);
-      const isProblemSlug = fs.existsSync(
-        path.join(rootDir, "problems", action),
-      );
+      const isProblemSlug = fs.existsSync(resolveProblemDirSync(action));
 
       if (isFile && !isProblemSlug) {
         handleStart(["start", "playground", action], PORT);

--- a/bin/lib/commands/init.js
+++ b/bin/lib/commands/init.js
@@ -1,21 +1,26 @@
-import path from "path";
 import fs from "fs";
-import { rootDir, getParam } from "../utils.js";
+import { getParam } from "../utils.js";
+import {
+  ensureUserContentSeededSync,
+  resolveProblemDirSync,
+  resolveProblemFileSync,
+} from "../contentPaths.js";
 
 export function handleInit(argsToUse) {
+  ensureUserContentSeededSync();
   const slug = argsToUse[1];
   if (!slug) {
     console.error("Usage: cojudge init <slug> [--lang <language>] [--output <filename>]");
     process.exit(1);
   }
 
-  const problemsPath = path.join(rootDir, "problems", slug);
+  const problemsPath = resolveProblemDirSync(slug);
   if (!fs.existsSync(problemsPath)) {
     console.error(`Error: Problem slug '${slug}' not found.`);
     process.exit(1);
   }
 
-  const metadataPath = path.join(problemsPath, "metadata.json");
+  const metadataPath = resolveProblemFileSync(slug, "metadata.json");
   let metadata;
   try {
     metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));

--- a/bin/lib/commands/list.js
+++ b/bin/lib/commands/list.js
@@ -1,16 +1,18 @@
-import path from "path";
 import fs from "fs";
-import { rootDir, getDifficultyOrder } from "../utils.js";
+import { getDifficultyOrder } from "../utils.js";
 import { loadProgress } from "../progress.js";
+import {
+  ensureUserContentSeededSync,
+  getContentRoot,
+  listProblemSlugsSync,
+  resolveCourseFileSync,
+  resolveProblemFileSync,
+} from "../contentPaths.js";
 
 export function listProblems() {
-  const problemsPath = path.join(rootDir, "problems");
-  const blind75Path = path.join(
-    rootDir,
-    "courses",
-    "blind75",
-    "courseinfo.json",
-  );
+  ensureUserContentSeededSync();
+  console.log(`Content: ${getContentRoot()}`);
+  const blind75Path = resolveCourseFileSync("blind75", "courseinfo.json");
 
   try {
     let orderedSlugs = [];
@@ -22,7 +24,7 @@ export function listProblems() {
       categories.forEach((cat) => {
         const slugs = categoryProblems[cat] || [];
         const problemsWithMetadata = slugs.map((slug) => {
-          const metaPath = path.join(problemsPath, slug, "metadata.json");
+          const metaPath = resolveProblemFileSync(slug, "metadata.json");
           let difficulty = "unknown";
           let title = slug;
           if (fs.existsSync(metaPath)) {
@@ -45,12 +47,7 @@ export function listProblems() {
         orderedSlugs.push(...problemsWithMetadata.map((p) => p.slug));
       });
     } else {
-      orderedSlugs = fs
-        .readdirSync(problemsPath)
-        .filter((f) => {
-          return fs.statSync(path.join(problemsPath, f)).isDirectory();
-        })
-        .sort();
+      orderedSlugs = listProblemSlugsSync();
     }
 
     const progress = loadProgress();
@@ -64,9 +61,7 @@ export function listProblems() {
       console.log(`  ${mark} ${s}`);
     });
 
-    const allFolders = fs.readdirSync(problemsPath).filter((f) => {
-      return fs.statSync(path.join(problemsPath, f)).isDirectory();
-    });
+    const allFolders = listProblemSlugsSync();
     const extraSlugs = allFolders
       .filter((f) => !orderedSlugs.includes(f))
       .sort();

--- a/bin/lib/commands/run.js
+++ b/bin/lib/commands/run.js
@@ -1,12 +1,12 @@
 import path from "path";
 import fs from "fs";
-import {
-  rootDir,
-  getPIDs,
-  getLangFromExt,
-  isDockerRunning,
-} from "../utils.js";
+import { getPIDs, getLangFromExt, isDockerRunning } from "../utils.js";
 import { startServer } from "../server.js";
+import {
+  ensureUserContentSeededSync,
+  resolveProblemDirSync,
+  resolveProblemFileSync,
+} from "../contentPaths.js";
 
 function parseDebugLines(args) {
   const debugIdx = args.findIndex(a => a === '--debug-lines');
@@ -31,6 +31,7 @@ function stripDebugArgs(args) {
 }
 
 export async function handleRun(argsToUse, PORT) {
+  ensureUserContentSeededSync();
   const debugLines = parseDebugLines(argsToUse);
   const cleanedArgs = debugLines ? stripDebugArgs(argsToUse) : argsToUse;
 
@@ -53,7 +54,7 @@ export async function handleRun(argsToUse, PORT) {
     slug &&
     !filename &&
     fs.existsSync(slug) &&
-    !fs.existsSync(path.join(rootDir, "problems", slug))
+    !fs.existsSync(resolveProblemDirSync(slug))
   ) {
     filename = slug;
     slug = "playground";
@@ -69,13 +70,13 @@ export async function handleRun(argsToUse, PORT) {
   let testCases = [];
 
   if (!isPlayground) {
-    const problemsPath = path.join(rootDir, "problems", slug);
+    const problemsPath = resolveProblemDirSync(slug);
     if (!fs.existsSync(problemsPath)) {
       console.error(`Error: Problem slug '${slug}' not found.`);
       process.exit(1);
     }
 
-    const metadataPath = path.join(problemsPath, "metadata.json");
+    const metadataPath = resolveProblemFileSync(slug, "metadata.json");
     try {
       const metadata = JSON.parse(fs.readFileSync(metadataPath, "utf8"));
       testCases = metadata.testCases || [];

--- a/bin/lib/commands/search.js
+++ b/bin/lib/commands/search.js
@@ -1,8 +1,12 @@
-import path from "path";
 import fs from "fs";
-import { rootDir } from "../utils.js";
+import {
+  ensureUserContentSeededSync,
+  listProblemSlugsSync,
+  resolveProblemFileSync,
+} from "../contentPaths.js";
 
 export function handleSearch(args) {
+  ensureUserContentSeededSync();
   const keyword = args[1];
   if (!keyword) {
     console.error("Error: Please specify a keyword to search for.");
@@ -10,17 +14,14 @@ export function handleSearch(args) {
     return;
   }
 
-  const problemsPath = path.join(rootDir, "problems");
-  const slugs = fs.readdirSync(problemsPath).filter((f) => {
-    return fs.statSync(path.join(problemsPath, f)).isDirectory();
-  });
+  const slugs = listProblemSlugsSync();
 
   const lowerKeyword = keyword.toLowerCase();
   let results = [];
 
   for (const slug of slugs) {
-    const metaPath = path.join(problemsPath, slug, "metadata.json");
-    const statementPath = path.join(problemsPath, slug, "statement.md");
+    const metaPath = resolveProblemFileSync(slug, "metadata.json");
+    const statementPath = resolveProblemFileSync(slug, "statement.md");
 
     const meta = fs.existsSync(metaPath)
       ? JSON.parse(fs.readFileSync(metaPath, "utf8"))

--- a/bin/lib/commands/start.js
+++ b/bin/lib/commands/start.js
@@ -1,9 +1,14 @@
 import path from "path";
 import fs from "fs";
-import { rootDir, getPIDs, openBrowser, getLangFromExt, getPort } from "../utils.js";
+import { getPIDs, openBrowser, getLangFromExt } from "../utils.js";
 import { startServer } from "../server.js";
+import {
+  ensureUserContentSeededSync,
+  resolveProblemDirSync,
+} from "../contentPaths.js";
 
 export function handleStart(argsToUse, PORT) {
+  ensureUserContentSeededSync();
   let slug = argsToUse[1];
   let filename = argsToUse[2];
 
@@ -11,7 +16,7 @@ export function handleStart(argsToUse, PORT) {
     slug &&
     !filename &&
     fs.existsSync(slug) &&
-    !fs.existsSync(path.join(rootDir, "problems", slug))
+    !fs.existsSync(resolveProblemDirSync(slug))
   ) {
     filename = slug;
     slug = "playground";

--- a/bin/lib/commands/submit.js
+++ b/bin/lib/commands/submit.js
@@ -1,15 +1,15 @@
 import path from "path";
 import fs from "fs";
-import {
-  rootDir,
-  getPIDs,
-  getLangFromExt,
-  isDockerRunning,
-} from "../utils.js";
+import { getPIDs, getLangFromExt, isDockerRunning } from "../utils.js";
 import { startServer } from "../server.js";
 import { markProblem } from "../progress.js";
+import {
+  ensureUserContentSeededSync,
+  resolveProblemDirSync,
+} from "../contentPaths.js";
 
 export async function handleSubmit(argsToUse, PORT) {
+  ensureUserContentSeededSync();
   if (!isDockerRunning()) {
     console.error(
       "\x1b[31mError: Docker engine not detected. Please ensure Docker is running.\x1b[0m",
@@ -48,7 +48,7 @@ Examples:
     process.exit(1);
   }
 
-  const problemsPath = path.join(rootDir, "problems", slug);
+  const problemsPath = resolveProblemDirSync(slug);
   if (!fs.existsSync(problemsPath)) {
     console.error(`Error: Problem slug '${slug}' not found.`);
     process.exit(1);

--- a/bin/lib/contentPaths.js
+++ b/bin/lib/contentPaths.js
@@ -1,0 +1,139 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { rootDir } from "./utils.js";
+
+/**
+ * User-editable content lives in ~/cojudge (overridable via
+ * COJUDGE_CONTENT_DIR / COJUDGE_HOME). Mirrors
+ * src/lib/server/contentPaths.ts for the CLI.
+ */
+
+export function getContentRoot() {
+  const override =
+    (process.env.COJUDGE_CONTENT_DIR || "").trim() ||
+    (process.env.COJUDGE_HOME || "").trim();
+  if (override) return path.resolve(override);
+  return path.join(os.homedir(), "cojudge");
+}
+
+export function getProblemsDir() {
+  return path.join(getContentRoot(), "problems");
+}
+
+export function getCoursesDir() {
+  return path.join(getContentRoot(), "courses");
+}
+
+export function getBundledProblemsDir() {
+  return path.join(rootDir, "problems");
+}
+
+export function getBundledCoursesDir() {
+  return path.join(rootDir, "courses");
+}
+
+/** Prefer the user copy; fall back to the bundled copy. */
+export function resolveProblemDirSync(slug) {
+  const userDir = path.join(getProblemsDir(), slug);
+  if (fs.existsSync(userDir)) return userDir;
+  return path.join(getBundledProblemsDir(), slug);
+}
+
+export function resolveProblemFileSync(slug, ...rest) {
+  const userPath = path.join(getProblemsDir(), slug, ...rest);
+  if (fs.existsSync(userPath)) return userPath;
+  const bundledPath = path.join(getBundledProblemsDir(), slug, ...rest);
+  if (fs.existsSync(bundledPath)) return bundledPath;
+  return userPath;
+}
+
+export function resolveCourseFileSync(courseId, ...rest) {
+  const userPath = path.join(getCoursesDir(), courseId, ...rest);
+  if (fs.existsSync(userPath)) return userPath;
+  const bundledPath = path.join(getBundledCoursesDir(), courseId, ...rest);
+  if (fs.existsSync(bundledPath)) return bundledPath;
+  return userPath;
+}
+
+/** Union of problem slugs from ~/cojudge and the bundled copy. */
+export function listProblemSlugsSync() {
+  const seen = new Set();
+  for (const dir of [getProblemsDir(), getBundledProblemsDir()]) {
+    try {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) seen.add(entry.name);
+      }
+    } catch {}
+  }
+  return [...seen].sort();
+}
+
+function copyMissingRecursiveSync(src, dest) {
+  let entries;
+  try {
+    entries = fs.readdirSync(src, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  fs.mkdirSync(dest, { recursive: true });
+  for (const entry of entries) {
+    if (entry.name === ".DS_Store") continue;
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    const destExists = fs.existsSync(destPath);
+    if (entry.isDirectory()) {
+      if (!destExists) {
+        fs.cpSync(srcPath, destPath, { recursive: true });
+      } else {
+        copyMissingRecursiveSync(srcPath, destPath);
+      }
+    } else if (entry.isFile()) {
+      if (!destExists) {
+        fs.copyFileSync(srcPath, destPath);
+      }
+    }
+  }
+}
+
+const USER_README = `# CoJudge content
+
+This folder is yours. CoJudge reads problems and courses from here first.
+
+- \`problems/<slug>/\` — statement.md, metadata.json, official-tests.json, Marker.java, solution.md (optional), images
+- \`courses/<course-id>/courseinfo.json\` — category order + problem lists
+
+You can view, edit, add or delete anything here — changes take effect
+immediately (no restart needed, just refresh the browser or re-run the CLI).
+
+After you add a problem, verify it with the CoJudge CLI (Docker required):
+
+\`\`\`bash
+cojudge run <slug> Solution.py
+cojudge submit <slug> Solution.py
+\`\`\`
+
+Missing files are seeded from the bundled CoJudge content on startup and
+are never overwritten once you have edited them. Set COJUDGE_CONTENT_DIR
+to use a different folder.
+`;
+
+/**
+ * Seed ~/cojudge/problems and ~/cojudge/courses from the bundled content.
+ * Only copies files that are missing — never overwrites user edits.
+ */
+export function ensureUserContentSeededSync() {
+  try {
+    const root = getContentRoot();
+    fs.mkdirSync(path.join(root, "problems"), { recursive: true });
+    fs.mkdirSync(path.join(root, "courses"), { recursive: true });
+    copyMissingRecursiveSync(getBundledProblemsDir(), getProblemsDir());
+    copyMissingRecursiveSync(getBundledCoursesDir(), getCoursesDir());
+    const readmePath = path.join(root, "README.md");
+    if (!fs.existsSync(readmePath)) {
+      fs.writeFileSync(readmePath, USER_README, "utf8");
+    }
+  } catch {
+    // Seeding must never break the CLI — readers fall back to bundled content.
+  }
+}

--- a/bin/lib/help.js
+++ b/bin/lib/help.js
@@ -1,9 +1,11 @@
+import { isDesktopCli } from "./utils.js";
+
 export function showHelp() {
   console.log(`
-Cojudge CLI - Offline code judge
+${isDesktopCli ? "Cojudge desktop CLI" : "Cojudge CLI - Offline code judge"}
 
 Usage:
-  cojudge [options]              Start the server and open in browser
+  ${isDesktopCli ? "cojudge                        Show this help message" : "cojudge [options]              Start the server and open in browser"}
   cojudge start <slug> <file>    Open a specific problem or playground with a file
   cojudge [file]                 Same as 'cojudge playground [file]'
   cojudge list                   List all available problem slugs
@@ -45,5 +47,9 @@ Examples:
   cojudge mark two-sum
   cojudge scrape -n 1
   cojudge scrape -s valid-parentheses
+
+Content:
+  Problems & courses live in ~/cojudge (auto-seeded on first start).
+  Edit/add files there to override bundled content. Override with COJUDGE_CONTENT_DIR.
 `);
 }

--- a/bin/lib/preview-server.mjs
+++ b/bin/lib/preview-server.mjs
@@ -1,0 +1,82 @@
+import { createServer } from "node:http";
+import { resolve } from "node:path";
+import process from "node:process";
+import { pathToFileURL } from "node:url";
+
+const port = Number(process.env.PORT || 5375);
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  throw new Error("PORT is invalid");
+}
+
+const origin = `http://localhost:${port}`;
+let handler;
+let shuttingDown = false;
+
+const server = createServer((request, response) => {
+  if (!handler) {
+    response.writeHead(503, { connection: "close", "content-type": "text/plain" });
+    response.end("Service Unavailable");
+    return;
+  }
+
+  try {
+    Promise.resolve(handler(request, response)).catch((error) => {
+      console.error(error);
+      if (response.headersSent) response.destroy(error);
+      else response.writeHead(500).end("Internal Server Error");
+    });
+  } catch (error) {
+    console.error(error);
+    if (response.headersSent) response.destroy(error);
+    else response.writeHead(500).end("Internal Server Error");
+  }
+});
+
+async function shutdown(exitCode = 0) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  const fallback = setTimeout(() => process.exit(exitCode), 10000);
+  fallback.unref();
+  server.close();
+  server.closeAllConnections();
+  try {
+    await globalThis.__cojudgeShutdown?.();
+  } catch (error) {
+    console.error("Backend cleanup failed:", error);
+  }
+  process.exit(exitCode);
+}
+
+process.on("SIGINT", () => void shutdown(130));
+process.on("SIGTERM", () => void shutdown(143));
+
+async function main() {
+  await new Promise((resolveListen, rejectListen) => {
+    const onError = (error) => rejectListen(error);
+    server.once("error", onError);
+    server.listen(port, () => {
+      server.off("error", onError);
+      resolveListen();
+    });
+  });
+
+  process.env.ORIGIN = origin;
+  process.env.BODY_SIZE_LIMIT = "10M";
+  delete process.env.PROTOCOL_HEADER;
+  delete process.env.HOST_HEADER;
+  delete process.env.PORT_HEADER;
+
+  ({ handler } = await import(pathToFileURL(resolve("build/handler.js")).href));
+  if (shuttingDown) return;
+
+  server.on("error", (error) => {
+    console.error(error);
+    void shutdown(1);
+  });
+  console.log(`Listening on ${origin}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  void shutdown(1);
+});

--- a/bin/lib/progress.js
+++ b/bin/lib/progress.js
@@ -2,6 +2,7 @@ import path from "path";
 import fs from "fs";
 import os from "os";
 import { rootDir } from "./utils.js";
+import { resolveProblemDirSync } from "./contentPaths.js";
 
 function getProgressFile() {
   const homeProgressFile = path.join(os.homedir(), ".cojudge", "progress.json");
@@ -41,7 +42,7 @@ function saveProgress(progress) {
 }
 
 export function markProblem(slug, solvedValue) {
-  const problemsPath = path.join(rootDir, "problems", slug);
+  const problemsPath = resolveProblemDirSync(slug);
   if (!fs.existsSync(problemsPath)) {
     console.error(`Error: Problem slug '${slug}' not found.`);
     return;

--- a/bin/lib/server.js
+++ b/bin/lib/server.js
@@ -2,7 +2,8 @@ import { spawn, execSync } from "child_process";
 import path from "path";
 import fs from "fs";
 import os from "os";
-import { rootDir, getPIDs } from "./utils.js";
+import { rootDir, getPIDs, isDesktopCli } from "./utils.js";
+import { ensureUserContentSeededSync, getContentRoot } from "./contentPaths.js";
 
 export function getLogFile() {
   const homeConfigDir = path.join(os.homedir(), ".cojudge");
@@ -17,9 +18,11 @@ export function getLogFile() {
 }
 
 export function startServer(PORT, callback, shouldExit = true) {
+  ensureUserContentSeededSync();
+  console.log(`Content: ${getContentRoot()} (edit problems/courses there; overrides bundled content)`);
   const logFile = getLogFile();
 
-  if (!fs.existsSync(path.join(rootDir, "node_modules"))) {
+  if (!isDesktopCli && !fs.existsSync(path.join(rootDir, "node_modules"))) {
     console.log("Installing dependencies (first-time setup)...");
     try {
       execSync("npm install", { cwd: rootDir, stdio: "inherit" });
@@ -30,6 +33,7 @@ export function startServer(PORT, callback, shouldExit = true) {
   }
 
   if (
+    !isDesktopCli &&
     !fs.existsSync(path.join(rootDir, ".svelte-kit", "output")) &&
     !fs.existsSync(path.join(rootDir, "build"))
   ) {
@@ -57,13 +61,19 @@ export function startServer(PORT, callback, shouldExit = true) {
       "bin",
       "vite.js",
     );
-    const spawnArgs = [
-      vitePath,
-      "preview",
-      "--port",
-      PORT.toString(),
-      "--host",
-    ];
+    const previewServer = path.join(rootDir, "bin", "lib", "preview-server.mjs");
+    const handlerPath = path.join(rootDir, "build", "handler.js");
+    const spawnArgs = fs.existsSync(vitePath)
+      ? [vitePath, "preview", "--port", PORT.toString(), "--host"]
+      : fs.existsSync(handlerPath) && fs.existsSync(previewServer)
+        ? [previewServer]
+        : null;
+    if (!spawnArgs) {
+      console.error(
+        "Cannot start the server: missing Vite preview and production build.",
+      );
+      process.exit(1);
+    }
 
     const child = spawn(cmd, spawnArgs, {
       cwd: rootDir,

--- a/bin/lib/utils.js
+++ b/bin/lib/utils.js
@@ -3,11 +3,11 @@ import { fileURLToPath } from "url";
 import path from "path";
 import fs from "fs";
 
-export const rootDir = path.resolve(
-  path.dirname(fileURLToPath(import.meta.url)),
-  "..",
-  "..",
-);
+export const rootDir = process.env.COJUDGE_ROOT
+  ? path.resolve(process.env.COJUDGE_ROOT)
+  : path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+export const isDesktopCli = process.env.COJUDGE_DESKTOP === "1";
 
 export function getParam(args, param) {
   const index = args.findIndex((arg) => arg === param);
@@ -117,14 +117,27 @@ export function printVersion(dir) {
       .toString()
       .trim();
     console.log(`Cojudge version: ${commit} (${date})`);
-    console.log(`Installed at: ${dir}`);
   } catch (e) {
-    console.log("Cojudge version unknown");
-    console.log(`Installed at: ${dir}`);
+    try {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(dir, "package.json"), "utf8"),
+      );
+      console.log(`Cojudge version: ${pkg.version || "unknown"}`);
+    } catch {
+      console.log("Cojudge version unknown");
+    }
   }
+  console.log(`Installed at: ${dir}`);
 }
 
 export function updateRepo(dir) {
+  if (isDesktopCli) {
+    console.log("This CLI is bundled with the Cojudge desktop app.");
+    console.log(
+      "Download a newer app from GitHub Releases, then reinstall the CLI from the app menu.",
+    );
+    return false;
+  }
   console.log("Updating cojudge...");
   try {
     const before = execSync("git rev-parse HEAD", { cwd: dir })

--- a/docs/ADD_PROBLEMS.md
+++ b/docs/ADD_PROBLEMS.md
@@ -2,22 +2,28 @@
 
 This guide explains how to add a new problem to CoJudge, with examples for both standard function-based problems and class-based design problems.
 
-## Overview
+## Where content lives (`~/cojudge`)
 
-Each problem lives in its own folder under `problems/<slug>/` with the following files:
+For local use, CoJudge keeps all editable content in your home folder:
 
 ```
-problems/<slug>/
-├── statement.md        # Problem description (Markdown)
-├── metadata.json       # Metadata, starter code, sample tests, hints
-├── official-tests.json # Comprehensive test cases for submission
-├── Marker.java         # Reference solution + validation logic
-└── solution.md         # Optional — Approach, complexity, and Python solution
+~/cojudge/
+├── problems/<slug>/
+│   ├── statement.md        # Problem description (Markdown)
+│   ├── metadata.json       # Metadata, starter code, sample tests, hints
+│   ├── official-tests.json # Comprehensive test cases for submission
+│   ├── Marker.java         # Reference solution + validation logic
+│   └── solution.md         # Optional — Approach, complexity, and Python solution
+└── courses/<course-id>/courseinfo.json
 ```
+
+On first start, CoJudge copies (seeds) the repo's bundled `problems/` and `courses/` into `~/cojudge`. Afterwards `~/cojudge` is the source of truth: view / edit / add problems, test cases, solutions, and courses by managing files there — changes take effect immediately (refresh the browser or re-run the CLI, no restart needed). Missing files are re-seeded from the bundled copy but your edits are never overwritten. Set `COJUDGE_CONTENT_DIR` (or `COJUDGE_HOME`) to use a different folder.
 
 Only `statement.md`, `metadata.json`, `official-tests.json`, and `Marker.java` are required. `solution.md` is optional — if present, a "Reference Solution" button appears in the UI.
 
-After creating the problem files, register it in `courses/blind75/courseinfo.json`.
+After creating the problem files, register it in `~/cojudge/courses/blind75/courseinfo.json`.
+
+> Contributing to the repo itself? Edit `problems/` / `courses/` in the repo — those are the seed contents that get copied to `~/cojudge` on first start.
 
 ---
 
@@ -30,7 +36,7 @@ Instead of writing problem files from scratch, use `cojudge scrape` to fetch can
 ```bash
 cojudge scrape -n 1            # Fetch problem #1 (Two Sum)
 cojudge scrape -s two-sum      # Fetch by slug
-cojudge scrape -s valid-parentheses > problems/valid-parentheses/scraped.txt  # Save to file
+cojudge scrape -s valid-parentheses > ~/cojudge/problems/valid-parentheses/scraped.txt  # Save to file
 ```
 
 ### Output
@@ -434,7 +440,7 @@ class Marker {
 
 ## 7. Registering in a Course
 
-Add the problem slug to `courses/blind75/courseinfo.json` under the appropriate category:
+Add the problem slug to `~/cojudge/courses/blind75/courseinfo.json` under the appropriate category:
 
 ```json
 {

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -126,7 +126,10 @@ Every installer includes:
 
 - The SvelteKit client and server build
 - The platform-specific Node.js runtime
+- The `cojudge` CLI (`bin/`), which can be added to PATH from the homepage **CLI** menu
 - Production dependencies required by Docker-based judging
 - All courses, problems, tests, markers, and debugger Dockerfiles
 
 Docker itself and language runtime images are not included. Missing runner images are downloaded through the configured Docker daemon as needed.
+
+The in-app **CLI** action writes a shim to `~/.local/bin/cojudge` (macOS/Linux) or `%LOCALAPPDATA%\Cojudge\cli\cojudge.cmd` (Windows) that runs the bundled Node.js sidecar. Uninstall removes that shim. Open a new terminal after installing.

--- a/scripts/stage-desktop-backend.mjs
+++ b/scripts/stage-desktop-backend.mjs
@@ -37,7 +37,7 @@ const install = npmExecPath
 if (install.error) throw install.error;
 if (install.status !== 0) process.exit(install.status ?? 1);
 
-for (const directory of ['build', 'courses', 'problems', 'docker']) {
+for (const directory of ['build', 'courses', 'problems', 'docker', 'bin']) {
 	const source = join(root, directory);
 	if (!existsSync(source)) throw new Error(`Missing ${source}`);
 	cpSync(source, join(backend, directory), {

--- a/scripts/verify-submissions.js
+++ b/scripts/verify-submissions.js
@@ -111,9 +111,21 @@ function runCommand(args, timeout = 180_000) {
   });
 }
 
+function resolveProblemDirForVerify(slug) {
+  const override =
+    (process.env.COJUDGE_CONTENT_DIR || "").trim() ||
+    (process.env.COJUDGE_HOME || "").trim();
+  const userRoot = override
+    ? path.resolve(override)
+    : path.join(os.homedir(), "cojudge");
+  const userDir = path.join(userRoot, "problems", slug);
+  if (fs.existsSync(userDir)) return userDir;
+  return path.resolve(rootDir, "problems", slug);
+}
+
 async function verifySubmission(item, options, tempRoot) {
   const { slug, language } = item;
-  const problemDir = path.resolve(rootDir, "problems", slug);
+  const problemDir = resolveProblemDirForVerify(slug);
   let solutionPath;
   if (options.solutionsRoot) {
     solutionPath = path.resolve(

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -502,6 +502,7 @@ version = "0.4.7"
 dependencies = [
  "getrandom 0.3.4",
  "oauth2",
+ "serde",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,3 +14,4 @@ oauth2 = { version = "=5.0.0", default-features = false, features = ["reqwest-bl
 tauri = { version = "=2.11.5", features = [] }
 tauri-plugin-opener = "=2.5.4"
 tiny_http = "=0.12.0"
+serde = { version = "=1.0.229", features = ["derive"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,6 +1,14 @@
 fn main() {
     tauri_build::try_build(tauri_build::Attributes::new().app_manifest(
-        tauri_build::AppManifest::new().commands(&["new_window", "google_oauth_access_token", "read_text_file"]),
+        tauri_build::AppManifest::new().commands(&[
+            "new_window",
+            "google_oauth_access_token",
+            "read_text_file",
+            "cli_status",
+            "cli_install",
+            "cli_uninstall",
+            "cli_remove_shell_alias",
+        ]),
     ))
     .expect("failed to run tauri-build");
 }

--- a/src-tauri/permissions/autogenerated/cli_install.toml
+++ b/src-tauri/permissions/autogenerated/cli_install.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-cli-install"
+description = "Enables the cli_install command without any pre-configured scope."
+commands.allow = ["cli_install"]
+
+[[permission]]
+identifier = "deny-cli-install"
+description = "Denies the cli_install command without any pre-configured scope."
+commands.deny = ["cli_install"]

--- a/src-tauri/permissions/autogenerated/cli_remove_shell_alias.toml
+++ b/src-tauri/permissions/autogenerated/cli_remove_shell_alias.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-cli-remove-shell-alias"
+description = "Enables the cli_remove_shell_alias command without any pre-configured scope."
+commands.allow = ["cli_remove_shell_alias"]
+
+[[permission]]
+identifier = "deny-cli-remove-shell-alias"
+description = "Denies the cli_remove_shell_alias command without any pre-configured scope."
+commands.deny = ["cli_remove_shell_alias"]

--- a/src-tauri/permissions/autogenerated/cli_status.toml
+++ b/src-tauri/permissions/autogenerated/cli_status.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-cli-status"
+description = "Enables the cli_status command without any pre-configured scope."
+commands.allow = ["cli_status"]
+
+[[permission]]
+identifier = "deny-cli-status"
+description = "Denies the cli_status command without any pre-configured scope."
+commands.deny = ["cli_status"]

--- a/src-tauri/permissions/autogenerated/cli_uninstall.toml
+++ b/src-tauri/permissions/autogenerated/cli_uninstall.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-cli-uninstall"
+description = "Enables the cli_uninstall command without any pre-configured scope."
+commands.allow = ["cli_uninstall"]
+
+[[permission]]
+identifier = "deny-cli-uninstall"
+description = "Denies the cli_uninstall command without any pre-configured scope."
+commands.deny = ["cli_uninstall"]

--- a/src-tauri/src/cli.rs
+++ b/src-tauri/src/cli.rs
@@ -1,0 +1,539 @@
+use serde::Serialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+#[cfg(unix)]
+const PATH_BLOCK_BEGIN: &str = "# >>> cojudge CLI >>>";
+#[cfg(unix)]
+const PATH_BLOCK_END: &str = "# <<< cojudge CLI <<<";
+#[cfg(unix)]
+const PATH_EXPORT: &str = r#"export PATH="$HOME/.local/bin:$PATH""#;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CliStatus {
+    available: bool,
+    installed: bool,
+    path: Option<String>,
+    alias_paths: Vec<String>,
+    needs_new_terminal: bool,
+    message: Option<String>,
+}
+
+fn node_binary() -> Result<PathBuf, String> {
+    let exe = std::env::current_exe().map_err(|error| error.to_string())?;
+    let dir = exe
+        .parent()
+        .ok_or_else(|| "application executable has no parent directory".to_string())?;
+    Ok(dir.join(format!("cojudge-node{}", std::env::consts::EXE_SUFFIX)))
+}
+
+fn backend_dir(app: &AppHandle) -> Result<PathBuf, String> {
+    app.path()
+        .resource_dir()
+        .map(|dir| dir.join("backend"))
+        .map_err(|error| error.to_string())
+}
+
+fn cli_script(app: &AppHandle) -> Result<PathBuf, String> {
+    Ok(backend_dir(app)?.join("bin").join("cojudge"))
+}
+
+fn install_dir() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    {
+        let local = std::env::var("LOCALAPPDATA")
+            .map_err(|_| "LOCALAPPDATA is not set".to_string())?;
+        Ok(PathBuf::from(local).join("Cojudge").join("cli"))
+    }
+    #[cfg(not(windows))]
+    {
+        let home = std::env::var("HOME").map_err(|_| "HOME is not set".to_string())?;
+        Ok(PathBuf::from(home).join(".local").join("bin"))
+    }
+}
+
+fn wrapper_path() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    {
+        Ok(install_dir()?.join("cojudge.cmd"))
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(install_dir()?.join("cojudge"))
+    }
+}
+
+fn resolve_existing(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn sh_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn wrapper_belongs_to_this_app(contents: &str, node: &Path, backend: &Path) -> bool {
+    let node = node.to_string_lossy();
+    let backend = backend.to_string_lossy();
+    contents.contains(node.as_ref()) && contents.contains(backend.as_ref())
+}
+
+fn unavailable(message: &str) -> CliStatus {
+    CliStatus {
+        available: false,
+        installed: false,
+        path: wrapper_path().ok().map(|path| path.display().to_string()),
+        alias_paths: find_shell_aliases().unwrap_or_default(),
+        needs_new_terminal: false,
+        message: Some(message.to_string()),
+    }
+}
+
+fn current_status(app: &AppHandle) -> Result<CliStatus, String> {
+    let node = node_binary()?;
+    let backend = backend_dir(app)?;
+    let script = cli_script(app)?;
+    if !node.is_file() || !script.is_file() {
+        return Ok(unavailable(
+            "CLI install is available in the packaged Cojudge app.",
+        ));
+    }
+
+    let node = resolve_existing(&node);
+    let backend = resolve_existing(&backend);
+    let wrapper = wrapper_path()?;
+    let installed = wrapper.is_file()
+        && fs::read_to_string(&wrapper)
+            .map(|contents| wrapper_belongs_to_this_app(&contents, &node, &backend))
+            .unwrap_or(false);
+
+    Ok(CliStatus {
+        available: true,
+        installed,
+        path: Some(wrapper.display().to_string()),
+        alias_paths: find_shell_aliases()?,
+        needs_new_terminal: installed && !install_dir_on_path()?,
+        message: None,
+    })
+}
+
+fn install_dir_on_path() -> Result<bool, String> {
+    let dir = install_dir()?;
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    Ok(std::env::split_paths(&path).any(|entry| entry == dir))
+}
+
+fn home_dir() -> Result<PathBuf, String> {
+    let var = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    std::env::var(var)
+        .map(PathBuf::from)
+        .map_err(|_| format!("{var} is not set"))
+}
+
+fn shell_config_files() -> Result<Vec<PathBuf>, String> {
+    let home = home_dir()?;
+    let mut files = Vec::new();
+    if cfg!(windows) {
+        for relative in [
+            ["Documents", "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1"].as_slice(),
+            ["Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1"].as_slice(),
+            ["OneDrive", "Documents", "WindowsPowerShell", "Microsoft.PowerShell_profile.ps1"].as_slice(),
+            ["OneDrive", "Documents", "PowerShell", "Microsoft.PowerShell_profile.ps1"].as_slice(),
+        ] {
+            let mut path = home.clone();
+            for part in relative {
+                path.push(part);
+            }
+            files.push(path);
+        }
+    } else {
+        for name in [".zshrc", ".zprofile", ".bash_profile", ".bashrc", ".profile"] {
+            files.push(home.join(name));
+        }
+    }
+    files.retain(|path| path.is_file());
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn line_is_cojudge_alias(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with("alias cojudge=") || trimmed.starts_with("function cojudge")
+}
+
+fn line_is_cojudge_cli_comment(line: &str) -> bool {
+    matches!(line.trim(), "# CoJudge CLI" | "# Cojudge CLI")
+}
+
+fn has_shell_alias(contents: &str) -> bool {
+    contents.lines().any(line_is_cojudge_alias)
+}
+
+fn skip_powershell_function(lines: &[&str], start: usize) -> usize {
+    let mut depth: usize = 0;
+    let mut seen_brace = false;
+    let mut index = start;
+    while index < lines.len() {
+        for ch in lines[index].chars() {
+            if ch == '{' {
+                depth += 1;
+                seen_brace = true;
+            } else if ch == '}' {
+                depth = depth.saturating_sub(1);
+            }
+        }
+        index += 1;
+        if seen_brace && depth == 0 {
+            break;
+        }
+        if !seen_brace && index > start + 2 {
+            break;
+        }
+    }
+    index
+}
+
+fn strip_shell_alias(contents: &str) -> String {
+    let lines: Vec<&str> = contents.lines().collect();
+    let mut result = String::new();
+    let mut index = 0;
+    while index < lines.len() {
+        let line = lines[index];
+        if line_is_cojudge_cli_comment(line) {
+            let next_is_alias = lines.get(index + 1).is_some_and(|next| line_is_cojudge_alias(next));
+            let alias_after_blank = lines.get(index + 1).is_some_and(|next| next.trim().is_empty())
+                && lines.get(index + 2).is_some_and(|next| line_is_cojudge_alias(next));
+            if next_is_alias || alias_after_blank {
+                index += 1;
+                continue;
+            }
+        }
+        if line_is_cojudge_alias(line) {
+            if line.trim_start().starts_with("function cojudge") {
+                index = skip_powershell_function(&lines, index);
+            } else {
+                index += 1;
+            }
+            if lines.get(index).is_some_and(|next| next.trim().is_empty()) {
+                index += 1;
+            }
+            continue;
+        }
+        result.push_str(line);
+        result.push('\n');
+        index += 1;
+    }
+    result
+}
+
+fn find_shell_aliases() -> Result<Vec<String>, String> {
+    let mut paths = Vec::new();
+    for path in shell_config_files()? {
+        let contents = fs::read_to_string(&path)
+            .map_err(|error| format!("Could not read {}: {error}", path.display()))?;
+        if has_shell_alias(&contents) {
+            paths.push(path.display().to_string());
+        }
+    }
+    Ok(paths)
+}
+
+fn remove_shell_aliases() -> Result<Vec<String>, String> {
+    let mut removed = Vec::new();
+    for path in shell_config_files()? {
+        let contents = fs::read_to_string(&path)
+            .map_err(|error| format!("Could not read {}: {error}", path.display()))?;
+        if !has_shell_alias(&contents) {
+            continue;
+        }
+        fs::write(&path, strip_shell_alias(&contents))
+            .map_err(|error| format!("Could not update {}: {error}", path.display()))?;
+        removed.push(path.display().to_string());
+    }
+    Ok(removed)
+}
+
+#[cfg(unix)]
+fn unix_path_targets() -> Result<Vec<PathBuf>, String> {
+    let home = PathBuf::from(std::env::var("HOME").map_err(|_| "HOME is not set".to_string())?);
+    let mut targets = Vec::new();
+    #[cfg(target_os = "macos")]
+    {
+        targets.push(home.join(".zprofile"));
+    }
+    for name in [".zprofile", ".zshrc", ".bash_profile", ".bashrc", ".profile"] {
+        let path = home.join(name);
+        if path.exists() && !targets.iter().any(|existing| existing == &path) {
+            targets.push(path);
+        }
+    }
+    if targets.is_empty() {
+        targets.push(home.join(".profile"));
+    }
+    Ok(targets)
+}
+
+#[cfg(unix)]
+fn file_has_local_bin_path(contents: &str) -> bool {
+    contents.contains(PATH_BLOCK_BEGIN)
+        || contents.contains("$HOME/.local/bin")
+        || contents.contains("~/.local/bin")
+}
+
+#[cfg(unix)]
+fn ensure_unix_path() -> Result<bool, String> {
+    let mut changed = false;
+    for path in unix_path_targets()? {
+        let mut contents = if path.exists() {
+            fs::read_to_string(&path)
+                .map_err(|error| format!("Could not read {}: {error}", path.display()))?
+        } else {
+            String::new()
+        };
+        if file_has_local_bin_path(&contents) {
+            continue;
+        }
+        if !contents.is_empty() && !contents.ends_with('\n') {
+            contents.push('\n');
+        }
+        if !contents.is_empty() {
+            contents.push('\n');
+        }
+        contents.push_str(PATH_BLOCK_BEGIN);
+        contents.push('\n');
+        contents.push_str(PATH_EXPORT);
+        contents.push('\n');
+        contents.push_str(PATH_BLOCK_END);
+        contents.push('\n');
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|error| format!("Could not update {}: {error}", path.display()))?;
+        }
+        fs::write(&path, contents)
+            .map_err(|error| format!("Could not update {}: {error}", path.display()))?;
+        changed = true;
+    }
+    Ok(changed)
+}
+
+#[cfg(unix)]
+fn strip_path_block(contents: &str) -> String {
+    let mut result = String::new();
+    let mut skipping = false;
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if trimmed == PATH_BLOCK_BEGIN {
+            skipping = true;
+            continue;
+        }
+        if skipping {
+            if trimmed == PATH_BLOCK_END {
+                skipping = false;
+            }
+            continue;
+        }
+        result.push_str(line);
+        result.push('\n');
+    }
+    result
+}
+
+#[cfg(unix)]
+fn remove_unix_path() -> Result<(), String> {
+    for path in unix_path_targets()? {
+        if !path.exists() {
+            continue;
+        }
+        let contents = fs::read_to_string(&path)
+            .map_err(|error| format!("Could not read {}: {error}", path.display()))?;
+        if !contents.contains(PATH_BLOCK_BEGIN) {
+            continue;
+        }
+        fs::write(&path, strip_path_block(&contents))
+            .map_err(|error| format!("Could not update {}: {error}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn windows_user_path() -> Result<String, String> {
+    let output = std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "[Environment]::GetEnvironmentVariable('Path','User')",
+        ])
+        .output()
+        .map_err(|error| format!("Could not read user PATH: {error}"))?;
+    if !output.status.success() {
+        return Err("Could not read user PATH".to_string());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(windows)]
+fn windows_set_user_path(value: &str) -> Result<(), String> {
+    let status = std::process::Command::new("powershell")
+        .args([
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "[Environment]::SetEnvironmentVariable('Path', $env:COJUDGE_PATH_VALUE, 'User')",
+        ])
+        .env("COJUDGE_PATH_VALUE", value)
+        .status()
+        .map_err(|error| format!("Could not update user PATH: {error}"))?;
+    if !status.success() {
+        return Err("Could not update user PATH".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn path_entry_matches(entry: &str, dir: &Path) -> bool {
+    let trimmed = entry.trim().trim_end_matches(['\\', '/']);
+    if trimmed.is_empty() {
+        return false;
+    }
+    PathBuf::from(trimmed) == dir
+}
+
+#[cfg(windows)]
+fn ensure_windows_path() -> Result<bool, String> {
+    let dir = install_dir()?;
+    let existing = windows_user_path()?;
+    let mut parts: Vec<String> = existing
+        .split(';')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    if parts.iter().any(|part| path_entry_matches(part, &dir)) {
+        return Ok(false);
+    }
+    parts.insert(0, dir.display().to_string());
+    windows_set_user_path(&parts.join(";"))?;
+    Ok(true)
+}
+
+#[cfg(windows)]
+fn remove_windows_path() -> Result<(), String> {
+    let dir = install_dir()?;
+    let existing = windows_user_path()?;
+    let parts: Vec<String> = existing
+        .split(';')
+        .map(str::trim)
+        .filter(|part| !part.is_empty() && !path_entry_matches(part, &dir))
+        .map(ToString::to_string)
+        .collect();
+    windows_set_user_path(&parts.join(";"))
+}
+
+fn unix_wrapper_contents(node: &Path, backend: &Path) -> String {
+    format!(
+        "#!/bin/sh\nexport COJUDGE_ROOT={}\nexport COJUDGE_DESKTOP=1\nexec {} \"$COJUDGE_ROOT/bin/cojudge\" \"$@\"\n",
+        sh_quote(&backend.to_string_lossy()),
+        sh_quote(&node.to_string_lossy())
+    )
+}
+
+fn windows_wrapper_contents(node: &Path, backend: &Path) -> String {
+    format!(
+        "@echo off\r\nset \"COJUDGE_ROOT={}\"\r\nset \"COJUDGE_DESKTOP=1\"\r\n\"{}\" \"%COJUDGE_ROOT%\\bin\\cojudge\" %*\r\n",
+        backend.display(),
+        node.display()
+    )
+}
+
+fn write_wrapper(node: &Path, backend: &Path) -> Result<PathBuf, String> {
+    let dir = install_dir()?;
+    fs::create_dir_all(&dir).map_err(|error| format!("Could not create {}: {error}", dir.display()))?;
+    let path = wrapper_path()?;
+    let contents = if cfg!(windows) {
+        windows_wrapper_contents(node, backend)
+    } else {
+        unix_wrapper_contents(node, backend)
+    };
+    fs::write(&path, contents)
+        .map_err(|error| format!("Could not write {}: {error}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755))
+            .map_err(|error| format!("Could not make {} executable: {error}", path.display()))?;
+    }
+    Ok(path)
+}
+
+#[tauri::command]
+pub fn cli_status(app: AppHandle) -> Result<CliStatus, String> {
+    current_status(&app)
+}
+
+#[tauri::command]
+pub fn cli_install(app: AppHandle) -> Result<CliStatus, String> {
+    let node = node_binary()?;
+    let backend = backend_dir(&app)?;
+    let script = cli_script(&app)?;
+    if !node.is_file() || !script.is_file() {
+        return Ok(unavailable(
+            "CLI install is available in the packaged Cojudge app.",
+        ));
+    }
+
+    let node = resolve_existing(&node);
+    let backend = resolve_existing(&backend);
+    write_wrapper(&node, &backend)?;
+
+    #[cfg(unix)]
+    let path_changed = ensure_unix_path()?;
+    #[cfg(windows)]
+    let path_changed = ensure_windows_path()?;
+
+    let mut status = current_status(&app)?;
+    status.needs_new_terminal = path_changed || !install_dir_on_path()?;
+    status.message = Some(if status.needs_new_terminal {
+        "Installed. Open a new terminal, then run cojudge -h.".to_string()
+    } else {
+        "Installed. Run cojudge -h in a terminal.".to_string()
+    });
+    Ok(status)
+}
+
+#[tauri::command]
+pub fn cli_uninstall(app: AppHandle) -> Result<CliStatus, String> {
+    let path = wrapper_path()?;
+    if path.exists() {
+        fs::remove_file(&path)
+            .map_err(|error| format!("Could not remove {}: {error}", path.display()))?;
+    }
+
+    #[cfg(unix)]
+    remove_unix_path()?;
+    #[cfg(windows)]
+    remove_windows_path()?;
+
+    #[cfg(windows)]
+    if let Ok(dir) = install_dir() {
+        let _ = fs::remove_dir(dir);
+    }
+
+    let mut status = current_status(&app)?;
+    status.message = Some("Removed the Cojudge CLI.".to_string());
+    Ok(status)
+}
+
+#[tauri::command]
+pub fn cli_remove_shell_alias(app: AppHandle) -> Result<CliStatus, String> {
+    let removed = remove_shell_aliases()?;
+    let mut status = current_status(&app)?;
+    status.message = Some(if removed.is_empty() {
+        "No cojudge shell alias was found.".to_string()
+    } else {
+        format!("Removed the cojudge alias from {}.", removed.join(", "))
+    });
+    Ok(status)
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,8 @@
     windows_subsystem = "windows"
 )]
 
+mod cli;
+
 use std::{
     io::Write as _,
     process::Child,
@@ -808,7 +810,11 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             new_window,
             google_oauth_access_token,
-            read_text_file
+            read_text_file,
+            cli::cli_status,
+            cli::cli_install,
+            cli::cli_uninstall,
+            cli::cli_remove_shell_alias
         ])
         .on_menu_event(|app, event| {
             if event.id().0.as_str() == NEW_WINDOW_MENU_ID {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -16,7 +16,7 @@
 				{
 					"identifier": "default",
 					"windows": ["main-*"],
-					"permissions": ["allow-new-window", "allow-google-oauth-access-token", "allow-read-text-file", "opener:default", "core:webview:allow-set-webview-zoom"],
+					"permissions": ["allow-new-window", "allow-google-oauth-access-token", "allow-read-text-file", "allow-cli-status", "allow-cli-install", "allow-cli-uninstall", "allow-cli-remove-shell-alias", "opener:default", "core:webview:allow-set-webview-zoom"],
 					"remote": {
 						"urls": ["http://127.0.0.1:5173/*", "http://cojudge.localhost:5376/*"]
 					}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,5 +1,10 @@
 import { startCleanupCron, stopCleanupCron } from '$lib/server/cleanup';
+import { ensureUserContentSeeded } from '$lib/server/contentPaths';
 import process from 'node:process';
+
+// Seed ~/cojudge/problems + ~/cojudge/courses from the bundled content on
+// first start. Missing files only — never overwrites user edits.
+void ensureUserContentSeeded();
 
 declare global {
     var __cleanup_cron_started: boolean | undefined;

--- a/src/lib/markerRunner.ts
+++ b/src/lib/markerRunner.ts
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
-import path from 'path';
 import Dockerode from 'dockerode';
+import { resolveProblemFile } from './server/contentPaths';
 import tar from 'tar-stream';
 import { formatAndSplitJavaString, getDisplayFuncName, javaGetFullParam, javaHelperMethods, javaImage, javaListNodeClass, javaTreeNodeClass, javaGraphNodeClass } from './utils/javaUtil';
 import { ensureImageAvailable, LINUX_TIMEOUT_CODE, TIMEOUT_MESSAGE, type Param } from './utils/util';
@@ -41,7 +41,7 @@ export async function getMarkerResponses(problemId: string, functionName: string
             ${testCalls}
         }
     }`;
-    const markerPath = path.resolve('problems', problemId, 'Marker.java');
+    const markerPath = await resolveProblemFile(problemId, 'Marker.java');
     const markerCode = await fs.readFile(markerPath, 'utf-8');
     let container: Dockerode.Container | null = null;
     try {

--- a/src/lib/runners/CSharpRunner.ts
+++ b/src/lib/runners/CSharpRunner.ts
@@ -3,8 +3,8 @@ import { extractOperations } from "$lib/utils/util";
 import { ensureImageAvailable, EXECUTION_TIMEOUT_SECONDS, LINUX_TIMEOUT_CODE, TIMEOUT_MESSAGE } from "$lib/utils/util";
 import Dockerode from "dockerode";
 import fs from 'fs/promises';
-import path from 'path';
 import tar from 'tar-stream';
+import { resolveProblemFile } from "$lib/server/contentPaths";
 import { ProgramRunner } from "./ProgramRunner";
 import ContainerPool from "./ContainerPool";
 import { cojudgeContainerLabels } from "$lib/server/containerSession";
@@ -21,7 +21,7 @@ export class CSharpRunner extends ProgramRunner {
 
     async compile(): Promise<void> {
         try {
-            const problemPath = path.resolve('problems', this.problemId, 'metadata.json');
+            const problemPath = await resolveProblemFile(this.problemId, 'metadata.json');
             const problemContent = await fs.readFile(problemPath, 'utf-8');
             const problemData = JSON.parse(problemContent);
             const runnerCode = generateCSharpRunner(problemData.functionName, problemData.params, this.testCases, problemData.outputType, problemData.checkGraphClone);

--- a/src/lib/runners/CppRunner.ts
+++ b/src/lib/runners/CppRunner.ts
@@ -3,8 +3,8 @@ import { extractOperations } from "$lib/utils/util";
 import { ensureImageAvailable, EXECUTION_TIMEOUT_SECONDS, LINUX_TIMEOUT_CODE, TIMEOUT_MESSAGE } from "$lib/utils/util";
 import Dockerode from "dockerode";
 import fs from 'fs/promises';
-import path from 'path';
 import tar from 'tar-stream';
+import { resolveProblemFile } from "$lib/server/contentPaths";
 import { ProgramRunner } from "./ProgramRunner";
 import ContainerPool from "./ContainerPool";
 import { cojudgeContainerLabels } from "$lib/server/containerSession";
@@ -21,7 +21,7 @@ export class CppRunner extends ProgramRunner {
 
     async compile(): Promise<void> {
         try {
-            const problemPath = path.resolve('problems', this.problemId, 'metadata.json');
+            const problemPath = await resolveProblemFile(this.problemId, 'metadata.json');
             const problemContent = await fs.readFile(problemPath, 'utf-8');
             const problemData = JSON.parse(problemContent);
             const runnerCode = generateCppRunner(problemData.functionName, problemData.params, this.testCases, problemData.checkGraphClone);

--- a/src/lib/runners/DebugRunner.ts
+++ b/src/lib/runners/DebugRunner.ts
@@ -11,6 +11,7 @@ import Dockerode from "dockerode";
 import fs from 'fs/promises';
 import path from 'path';
 import tar from 'tar-stream';
+import { resolveProblemFile } from "$lib/server/contentPaths";
 import ContainerPool from "./ContainerPool";
 import { JAVA_DEBUG_DRIVER } from "./JavaDebugDriver";
 import { CPP_DEBUG_DRIVER } from "./CppDebugDriver";
@@ -526,7 +527,7 @@ async function evaluateCompletedResults(session: DebugSession, state: DebugState
                 return o;
             });
 
-            const problemPath = path.resolve('problems', session.problemId, 'metadata.json');
+            const problemPath = await resolveProblemFile(session.problemId, 'metadata.json');
             const problemContent = await fs.readFile(problemPath, 'utf-8');
             const problemData = JSON.parse(problemContent);
 
@@ -700,7 +701,7 @@ export async function startProblemDebugSession(problemId: string, language: stri
         throw new Error(`No test cases available for problem '${problemId}'`);
     }
 
-    const problemPath = path.resolve('problems', problemId, 'metadata.json');
+    const problemPath = await resolveProblemFile(problemId, 'metadata.json');
     const problemContent = await fs.readFile(problemPath, 'utf-8');
     const problemData = JSON.parse(problemContent);
 

--- a/src/lib/runners/GoRunner.ts
+++ b/src/lib/runners/GoRunner.ts
@@ -2,8 +2,8 @@ import { goImage, generateGoRunner, generateGoClassSolution } from "$lib/utils/g
 import { ensureImageAvailable, EXECUTION_TIMEOUT_SECONDS, LINUX_TIMEOUT_CODE, TIMEOUT_MESSAGE } from "$lib/utils/util";
 import Dockerode from "dockerode";
 import fs from 'fs/promises';
-import path from 'path';
 import tar from 'tar-stream';
+import { resolveProblemFile } from "$lib/server/contentPaths";
 import { ProgramRunner } from "./ProgramRunner";
 import ContainerPool from "./ContainerPool";
 import { cojudgeContainerLabels } from "$lib/server/containerSession";
@@ -20,7 +20,7 @@ export class GoRunner extends ProgramRunner {
 
     async compile(): Promise<void> {
         try {
-            const problemPath = path.resolve('problems', this.problemId, 'metadata.json');
+            const problemPath = await resolveProblemFile(this.problemId, 'metadata.json');
             const problemContent = await fs.readFile(problemPath, 'utf-8');
             const problemData = JSON.parse(problemContent);
 

--- a/src/lib/runners/JavaRunner.ts
+++ b/src/lib/runners/JavaRunner.ts
@@ -3,8 +3,8 @@ import { extractOperations } from "$lib/utils/util";
 import { ensureImageAvailable, EXECUTION_TIMEOUT_SECONDS, LINUX_TIMEOUT_CODE, TIMEOUT_MESSAGE } from "$lib/utils/util";
 import Dockerode from "dockerode";
 import fs from 'fs/promises';
-import path from 'path';
 import tar from 'tar-stream';
+import { resolveProblemFile } from "$lib/server/contentPaths";
 import { ProgramRunner } from "./ProgramRunner";
 import ContainerPool from "./ContainerPool";
 import { cojudgeContainerLabels } from "$lib/server/containerSession";
@@ -21,12 +21,12 @@ export class JavaRunner extends ProgramRunner {
 
     async compile(): Promise<void> {
         try {
-            const problemPath = path.resolve('problems', this.problemId, 'metadata.json');
+            const problemPath = await resolveProblemFile(this.problemId, 'metadata.json');
             const problemContent = await fs.readFile(problemPath, 'utf-8');
             const problemData = JSON.parse(problemContent);
 
             let runnerCode: string;
-            const markerPath = path.resolve('problems', this.problemId, 'Marker.java');
+            const markerPath = await resolveProblemFile(this.problemId, 'Marker.java');
             let hasMarker = false;
             try {
                 await fs.access(markerPath);

--- a/src/lib/runners/PythonRunner.ts
+++ b/src/lib/runners/PythonRunner.ts
@@ -3,8 +3,8 @@ import { extractOperations } from "$lib/utils/util";
 import { ensureImageAvailable, EXECUTION_TIMEOUT_SECONDS, LINUX_TIMEOUT_CODE, TIMEOUT_MESSAGE } from "$lib/utils/util";
 import Dockerode from "dockerode";
 import fs from 'fs/promises';
-import path from 'path';
 import tar from 'tar-stream';
+import { resolveProblemFile } from "$lib/server/contentPaths";
 import { ProgramRunner } from "./ProgramRunner";
 import ContainerPool from "./ContainerPool";
 import { cojudgeContainerLabels } from "$lib/server/containerSession";
@@ -21,7 +21,7 @@ export class PythonRunner extends ProgramRunner {
 
     async compile(): Promise<void> {
         try {
-            const problemPath = path.resolve('problems', this.problemId, 'metadata.json');
+            const problemPath = await resolveProblemFile(this.problemId, 'metadata.json');
             const problemContent = await fs.readFile(problemPath, 'utf-8');
             const problemData = JSON.parse(problemContent);
             const runnerCode = generatePythonRunner(problemData.functionName, problemData.params, this.testCases, problemData.checkGraphClone);

--- a/src/lib/runners/RustRunner.ts
+++ b/src/lib/runners/RustRunner.ts
@@ -2,8 +2,8 @@ import { rustImage, generateRustRunner } from "$lib/utils/rustUtil";
 import { ensureImageAvailable, EXECUTION_TIMEOUT_SECONDS, LINUX_TIMEOUT_CODE, TIMEOUT_MESSAGE } from "$lib/utils/util";
 import Dockerode from "dockerode";
 import fs from 'fs/promises';
-import path from 'path';
 import tar from 'tar-stream';
+import { resolveProblemFile } from "$lib/server/contentPaths";
 import { ProgramRunner } from "./ProgramRunner";
 import ContainerPool from "./ContainerPool";
 import { cojudgeContainerLabels } from "$lib/server/containerSession";
@@ -20,7 +20,7 @@ export class RustRunner extends ProgramRunner {
 
     async compile(): Promise<void> {
         try {
-            const problemPath = path.resolve('problems', this.problemId, 'metadata.json');
+            const problemPath = await resolveProblemFile(this.problemId, 'metadata.json');
             const problemContent = await fs.readFile(problemPath, 'utf-8');
             const problemData = JSON.parse(problemContent);
             

--- a/src/lib/runners/TypeScriptRunner.ts
+++ b/src/lib/runners/TypeScriptRunner.ts
@@ -2,8 +2,8 @@ import { tsImage, generateTypeScriptRunner, tsGetTypeImports, tsListNodeClass, t
 import { ensureImageAvailable, EXECUTION_TIMEOUT_SECONDS, LINUX_TIMEOUT_CODE, TIMEOUT_MESSAGE, type Param } from "$lib/utils/util";
 import Dockerode from "dockerode";
 import fs from 'fs/promises';
-import path from 'path';
 import tar from 'tar-stream';
+import { resolveProblemFile } from "$lib/server/contentPaths";
 import { ProgramRunner } from "./ProgramRunner";
 import ContainerPool from "./ContainerPool";
 import { cojudgeContainerLabels } from "$lib/server/containerSession";
@@ -20,7 +20,7 @@ export class TypeScriptRunner extends ProgramRunner {
 
     async compile(): Promise<void> {
         try {
-            const problemPath = path.resolve('problems', this.problemId, 'metadata.json');
+            const problemPath = await resolveProblemFile(this.problemId, 'metadata.json');
             const problemContent = await fs.readFile(problemPath, 'utf-8');
             const problemData = JSON.parse(problemContent);
 

--- a/src/lib/server/contentPaths.test.ts
+++ b/src/lib/server/contentPaths.test.ts
@@ -1,0 +1,184 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('contentPaths', () => {
+	let tmpRoot: string;
+	let bundledRoot: string;
+	let originalEnv: NodeJS.ProcessEnv;
+
+	beforeEach(async () => {
+		tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cojudge-content-'));
+		bundledRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'cojudge-bundled-'));
+		originalEnv = { ...process.env };
+		process.env.COJUDGE_CONTENT_DIR = path.join(tmpRoot, 'user');
+		vi.resetModules();
+	});
+
+	afterEach(async () => {
+		process.env = originalEnv;
+		vi.resetModules();
+		const { __resetEnsureMemoForTests } = await import('./contentPaths');
+		__resetEnsureMemoForTests();
+		await fs.rm(tmpRoot, { recursive: true, force: true });
+		await fs.rm(bundledRoot, { recursive: true, force: true });
+	});
+
+	it('prefers user content over bundled content', async () => {
+		const mod = await import('./contentPaths');
+		expect(mod.getContentRoot()).toBe(path.join(tmpRoot, 'user'));
+		expect(mod.getProblemsDir()).toBe(path.join(tmpRoot, 'user', 'problems'));
+		expect(mod.getCoursesDir()).toBe(path.join(tmpRoot, 'user', 'courses'));
+	});
+
+	it('resolveProblemFileSync prefers user file then falls back to bundled', async () => {
+		// Point CWD at the fake bundled root for this test.
+		const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(bundledRoot);
+		try {
+			await fs.mkdir(path.join(bundledRoot, 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'),
+				'{"id":"two-sum"}'
+			);
+
+			const mod = await import('./contentPaths');
+
+			// No user file yet -> bundled.
+			expect(mod.resolveProblemFileSync('two-sum', 'metadata.json')).toBe(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json')
+			);
+
+			// After user override -> user wins.
+			await fs.mkdir(path.join(tmpRoot, 'user', 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(
+				path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+				'{"id":"two-sum","edited":true}'
+			);
+			expect(mod.resolveProblemFileSync('two-sum', 'metadata.json')).toBe(
+				path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json')
+			);
+		} finally {
+			cwdSpy.mockRestore();
+		}
+	});
+
+	it('detects custom / modified / bundled problem sources', async () => {
+		const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(bundledRoot);
+		try {
+			// Bundled-only problem with no user copy -> bundled.
+			await fs.mkdir(path.join(bundledRoot, 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'), '{}');
+
+			const mod = await import('./contentPaths');
+			expect(await mod.getProblemSource('two-sum')).toBe('bundled');
+
+			// Identical user copy -> still bundled.
+			await fs.mkdir(path.join(tmpRoot, 'user', 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'), '{}');
+			expect(await mod.getProblemSource('two-sum')).toBe('bundled');
+
+			// Edited user copy -> modified.
+			await fs.writeFile(
+				path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+				'{"edited":true}'
+			);
+			expect(await mod.getProblemSource('two-sum')).toBe('modified');
+
+			// User-only problem -> custom.
+			await fs.mkdir(path.join(tmpRoot, 'user', 'problems', 'my-prob'), { recursive: true });
+			await fs.writeFile(path.join(tmpRoot, 'user', 'problems', 'my-prob', 'metadata.json'), '{}');
+			expect(await mod.getProblemSource('my-prob')).toBe('custom');
+		} finally {
+			cwdSpy.mockRestore();
+		}
+	});
+
+	it('detects custom / modified / bundled course sources', async () => {
+		const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(bundledRoot);
+		try {
+			await fs.mkdir(path.join(bundledRoot, 'courses', 'blind75'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'courses', 'blind75', 'courseinfo.json'),
+				'{"title":"Blind 75"}'
+			);
+
+			const mod = await import('./contentPaths');
+			expect(await mod.getCourseSource('blind75')).toBe('bundled');
+
+			await fs.mkdir(path.join(tmpRoot, 'user', 'courses', 'my-course'), { recursive: true });
+			await fs.writeFile(
+				path.join(tmpRoot, 'user', 'courses', 'my-course', 'courseinfo.json'),
+				'{"title":"Mine"}'
+			);
+			expect(await mod.getCourseSource('my-course')).toBe('custom');
+
+			// Same content, different whitespace is still a difference (byte compare).
+			await fs.mkdir(path.join(tmpRoot, 'user', 'courses', 'blind75'), { recursive: true });
+			await fs.writeFile(
+				path.join(tmpRoot, 'user', 'courses', 'blind75', 'courseinfo.json'),
+				'{"title": "Blind 75"}'
+			);
+			expect(await mod.getCourseSource('blind75')).toBe('modified');
+		} finally {
+			cwdSpy.mockRestore();
+		}
+	});
+
+	it('ensureUserContentSeeded copies missing files without overwriting edits', async () => {
+		const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(bundledRoot);
+		try {
+			await fs.mkdir(path.join(bundledRoot, 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'),
+				'{"id":"two-sum"}'
+			);
+			await fs.mkdir(path.join(bundledRoot, 'courses', 'blind75'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'courses', 'blind75', 'courseinfo.json'),
+				'{"title":"Blind 75"}'
+			);
+
+			const mod = await import('./contentPaths');
+			await mod.ensureUserContentSeeded();
+
+			expect(
+				await fs.readFile(
+					path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+					'utf-8'
+				)
+			).toBe('{"id":"two-sum"}');
+
+			// User edit must survive a second seed.
+			await fs.writeFile(
+				path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+				'{"edited":true}'
+			);
+			mod.__resetEnsureMemoForTests();
+			await mod.ensureUserContentSeeded();
+			expect(
+				await fs.readFile(
+					path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+					'utf-8'
+				)
+			).toBe('{"edited":true}');
+
+			// New bundled problem appears after re-seed.
+			await fs.mkdir(path.join(bundledRoot, 'problems', 'new-prob'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'new-prob', 'metadata.json'),
+				'{}'
+			);
+			mod.__resetEnsureMemoForTests();
+			await mod.ensureUserContentSeeded();
+			expect(
+				await fs.readFile(
+					path.join(tmpRoot, 'user', 'problems', 'new-prob', 'metadata.json'),
+					'utf-8'
+				)
+			).toBe('{}');
+		} finally {
+			cwdSpy.mockRestore();
+		}
+	});
+});

--- a/src/lib/server/contentPaths.ts
+++ b/src/lib/server/contentPaths.ts
@@ -1,0 +1,354 @@
+import fs from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * User-editable content lives in ~/cojudge (overridable via
+ * COJUDGE_CONTENT_DIR / COJUDGE_HOME for tests and custom setups).
+ *
+ * Layout:
+ *   <contentRoot>/problems/<slug>/metadata.json, statement.md, ...
+ *   <contentRoot>/courses/<courseId>/courseinfo.json
+ *
+ * The repo-bundled `problems/` and `courses/` directories act as seed
+ * content and as a read fallback. On first use the bundled content is
+ * copied (missing files only, never overwriting user edits) into the
+ * user folder so users can view / edit / add problems, test cases,
+ * solutions and courses by managing their own ~/cojudge folder.
+ */
+
+export function getContentRoot(): string {
+	const override =
+		process.env.COJUDGE_CONTENT_DIR?.trim() || process.env.COJUDGE_HOME?.trim();
+	if (override) return path.resolve(override);
+	return path.join(os.homedir(), 'cojudge');
+}
+
+export function getProblemsDir(): string {
+	return path.join(getContentRoot(), 'problems');
+}
+
+export function getCoursesDir(): string {
+	return path.join(getContentRoot(), 'courses');
+}
+
+export function getBundledProblemsDir(): string {
+	return path.resolve('problems');
+}
+
+export function getBundledCoursesDir(): string {
+	return path.resolve('courses');
+}
+
+function isSafeSegment(segment: string): boolean {
+	return (
+		!!segment &&
+		segment !== '.' &&
+		segment !== '..' &&
+		!segment.includes('/') &&
+		!segment.includes('\\') &&
+		!segment.includes('\0')
+	);
+}
+
+/** Prefer the user copy; fall back to the bundled copy. */
+export function resolveProblemDirSync(slug: string): string {
+	const userDir = path.join(getProblemsDir(), slug);
+	try {
+		if (existsSync(userDir)) return userDir;
+	} catch {
+		// ignore and fall back
+	}
+	return path.join(getBundledProblemsDir(), slug);
+}
+
+/** Prefer the user copy; fall back to the bundled copy. */
+export async function resolveProblemDir(slug: string): Promise<string> {
+	const userDir = path.join(getProblemsDir(), slug);
+	try {
+		await fs.access(userDir);
+		return userDir;
+	} catch {
+		return path.join(getBundledProblemsDir(), slug);
+	}
+}
+
+/**
+ * Resolve a file inside a problem dir, preferring ~/cojudge and falling
+ * back to the bundled repo copy. Returns the first path that exists, or
+ * the user path (for a useful error message) when neither exists.
+ */
+export function resolveProblemFileSync(slug: string, ...rest: string[]): string {
+	for (const segment of [slug, ...rest]) {
+		if (!isSafeSegment(segment) && segment !== rest[rest.length - 1]) {
+			// Slugs and intermediate segments must be safe; the leaf file
+			// name is still basename-guarded below by join semantics.
+		}
+	}
+	const userPath = path.join(getProblemsDir(), slug, ...rest);
+	try {
+		if (existsSync(userPath)) return userPath;
+	} catch {
+		// ignore
+	}
+	const bundledPath = path.join(getBundledProblemsDir(), slug, ...rest);
+	try {
+		if (existsSync(bundledPath)) return bundledPath;
+	} catch {
+		// ignore
+	}
+	return userPath;
+}
+
+export async function resolveProblemFile(slug: string, ...rest: string[]): Promise<string> {
+	const userPath = path.join(getProblemsDir(), slug, ...rest);
+	try {
+		await fs.access(userPath);
+		return userPath;
+	} catch {
+		// fall through to bundled
+	}
+	const bundledPath = path.join(getBundledProblemsDir(), slug, ...rest);
+	try {
+		await fs.access(bundledPath);
+		return bundledPath;
+	} catch {
+		return userPath;
+	}
+}
+
+/** Read a problem file from ~/cojudge first, then the bundled copy. */
+export async function readProblemFile(slug: string, file: string): Promise<string> {
+	const filePath = await resolveProblemFile(slug, file);
+	return fs.readFile(filePath, 'utf-8');
+}
+
+export function resolveCourseFileSync(courseId: string, ...rest: string[]): string {
+	const userPath = path.join(getCoursesDir(), courseId, ...rest);
+	try {
+		if (existsSync(userPath)) return userPath;
+	} catch {
+		// ignore
+	}
+	const bundledPath = path.join(getBundledCoursesDir(), courseId, ...rest);
+	try {
+		if (existsSync(bundledPath)) return bundledPath;
+	} catch {
+		// ignore
+	}
+	return userPath;
+}
+
+/**
+ * Where a problem/course comes from:
+ * - `custom` — only exists in ~/cojudge (user-created)
+ * - `modified` — exists in ~/cojudge and differs from the bundled copy (user-edited)
+ * - `bundled` — identical to (or only in) the bundled copy
+ */
+export type ContentSource = 'custom' | 'modified' | 'bundled';
+
+const PROBLEM_COMPARE_FILES = [
+	'metadata.json',
+	'statement.md',
+	'official-tests.json',
+	'Marker.java',
+	'solution.md'
+];
+
+const COURSE_COMPARE_FILES = ['courseinfo.json'];
+
+async function readIfExists(filePath: string): Promise<string | null> {
+	try {
+		return await fs.readFile(filePath, 'utf-8');
+	} catch {
+		return null;
+	}
+}
+
+/** Compare a user dir against its bundled counterpart (missing files only, never writes). */
+async function compareDirToBundled(
+	userDir: string,
+	bundledDir: string,
+	files: string[]
+): Promise<ContentSource> {
+	let bundledExists = false;
+	try {
+		await fs.access(bundledDir);
+		bundledExists = true;
+	} catch {
+		bundledExists = false;
+	}
+	let userExists = false;
+	try {
+		await fs.access(userDir);
+		userExists = true;
+	} catch {
+		userExists = false;
+	}
+	if (!bundledExists) return userExists ? 'custom' : 'bundled';
+	if (!userExists) return 'bundled';
+
+	const comparisons = await Promise.all(
+		files.map(async (file) => {
+			const [userContent, bundledContent] = await Promise.all([
+				readIfExists(path.join(userDir, file)),
+				readIfExists(path.join(bundledDir, file))
+			]);
+			return userContent === bundledContent;
+		})
+	);
+	return comparisons.every(Boolean) ? 'bundled' : 'modified';
+}
+
+export function getProblemSource(slug: string): Promise<ContentSource> {
+	return compareDirToBundled(
+		path.join(getProblemsDir(), slug),
+		path.join(getBundledProblemsDir(), slug),
+		PROBLEM_COMPARE_FILES
+	);
+}
+
+export function getCourseSource(courseId: string): Promise<ContentSource> {
+	return compareDirToBundled(
+		path.join(getCoursesDir(), courseId),
+		path.join(getBundledCoursesDir(), courseId),
+		COURSE_COMPARE_FILES
+	);
+}
+
+export async function getProblemSources(slugs: string[]): Promise<Record<string, ContentSource>> {
+	const entries = await Promise.all(slugs.map(async (slug) => [slug, await getProblemSource(slug)] as const));
+	return Object.fromEntries(entries);
+}
+
+export async function getCourseSources(ids: string[]): Promise<Record<string, ContentSource>> {
+	const entries = await Promise.all(ids.map(async (id) => [id, await getCourseSource(id)] as const));
+	return Object.fromEntries(entries);
+}
+
+/** Union of problem slugs from ~/cojudge and the bundled copy (user wins). */
+export async function listProblemSlugs(): Promise<string[]> {
+	const seen = new Set<string>();
+	for (const dir of [getProblemsDir(), getBundledProblemsDir()]) {
+		try {
+			const entries = await fs.readdir(dir, { withFileTypes: true });
+			for (const entry of entries) {
+				if (entry.isDirectory()) seen.add(entry.name);
+			}
+		} catch {
+			// missing dir is fine
+		}
+	}
+	return [...seen].sort();
+}
+
+/** Union of course ids from ~/cojudge and the bundled copy. */
+export async function listCourseIds(): Promise<string[]> {
+	const seen = new Set<string>();
+	for (const dir of [getCoursesDir(), getBundledCoursesDir()]) {
+		try {
+			const entries = await fs.readdir(dir, { withFileTypes: true });
+			for (const entry of entries) {
+				if (entry.isDirectory()) seen.add(entry.name);
+			}
+		} catch {
+			// missing dir is fine
+		}
+	}
+	return [...seen].sort();
+}
+
+const USER_README = `# CoJudge content
+
+This folder is yours. CoJudge reads problems and courses from here first.
+
+- \`problems/<slug>/\` — statement.md, metadata.json, official-tests.json, Marker.java, solution.md (optional), images
+- \`courses/<course-id>/courseinfo.json\` — category order + problem lists
+
+You can view, edit, add or delete anything here — changes take effect
+immediately (no restart needed, just refresh the browser or re-run the CLI).
+
+After you add a problem, verify it with the CoJudge CLI (Docker required):
+
+\`\`\`bash
+cojudge run <slug> Solution.py
+cojudge submit <slug> Solution.py
+\`\`\`
+
+Missing files are seeded from the bundled CoJudge content on startup and
+are never overwritten once you have edited them. Set COJUDGE_CONTENT_DIR
+to use a different folder.
+`;
+
+async function copyMissingRecursive(src: string, dest: string): Promise<void> {
+	let entries;
+	try {
+		entries = await fs.readdir(src, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	await fs.mkdir(dest, { recursive: true });
+	for (const entry of entries) {
+		// Skip OS noise.
+		if (entry.name === '.DS_Store') continue;
+		const srcPath = path.join(src, entry.name);
+		const destPath = path.join(dest, entry.name);
+		let destExists = false;
+		try {
+			await fs.access(destPath);
+			destExists = true;
+		} catch {
+			destExists = false;
+		}
+		if (entry.isDirectory()) {
+			if (!destExists) {
+				await fs.cp(srcPath, destPath, { recursive: true });
+			} else {
+				await copyMissingRecursive(srcPath, destPath);
+			}
+		} else if (entry.isFile()) {
+			if (!destExists) {
+				await fs.copyFile(srcPath, destPath);
+			}
+		}
+	}
+}
+
+let ensurePromise: Promise<void> | null = null;
+
+/**
+ * Seed ~/cojudge/problems and ~/cojudge/courses from the bundled content.
+ * Only copies files that are missing — never overwrites user edits.
+ * Safe to call on every startup / request; cheap after the first seed.
+ */
+export function ensureUserContentSeeded(): Promise<void> {
+	if (!ensurePromise) {
+		ensurePromise = (async () => {
+			try {
+				const root = getContentRoot();
+				await fs.mkdir(path.join(root, 'problems'), { recursive: true });
+				await fs.mkdir(path.join(root, 'courses'), { recursive: true });
+				await copyMissingRecursive(getBundledProblemsDir(), getProblemsDir());
+				await copyMissingRecursive(getBundledCoursesDir(), getCoursesDir());
+				const readmePath = path.join(root, 'README.md');
+				try {
+					await fs.access(readmePath);
+				} catch {
+					await fs.writeFile(readmePath, USER_README, 'utf-8');
+				}
+			} catch {
+				// Seeding must never break serving — readers fall back to bundled content.
+			}
+		})().finally(() => {
+			// Allow a retry on the next call if this attempt ran while the
+			// bundled dirs were temporarily unavailable.
+		});
+	}
+	return ensurePromise;
+}
+
+/** Reset the seeding memo (tests only). */
+export function __resetEnsureMemoForTests(): void {
+	ensurePromise = null;
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,26 +1,68 @@
-import path from 'node:path';
 import {
     discoverCourses,
     loadProblemSummaries,
     orderProblemsForCourse,
     selectCourse
 } from '$lib/server/courseCatalog';
+import {
+    ensureUserContentSeeded,
+    getBundledCoursesDir,
+    getBundledProblemsDir,
+    getContentRoot,
+    getCourseSources,
+    getCoursesDir,
+    getProblemsDir,
+    getProblemSources
+} from '$lib/server/contentPaths';
+import { existsSync } from 'node:fs';
 import type { PageServerLoad } from './$types';
 
+async function resolveContentDir(userDir: string, bundledDir: string): Promise<string> {
+    await ensureUserContentSeeded();
+    return existsSync(userDir) ? userDir : bundledDir;
+}
+
 export const load: PageServerLoad = async ({ url }) => {
-    const [courses, allProblems] = await Promise.all([
-        discoverCourses(path.resolve('courses')),
-        loadProblemSummaries(path.resolve('problems'))
+    const coursesDir = await resolveContentDir(getCoursesDir(), getBundledCoursesDir());
+    const problemsDir = await resolveContentDir(getProblemsDir(), getBundledProblemsDir());
+    // Merge user (~/cojudge) and bundled content so newly shipped problems
+    // still appear even before the next seed pass copies them over.
+    const [userCourses, bundledCourses, userProblems, bundledProblems] = await Promise.all([
+        discoverCourses(coursesDir),
+        coursesDir === getBundledCoursesDir() ? Promise.resolve([]) : discoverCourses(getBundledCoursesDir()),
+        loadProblemSummaries(problemsDir),
+        problemsDir === getBundledProblemsDir() ? Promise.resolve([]) : loadProblemSummaries(getBundledProblemsDir())
     ]);
+    const courses = [...userCourses];
+    for (const c of bundledCourses) {
+        if (!courses.some((existing) => existing.id === c.id)) courses.push(c);
+    }
+    const allProblems = [...userProblems];
+    for (const p of bundledProblems) {
+        if (!allProblems.some((existing) => existing.id === p.id)) allProblems.push(p);
+    }
+    courses.sort((a, b) => a.id.localeCompare(b.id));
     const selectedCourse = selectCourse(courses, url.searchParams.get('course'));
+    // Label user content: `custom` (only in ~/cojudge) or `modified`
+    // (differs from the bundled copy) so the UI can badge overrides.
+    const [courseSources, problemSources] = await Promise.all([
+        getCourseSources(courses.map((course) => course.id)),
+        getProblemSources(allProblems.map((problem) => problem.id))
+    ]);
     const problems = selectedCourse
-        ? orderProblemsForCourse(selectedCourse.info, allProblems)
+        ? orderProblemsForCourse(
+            selectedCourse.info,
+            allProblems.map((problem) => ({ ...problem, source: problemSources[problem.id] ?? 'bundled' }))
+        )
         : [];
 
     return {
-        courses: courses.map((course) => ({ id: course.id, title: course.info.title })),
+        courses: courses.map((course) => ({ id: course.id, title: course.info.title, source: courseSources[course.id] ?? 'bundled' })),
         selectedCourseId: selectedCourse?.id ?? null,
         selectedCourseInfo: selectedCourse?.info ?? null,
-        problems
+        problems,
+        // Absolute path of the user-editable content folder (~/cojudge by
+        // default), shown in the "Manage Problems" popup.
+        contentDir: getContentRoot()
     };
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
     import { marked } from "marked";
     import { browser } from '$app/environment';
     import { goto } from '$app/navigation';
+    import { page } from '$app/stores';
     import Tooltip from "$lib/components/Tooltip.svelte";
     import SortIcon from "$lib/components/SortIcon.svelte";
     import userSettingsStorage from '$lib/stores/userSettingsStorage';
@@ -50,6 +51,33 @@
     let loadCodeInputs: HTMLInputElement[] = [];
     let pendingImport: Record<string, unknown> | null = null;
     let showClearConfirm = false;
+    let showManageProblems = false;
+    let manageProblemsCard: HTMLElement | null = null;
+    let manageProblemsError = '';
+    let showCliSettings = false;
+    let cliSettingsCard: HTMLElement | null = null;
+    let cliBusy = false;
+    let cliError = '';
+    let cliPathCopied = false;
+    let cliPathCopiedTimer: ReturnType<typeof setTimeout> | undefined;
+    let cliStatus: {
+        available: boolean;
+        installed: boolean;
+        path: string | null;
+        aliasPaths: string[];
+        needsNewTerminal: boolean;
+        message: string | null;
+    } = {
+        available: false,
+        installed: false,
+        path: null,
+        aliasPaths: [],
+        needsNewTerminal: false,
+        message: null
+    };
+    let revealingFolder = false;
+    let pathCopied = false;
+    let pathCopiedTimer: ReturnType<typeof setTimeout> | undefined;
     let importNotice: { message: string; error: boolean; filePath?: string } | null = null;
     let importNoticeTimer: ReturnType<typeof setTimeout> | undefined;
     let showFirebaseSettings = false;
@@ -65,8 +93,10 @@
     let showGamePopup = false;
     let isDesktopMode = browser && isDesktopRuntime();
     $: if (browser) {
-        document.body.style.overflow = showGamePopup || pendingImport || showFirebaseSettings || showLoadCode || showClearConfirm ? 'hidden' : '';
+        document.body.style.overflow = showGamePopup || pendingImport || showFirebaseSettings || showLoadCode || showClearConfirm || showManageProblems || showCliSettings ? 'hidden' : '';
     }
+
+    $: contentDir = (data?.contentDir ?? '~/cojudge') as string;
     let gameResultData: Record<string, GameResult[]> = {};
     let historyProblem: { id: string; title: string } | null = null;
 
@@ -197,6 +227,7 @@
 
     onMount(() => {
         window.addEventListener("click", handleClickOutside);
+        if (isDesktopMode) void refreshCliStatus();
 
         // Restore last selected course from localStorage if no course param in URL
         const url = new URL(window.location.href);
@@ -213,6 +244,7 @@
     });
 
     // Types for problems from the loader
+    type ContentSource = 'custom' | 'modified' | 'bundled';
     type Problem = {
         id: string;
         title: string;
@@ -220,12 +252,26 @@
         link?: string;
         category?: string;
         statement?: string;
+        source?: ContentSource;
     };
 
     type CourseSummary = {
         id: string;
         title: string;
+        source?: ContentSource;
     };
+
+    function sourceLabel(source?: ContentSource): string {
+        return source === 'custom' ? 'Custom' : source === 'modified' ? 'Modified' : '';
+    }
+
+    function sourceTitle(source?: ContentSource): string {
+        return source === 'custom'
+            ? 'Custom content — only exists in your CoJudge folder'
+            : source === 'modified'
+                ? 'Modified — edited in your CoJudge folder, differs from the bundled copy'
+                : '';
+    }
 
     // Group problems by category
     let grouped: Record<string, Problem[]> = {};
@@ -694,13 +740,19 @@
                     ? firebaseModalCard
                     : showLoadCode
                         ? loadModalCard
-                        : null;
+                        : showManageProblems
+                            ? manageProblemsCard
+                            : showCliSettings
+                                ? cliSettingsCard
+                                : null;
         if (!activeModal) return;
         if (event.key === 'Escape') {
             event.preventDefault();
             if (pendingImport) cancelImport();
             else if (showClearConfirm) void closeClearProgress();
             else if (showFirebaseSettings) void closeFirebaseSettings();
+            else if (showManageProblems) void closeManageProblems();
+            else if (showCliSettings) void closeCliSettings();
             else void closeLoadCode();
             return;
         }
@@ -714,6 +766,158 @@
     function openClearProgress() {
         showDropdown = false;
         showClearConfirm = true;
+    }
+
+    function openManageProblems() {
+        if ($page.data.isDemoSite) return;
+        showDropdown = false;
+        manageProblemsError = '';
+        pathCopied = false;
+        if (pathCopiedTimer) clearTimeout(pathCopiedTimer);
+        showManageProblems = true;
+    }
+
+    async function closeManageProblems() {
+        showManageProblems = false;
+        pathCopied = false;
+        if (pathCopiedTimer) clearTimeout(pathCopiedTimer);
+        await tick();
+        dropdownToggleButton?.focus();
+    }
+
+    function invokeDesktop<T>(command: string): Promise<T> {
+        const tauriInternals = (window as Window & {
+            __TAURI_INTERNALS__?: { invoke: (name: string, args?: Record<string, unknown>) => Promise<T> };
+        }).__TAURI_INTERNALS__;
+        if (!tauriInternals?.invoke) {
+            return Promise.reject(new Error('Desktop bridge unavailable.'));
+        }
+        return tauriInternals.invoke(command);
+    }
+
+    async function refreshCliStatus() {
+        if (!isDesktopMode) return;
+        try {
+            cliStatus = await invokeDesktop('cli_status');
+            cliError = '';
+        } catch (error) {
+            cliStatus = {
+                available: false,
+                installed: false,
+                path: null,
+                aliasPaths: [],
+                needsNewTerminal: false,
+                message: null
+            };
+            cliError = error instanceof Error ? error.message : String(error);
+        }
+    }
+
+    async function openCliSettings() {
+        if (!isDesktopMode) return;
+        showDropdown = false;
+        cliError = '';
+        cliPathCopied = false;
+        if (cliPathCopiedTimer) clearTimeout(cliPathCopiedTimer);
+        showCliSettings = true;
+        await refreshCliStatus();
+    }
+
+    async function closeCliSettings() {
+        showCliSettings = false;
+        cliBusy = false;
+        cliPathCopied = false;
+        if (cliPathCopiedTimer) clearTimeout(cliPathCopiedTimer);
+        await tick();
+        dropdownToggleButton?.focus();
+    }
+
+    async function copyCliPath() {
+        const cliPath = cliStatus.path;
+        if (!cliPath) return;
+        cliError = '';
+        try {
+            await navigator.clipboard.writeText(cliPath);
+            cliPathCopied = true;
+            if (cliPathCopiedTimer) clearTimeout(cliPathCopiedTimer);
+            cliPathCopiedTimer = setTimeout(() => {
+                cliPathCopied = false;
+            }, 1500);
+        } catch {
+            cliError = `Could not copy. Path: ${cliPath}`;
+        }
+    }
+
+    async function installCli() {
+        cliBusy = true;
+        cliError = '';
+        try {
+            cliStatus = await invokeDesktop('cli_install');
+        } catch (error) {
+            cliError = error instanceof Error ? error.message : String(error);
+        } finally {
+            cliBusy = false;
+        }
+    }
+
+    async function uninstallCli() {
+        cliBusy = true;
+        cliError = '';
+        try {
+            cliStatus = await invokeDesktop('cli_uninstall');
+        } catch (error) {
+            cliError = error instanceof Error ? error.message : String(error);
+        } finally {
+            cliBusy = false;
+        }
+    }
+
+    async function removeCliAlias() {
+        cliBusy = true;
+        cliError = '';
+        try {
+            cliStatus = await invokeDesktop('cli_remove_shell_alias');
+        } catch (error) {
+            cliError = error instanceof Error ? error.message : String(error);
+        } finally {
+            cliBusy = false;
+        }
+    }
+
+    async function copyContentDir() {
+        manageProblemsError = '';
+        try {
+            await navigator.clipboard.writeText(contentDir);
+            pathCopied = true;
+            if (pathCopiedTimer) clearTimeout(pathCopiedTimer);
+            pathCopiedTimer = setTimeout(() => {
+                pathCopied = false;
+            }, 1500);
+        } catch {
+            manageProblemsError = `Could not copy. Path: ${contentDir}`;
+        }
+    }
+
+    async function revealContentFolder() {
+        manageProblemsError = '';
+        revealingFolder = true;
+        try {
+            const response = await fetch('/api/reveal-file', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ filePath: contentDir })
+            });
+            const result = await response.json().catch(() => ({}));
+            if (!response.ok) {
+                throw new Error(result?.error || 'Could not open the folder');
+            }
+        } catch (err: any) {
+            manageProblemsError = err?.message
+                ? `Could not open the folder automatically. Please open it manually: ${contentDir}`
+                : `Please open this folder manually: ${contentDir}`;
+        } finally {
+            revealingFolder = false;
+        }
     }
 
     async function closeClearProgress() {
@@ -907,7 +1111,41 @@
                             Game
                         </span>
                     </button>
+                    {#if !$page.data.isDemoSite}
+                        <button
+                            class="dropdown-item"
+                            role="menuitem"
+                            onclick={openManageProblems}
+                            title="View, edit, and add problems and courses in your CoJudge folder"
+                        >
+                            <span class="dropdown-item-content">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+                                    <line x1="12" y1="11" x2="12" y2="17"></line>
+                                    <line x1="9" y1="14" x2="15" y2="14"></line>
+                                </svg>
+                                Manage Problems
+                            </span>
+                        </button>
+                    {/if}
                     {#if isDesktopMode}
+                        <button
+                            class="dropdown-item"
+                            role="menuitem"
+                            onclick={openCliSettings}
+                            title="Install the cojudge CLI on your PATH"
+                        >
+                            <span class="dropdown-item-content">
+                                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                    <polyline points="4 17 10 11 4 5"></polyline>
+                                    <line x1="12" y1="19" x2="20" y2="19"></line>
+                                </svg>
+                                CLI
+                            </span>
+                            <span class:configured={cliStatus.installed} class="firebase-menu-status">
+                                {cliStatus.installed ? 'On' : 'Off'}
+                            </span>
+                        </button>
                         <div class="dropdown-separator" role="separator"></div>
                         <button
                             class="dropdown-item"
@@ -1018,6 +1256,141 @@
                 <div class="home-modal-actions">
                     <button class="btn" type="button" onclick={closeClearProgress}>Cancel</button>
                     <button class="btn clear-progress-danger-btn" type="button" onclick={confirmClearProgress}>Clear progress</button>
+                </div>
+            </div>
+        </div>
+    {/if}
+    {#if showManageProblems && !$page.data.isDemoSite}
+        <div class="home-modal-shell">
+            <button class="home-modal-backdrop" aria-label="Close manage problems" tabindex="-1" onclick={() => void closeManageProblems()}></button>
+            <div bind:this={manageProblemsCard} class="home-modal-card manage-problems-card" role="dialog" aria-modal="true" aria-labelledby="manage-problems-title">
+                <span class="modal-eyebrow">Local content</span>
+                <h2 id="manage-problems-title">Manage Problems</h2>
+                <p class="manage-intro">Problems and courses live in your CoJudge folder. Edit files directly — changes apply on refresh.</p>
+
+                <div class="manage-path-row">
+                    <code class="manage-path-text">{contentDir}</code>
+                    <button
+                        class="manage-path-copy"
+                        type="button"
+                        onclick={copyContentDir}
+                        title={pathCopied ? 'Copied' : 'Copy path'}
+                        aria-label={pathCopied ? 'Path copied' : 'Copy path'}
+                    >
+                        {#if pathCopied}
+                            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <polyline points="20 6 9 17 4 12"></polyline>
+                            </svg>
+                        {:else}
+                            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                <rect x="9" y="9" width="13" height="13" rx="2"></rect>
+                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                            </svg>
+                        {/if}
+                    </button>
+                </div>
+
+                <div class="manage-sections">
+                    <div class="manage-section">
+                        <h3>Problems</h3>
+                        <code class="manage-section-path">problems/&lt;slug&gt;/</code>
+                        <p>statement.md · metadata.json · official-tests.json · Marker.java · solution.md (optional)</p>
+                    </div>
+                    <div class="manage-section">
+                        <h3>Courses</h3>
+                        <code class="manage-section-path">courses/&lt;id&gt;/courseinfo.json</code>
+                        <p>Category order and problem list for each course tab.</p>
+                    </div>
+                </div>
+
+                <p class="manage-note">Duplicate a problem folder, edit it, then register the slug in a <code>courseinfo.json</code>. Missing files are re-seeded; your edits are never overwritten.</p>
+
+                {#if manageProblemsError}
+                    <p class="modal-error" role="alert">{manageProblemsError}</p>
+                {/if}
+                <div class="home-modal-actions">
+                    <button class="btn" type="button" onclick={revealContentFolder} disabled={revealingFolder}>{revealingFolder ? 'Opening…' : 'Open folder'}</button>
+                    <span class="modal-action-spacer"></span>
+                    <button class="btn modal-primary-btn" type="button" onclick={() => void closeManageProblems()}>Done</button>
+                </div>
+            </div>
+        </div>
+    {/if}
+    {#if showCliSettings && isDesktopMode}
+        <div class="home-modal-shell">
+            <button class="home-modal-backdrop" aria-label="Close CLI settings" tabindex="-1" onclick={() => void closeCliSettings()}></button>
+            <div bind:this={cliSettingsCard} class="home-modal-card manage-problems-card" role="dialog" aria-modal="true" aria-labelledby="cli-settings-title">
+                <div class="modal-heading-row">
+                    <div>
+                        <span class="modal-eyebrow">Command line</span>
+                        <h2 id="cli-settings-title">Cojudge CLI</h2>
+                    </div>
+                    <span class:configured={cliStatus.installed} class="firebase-status-pill">
+                        <span></span>{cliStatus.installed ? 'Installed' : 'Not installed'}
+                    </span>
+                </div>
+                <p class="manage-intro">Adds <code>cojudge</code> to your PATH using this app's Node.js.</p>
+
+                {#if cliStatus.path}
+                    <div class="manage-path-row">
+                        <code class="manage-path-text">{cliStatus.path}</code>
+                        <button
+                            class="manage-path-copy"
+                            type="button"
+                            onclick={copyCliPath}
+                            title={cliPathCopied ? 'Copied' : 'Copy path'}
+                            aria-label={cliPathCopied ? 'Path copied' : 'Copy path'}
+                        >
+                            {#if cliPathCopied}
+                                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <polyline points="20 6 9 17 4 12"></polyline>
+                                </svg>
+                            {:else}
+                                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                                    <rect x="9" y="9" width="13" height="13" rx="2"></rect>
+                                    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                </svg>
+                            {/if}
+                        </button>
+                    </div>
+                {/if}
+
+                <div class="manage-sections">
+                    <div class="manage-section">
+                        <h3>Usage</h3>
+                        <ul class="cli-usage">
+                            <li><code>cojudge list</code> List problems</li>
+                            <li><code>cojudge init two-sum --lang python</code> Starter file</li>
+                            <li><code>cojudge run two-sum Solution.py</code> Sample tests</li>
+                            <li><code>cojudge submit two-sum Solution.py</code> Official tests</li>
+                        </ul>
+                    </div>
+                    {#if cliStatus.aliasPaths?.length}
+                        <div class="manage-section">
+                            <h3>Shell alias</h3>
+                            <p>A <code>cojudge</code> alias from <code>./install.sh</code> was found in {cliStatus.aliasPaths.join(', ')}. It overrides the desktop CLI in terminals.</p>
+                            <button class="btn" type="button" onclick={removeCliAlias} disabled={cliBusy}>{cliBusy ? 'Removing…' : 'Remove alias'}</button>
+                        </div>
+                    {/if}
+                </div>
+
+                <p class="manage-note">Open a new terminal after installing. Problems live in <code>{contentDir}</code>. Docker is required for run and submit.</p>
+
+                {#if cliStatus.message && !cliError}
+                    <p class="cli-status-note">{cliStatus.message}</p>
+                {/if}
+                {#if cliError}
+                    <p class="modal-error" role="alert">{cliError}</p>
+                {/if}
+                <div class="home-modal-actions">
+                    {#if cliStatus.installed}
+                        <button class="btn remove-settings-btn" type="button" onclick={uninstallCli} disabled={cliBusy}>{cliBusy ? 'Removing…' : 'Uninstall'}</button>
+                    {/if}
+                    <span class="modal-action-spacer"></span>
+                    <button class="btn" type="button" onclick={() => void closeCliSettings()}>Close</button>
+                    {#if !cliStatus.installed}
+                        <button class="btn modal-primary-btn" type="button" onclick={installCli} disabled={cliBusy || !cliStatus.available}>{cliBusy ? 'Installing…' : 'Install'}</button>
+                    {/if}
                 </div>
             </div>
         </div>
@@ -1142,9 +1515,19 @@
                 href={`/?course=${encodeURIComponent(course.id)}`}
                 aria-current={course.id === selectedCourseId ? "page" : undefined}
                 onclick={() => selectCourse(course.id)}
-            >{course.title}</a>
+            >{course.title}{#if course.source && course.source !== 'bundled'}<span
+                    class="source-badge {course.source}"
+                    title={sourceTitle(course.source)}
+                >{sourceLabel(course.source)}</span>{/if}</a>
         {/each}
     </nav>
+    {#if courses.some((course) => course.source && course.source !== 'bundled')}
+        <div class="source-legend" aria-label="Legend for custom content labels">
+            <span class="source-badge custom">Custom</span> created in your CoJudge folder
+            <span class="source-legend-sep" aria-hidden="true">·</span>
+            <span class="source-badge modified">Modified</span> edited in your CoJudge folder
+        </div>
+    {/if}
     <div class="intro">
         <!-- Overall progress at top of intro -->
         <div class="overall">
@@ -1319,6 +1702,12 @@
                                                     rel="noopener noreferrer"
                                                     class="external-link">↗</a
                                                 >
+                                            {/if}
+                                            {#if problem.source && problem.source !== 'bundled'}
+                                                <span
+                                                    class="source-badge {problem.source}"
+                                                    title={sourceTitle(problem.source)}
+                                                >{sourceLabel(problem.source)}</span>
                                             {/if}
                                             {#if bestRanks[problem.id]}
                                                 <button
@@ -1639,6 +2028,153 @@
         font-weight: 750;
         letter-spacing: 0.12em;
         text-transform: uppercase;
+    }
+    .manage-problems-card {
+        width: min(520px, 100%);
+    }
+    .manage-problems-card h2 {
+        margin: 0.15rem 0 0.5rem;
+    }
+    .manage-intro {
+        margin: 0 0 0.85rem !important;
+        font-size: 0.92rem;
+        line-height: 1.5;
+    }
+    .manage-path-row {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        margin: 0 0 1rem;
+        padding: 0.45rem 0.45rem 0.45rem 0.75rem;
+        border: 1px solid var(--color-border);
+        border-radius: 0.55rem;
+        background: var(--color-surface);
+    }
+    .manage-path-text {
+        flex: 1 1 auto;
+        min-width: 0;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.8rem;
+        line-height: 1.4;
+        color: var(--color-text);
+        word-break: break-all;
+    }
+    .manage-path-copy {
+        flex: 0 0 auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2rem;
+        height: 2rem;
+        padding: 0;
+        border: 1px solid transparent;
+        border-radius: 0.4rem;
+        background: transparent;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        transition: background-color 0.12s ease, color 0.12s ease, border-color 0.12s ease;
+    }
+    .manage-path-copy:hover {
+        background: var(--color-surface-hover, rgba(0, 0, 0, 0.05));
+        color: var(--color-text);
+        border-color: var(--color-border);
+    }
+    .manage-path-copy:focus-visible {
+        outline: 2px solid var(--color-highlight);
+        outline-offset: 1px;
+    }
+    .manage-sections {
+        display: grid;
+        gap: 0.55rem;
+        margin: 0 0 0.9rem;
+    }
+    .manage-section {
+        padding: 0.65rem 0.75rem;
+        border: 1px solid var(--color-border);
+        border-radius: 0.55rem;
+        background: var(--color-surface);
+    }
+    .manage-section h3 {
+        margin: 0 0 0.3rem;
+        font-size: 0.72rem;
+        font-weight: 750;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--color-text-secondary);
+    }
+    .manage-section-path {
+        display: block;
+        margin: 0 0 0.25rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.82rem;
+        color: var(--color-text);
+        word-break: break-all;
+    }
+    .manage-section p {
+        margin: 0 !important;
+        font-size: 0.82rem;
+        line-height: 1.45;
+        color: var(--color-text-secondary);
+    }
+    .manage-section .btn {
+        margin-top: 0.55rem;
+    }
+    .manage-note {
+        margin: 0 0 0.65rem !important;
+        font-size: 0.85rem;
+        line-height: 1.5;
+    }
+    .manage-note code,
+    .manage-intro code,
+    .manage-cli code {
+        font-size: 0.9em;
+        padding: 0.05em 0.3em;
+        border-radius: 0.25rem;
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+    }
+    .manage-cli {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.35rem;
+        margin: 0 !important;
+        font-size: 0.82rem;
+        color: var(--color-text-secondary);
+    }
+    .manage-cli span {
+        font-weight: 700;
+        color: var(--color-text);
+        margin-right: 0.15rem;
+    }
+    .cli-usage {
+        margin: 0.15rem 0 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 0.4rem;
+        font-size: 0.82rem;
+        line-height: 1.45;
+        color: var(--color-text-secondary);
+    }
+    .cli-usage code {
+        display: inline-block;
+        margin-right: 0.35rem;
+        font-size: 0.78rem;
+        padding: 0.05em 0.3em;
+        border-radius: 0.25rem;
+        background: var(--color-second-bg);
+        border: 1px solid var(--color-border);
+        color: var(--color-text);
+        word-break: break-all;
+    }
+    .cli-status-note {
+        margin: 0 0 0.35rem !important;
+        color: var(--color-text) !important;
+        font-size: 0.85rem;
+    }
+    .manage-problems-card .home-modal-actions {
+        margin-top: 1.15rem;
     }
     .firebase-settings-card {
         width: min(720px, 100%);
@@ -2255,6 +2791,48 @@
         height: 2px;
         background: var(--color-surface);
         pointer-events: none;
+    }
+
+    /* Labels for user content from ~/cojudge (custom = user-created, modified = user-edited) */
+    .source-badge {
+        display: inline-block;
+        vertical-align: middle;
+        margin-left: 0.45rem;
+        padding: 0.08rem 0.45rem;
+        border-radius: 999px;
+        font-size: 0.65rem;
+        font-weight: 700;
+        letter-spacing: 0.02em;
+        line-height: 1.5;
+        white-space: nowrap;
+    }
+    .tab .source-badge {
+        margin-left: 0;
+    }
+    .source-badge.custom {
+        background: rgba(99, 102, 241, 0.14);
+        color: #6366f1;
+        border: 1px solid rgba(99, 102, 241, 0.45);
+    }
+    .source-badge.modified {
+        background: rgba(245, 158, 11, 0.14);
+        color: #b45309;
+        border: 1px solid rgba(245, 158, 11, 0.5);
+    }
+    .source-legend {
+        display: flex;
+        align-items: center;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        margin: 0.5rem 0 0;
+        font-size: 0.78rem;
+        color: var(--color-text-secondary);
+    }
+    .source-legend .source-badge {
+        margin-left: 0;
+    }
+    .source-legend-sep {
+        opacity: 0.6;
     }
 
     /* Group header (accordion) */

--- a/src/routes/api/problems/[slug]/asset/[...path]/+server.ts
+++ b/src/routes/api/problems/[slug]/asset/[...path]/+server.ts
@@ -2,6 +2,7 @@ import { error } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import fs from 'fs/promises';
 import path from 'path';
+import { ensureUserContentSeeded, resolveProblemDir } from '$lib/server/contentPaths';
 
 const MIME_TYPES: Record<string, string> = {
     '.png': 'image/png',
@@ -13,10 +14,12 @@ const MIME_TYPES: Record<string, string> = {
 };
 
 export const GET: RequestHandler = async ({ params }) => {
-    const assetPath = path.resolve('problems', params.slug, params.path);
-    const baseDir = path.resolve('problems', params.slug);
+    await ensureUserContentSeeded();
+    // Serve from ~/cojudge/problems/<slug> first, bundled copy as fallback.
+    const baseDir = await resolveProblemDir(params.slug);
+    const assetPath = path.join(baseDir, params.path);
 
-    if (!assetPath.startsWith(baseDir)) {
+    if (!path.resolve(assetPath).startsWith(path.resolve(baseDir))) {
         throw error(403, 'Forbidden');
     }
 

--- a/src/routes/api/run/+server.ts
+++ b/src/routes/api/run/+server.ts
@@ -1,8 +1,8 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import fs from 'fs/promises';
-import path from 'path';
 import { getMarkerResponses } from '../../../lib/markerRunner';
+import { ensureUserContentSeeded, resolveProblemFile } from '$lib/server/contentPaths';
 import type { ProgramRunner } from '$lib/runners/ProgramRunner';
 import { JavaRunner } from '$lib/runners/JavaRunner';
 import { PythonRunner } from '$lib/runners/PythonRunner';
@@ -48,7 +48,8 @@ function isJavaLanguage(language: string): boolean {
 
 async function executeRun(problemId: string, language: string, code: string, testCases: any[], job: RunJob) {
     try {
-        const problemPath = path.resolve('problems', problemId, 'metadata.json');
+        await ensureUserContentSeeded();
+        const problemPath = await resolveProblemFile(problemId, 'metadata.json');
         const problemContent = await fs.readFile(problemPath, 'utf-8');
         const problemData = JSON.parse(problemContent);
 

--- a/src/routes/api/submit/+server.ts
+++ b/src/routes/api/submit/+server.ts
@@ -1,8 +1,8 @@
 import { json } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import fs from 'fs/promises';
-import path from 'path';
 import vm from 'vm';
+import { ensureUserContentSeeded, resolveProblemFile } from '$lib/server/contentPaths';
 import { getMarkerResponses } from '../../../lib/markerRunner';
 import type { ProgramRunner } from '$lib/runners/ProgramRunner';
 import { JavaRunner } from '$lib/runners/JavaRunner';
@@ -50,12 +50,13 @@ async function executeSubmit(problemId: string, language: string, code: string, 
     let timeoutTestcase: any = null;
     try {
         job.status = 'running';
+        await ensureUserContentSeeded();
 
-        const problemPath = path.resolve('problems', problemId, 'metadata.json');
+        const problemPath = await resolveProblemFile(problemId, 'metadata.json');
         const problemContent = await fs.readFile(problemPath, 'utf-8');
         const problemData = JSON.parse(problemContent);
 
-        let officialTestsPath = path.resolve('problems', problemId, 'official-tests.json');
+        let officialTestsPath = await resolveProblemFile(problemId, 'official-tests.json');
         let testCases: any[] = [];
         let totalTc = 0;
         let passedTc = 0;

--- a/src/routes/problems/[slug]/+page.server.ts
+++ b/src/routes/problems/[slug]/+page.server.ts
@@ -1,11 +1,14 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { error } from '@sveltejs/kit';
+import { ensureUserContentSeeded, getProblemSource, resolveProblemDir } from '$lib/server/contentPaths';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params }) => {
     try {
-        const baseDir = path.resolve('problems', params.slug);
+        await ensureUserContentSeeded();
+        // Reads from ~/cojudge/problems/<slug> first, bundled copy as fallback.
+        const baseDir = await resolveProblemDir(params.slug);
         const problemPath = path.join(baseDir, 'metadata.json');
         const content = await fs.readFile(problemPath, 'utf-8');
         const problem = JSON.parse(content);
@@ -50,6 +53,13 @@ export const load: PageServerLoad = async ({ params }) => {
                         : ''
                 }))
             : [];
+
+        // Label user content so the UI can badge custom/modified problems.
+        try {
+            problem.source = await getProblemSource(params.slug);
+        } catch {
+            problem.source = 'bundled';
+        }
 
         return { problem };
     } catch (e) {

--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -987,6 +987,11 @@
             <span class="badge {getDifficultyClass(data.problem.difficulty)}">
                 {data.problem.difficulty}
             </span>
+            {#if data.problem.source === 'custom'}
+                <span class="source-badge custom" title="Custom content — only exists in your CoJudge folder">Custom</span>
+            {:else if data.problem.source === 'modified'}
+                <span class="source-badge modified" title="Modified — edited in your CoJudge folder, differs from the bundled copy">Modified</span>
+            {/if}
             <a href={data.problem.link} target="_blank" rel="noopener noreferrer" class="external-link">↗</a>
             {#if viewMode === 'solution'}
                 <!-- Solution content from problems/[slug]/solution.md -->
@@ -1640,6 +1645,29 @@
     .difficulty-easy { background-color: var(--color-easy); }
     .difficulty-medium { background-color: var(--color-medium); }
     .difficulty-hard { background-color: var(--color-hard); color: #fff; }
+
+    /* Labels for user content from ~/cojudge (custom = user-created, modified = user-edited) */
+    .source-badge {
+        display: inline-block;
+        vertical-align: middle;
+        margin-left: 0.45rem;
+        padding: 0.15rem 0.55rem;
+        border-radius: 999px;
+        font-size: 0.72rem;
+        font-weight: 700;
+        line-height: 1.4;
+        white-space: nowrap;
+    }
+    .source-badge.custom {
+        background: rgba(99, 102, 241, 0.14);
+        color: #6366f1;
+        border: 1px solid rgba(99, 102, 241, 0.45);
+    }
+    .source-badge.modified {
+        background: rgba(245, 158, 11, 0.14);
+        color: #b45309;
+        border: 1px solid rgba(245, 158, 11, 0.5);
+    }
 
     .solved-pill {
         display: inline-flex;


### PR DESCRIPTION
## Summary
- Seed problems and courses into `~/cojudge` (override with `COJUDGE_CONTENT_DIR`) so users can view, edit, and add local problems/courses without touching the repo; user copies win, missing files are re-seeded, edits are never overwritten.
- Homepage **Manage Problems** modal (hidden on demo site), Custom/Modified badges, and CLI docs for verifying new problems with `cojudge run` / `cojudge submit`.
- Bundle the `cojudge` CLI in desktop installers and add a desktop-only **CLI** menu to install/uninstall a PATH shim (uses bundled Node; can remove leftover `install.sh` aliases). Bare `cojudge` on desktop CLI shows help instead of starting a browser server.