### PR TITLE
docs: add Manage Problems section to desktop release notes

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -241,7 +241,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           TAG: v${{ inputs.version }}
-          MACOS_INSTALL_NOTE: |
+          RELEASE_NOTES: |
+            ## Manage Problems
+
+            You can add or edit problems without having to clone the repo, modify files and build a new binary!
+            All you need is to go to `~/cojudge` to add or edit files there:
+
+            - `/problems/[slug]` for adding new problems. You can also view or edit existing problems
+            - `/courses/[id]/courseinfo.json` for adding new course. You can also view or edit existing courses
+
+            Optional: You can install the `cojudge` desktop CLI via GUI to verify your new problems programmatically after adding them.
+
+            View `~/cojudge/README.md` for a more detailed guide.
+
             ## macOS installation
 
             The macOS application is ad-hoc signed and is not notarized. After dragging `Cojudge.app` into `/Applications`, this command is required before the first launch:
@@ -258,5 +270,5 @@ jobs:
             --target "$GITHUB_SHA" \
             --title "Cojudge $TAG" \
             --generate-notes \
-            --notes "$MACOS_INSTALL_NOTE" \
+            --notes "$RELEASE_NOTES" \
             "${release_args[@]}"

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -108,7 +108,7 @@ Before running a release, configure these GitHub Actions repository secrets. Vit
 - `GOOGLE_DESKTOP_CLIENT_ID`
 - `GOOGLE_DESKTOP_CLIENT_SECRET`
 
-The generated release notes automatically include this required command for the ad-hoc-signed macOS build:
+The generated release notes automatically include a **Manage Problems** section (`~/cojudge` for adding/editing problems and courses, plus optional desktop CLI verification) and this required command for the ad-hoc-signed macOS build:
 
 ```bash
 xattr -dr com.apple.quarantine /Applications/Cojudge.app


### PR DESCRIPTION
## Summary
- Prepend a **Manage Problems** section to every desktop GitHub Release note (`~/cojudge` paths, optional desktop CLI, README pointer).
- Keep the existing macOS quarantine install note; update `docs/DESKTOP.md` to match.

## Test plan
- [ ] Inspect workflow `RELEASE_NOTES` in `.github/workflows/release-desktop.yml`
- [ ] Next desktop release includes Manage Problems before macOS installation