### PR TITLE
fix: auto-update pristine content copies, add reset-to-bundled recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ npm run dev
 
 ## Add a problem
 
-Local content lives in `~/cojudge` (auto-seeded from the repo's bundled `problems/` + `courses/` on first start; your copy overrides bundled content — edit / add / delete files there, changes apply immediately). Override the location with `COJUDGE_CONTENT_DIR`.
+Local content lives in `~/cojudge` (auto-seeded from the repo's bundled `problems/` + `courses/` on first start; your copy overrides bundled content — edit / add / delete files there, changes apply immediately). Unedited copies auto-update when Cojudge ships fixes; your edits are never overwritten (reset stale "Modified" items in Manage Problems or via `cojudge sync --reset <id>`). Override the location with `COJUDGE_CONTENT_DIR`.
 
 See [`docs/ADD_PROBLEMS.md`](docs/ADD_PROBLEMS.md) for a comprehensive guide covering:
 

--- a/bin/cojudge
+++ b/bin/cojudge
@@ -15,6 +15,7 @@ import { listProblems } from "./lib/commands/list.js";
 import { handleSearch } from "./lib/commands/search.js";
 import { handleScrape } from "./lib/commands/scrape.js";
 import { handleDebug } from "./lib/commands/debug.js";
+import { handleSync } from "./lib/commands/sync.js";
 
 const args = process.argv.slice(2);
 const PORT = getPort(args);
@@ -69,6 +70,11 @@ async function main() {
       return;
     }
     markProblem(slug, false);
+    return;
+  }
+
+  if (action === "sync") {
+    handleSync(args);
     return;
   }
 

--- a/bin/lib/commands/sync.js
+++ b/bin/lib/commands/sync.js
@@ -1,0 +1,127 @@
+import fs from "fs";
+import path from "path";
+import {
+  ensureUserContentSeededSync,
+  getBundledCoursesDir,
+  getBundledProblemsDir,
+  getContentRoot,
+  getCourseSourceSync,
+  getProblemSourceSync,
+  listCourseIdsSync,
+  listProblemSlugsSync,
+  resetCourseToBundledSync,
+  resetProblemToBundledSync,
+} from "../contentPaths.js";
+
+function isBundledProblem(id) {
+  try {
+    return fs.statSync(path.join(getBundledProblemsDir(), id)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isBundledCourse(id) {
+  try {
+    return fs.statSync(path.join(getBundledCoursesDir(), id)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function resetOne(target) {
+  if (isBundledProblem(target)) {
+    resetProblemToBundledSync(target);
+    console.log(`Reset problem '${target}' to the bundled version.`);
+    return true;
+  }
+  if (isBundledCourse(target)) {
+    resetCourseToBundledSync(target);
+    console.log(`Reset course '${target}' to the bundled version.`);
+    return true;
+  }
+  console.error(`Error: no bundled problem or course named '${target}' to reset to.`);
+  return false;
+}
+
+function resetAllModified() {
+  const slugs = listProblemSlugsSync();
+  const ids = listCourseIdsSync();
+  let count = 0;
+  for (const slug of slugs) {
+    if (getProblemSourceSync(slug) !== "modified") continue;
+    try {
+      resetProblemToBundledSync(slug);
+      console.log(`Reset problem '${slug}' to the bundled version.`);
+      count++;
+    } catch {}
+  }
+  for (const id of ids) {
+    if (getCourseSourceSync(id) !== "modified") continue;
+    try {
+      resetCourseToBundledSync(id);
+      console.log(`Reset course '${id}' to the bundled version.`);
+      count++;
+    } catch {}
+  }
+  console.log(count === 0 ? "Nothing to reset — no modified content." : `Reset ${count} item(s).`);
+}
+
+function printStatus() {
+  console.log(`Content: ${getContentRoot()}`);
+  const slugs = listProblemSlugsSync();
+  const ids = listCourseIdsSync();
+  const modifiedProblems = slugs.filter((s) => getProblemSourceSync(s) === "modified");
+  const modifiedCourses = ids.filter((id) => getCourseSourceSync(id) === "modified");
+  const customProblems = slugs.filter(
+    (s) => getProblemSourceSync(s) === "custom" && !isBundledProblem(s),
+  );
+  const customCourses = ids.filter(
+    (id) => getCourseSourceSync(id) === "custom" && !isBundledCourse(id),
+  );
+  const total = modifiedProblems.length + modifiedCourses.length;
+  if (total === 0) {
+    console.log("All bundled content is up to date. Unedited copies auto-update on new versions; your edits are never overwritten.");
+  } else {
+    console.log(
+      `${total} item(s) differ from the bundled copy (your edits are preserved):`,
+    );
+    for (const s of modifiedProblems) console.log(`  problem  ${s}`);
+    for (const id of modifiedCourses) console.log(`  course   ${id}`);
+    console.log(
+      "If you did not edit these, they are stale copies from an older version —",
+    );
+    console.log("reset them with `cojudge sync --reset <id>` (or `cojudge sync --reset --all`).");
+  }
+  const customTotal = customProblems.length + customCourses.length;
+  if (customTotal > 0) {
+    console.log(`Custom content (only in your folder): ${customTotal} item(s).`);
+    for (const s of customProblems) console.log(`  problem  ${s}`);
+    for (const id of customCourses) console.log(`  course   ${id}`);
+  }
+}
+
+export function handleSync(args) {
+  // Smart sync runs first: pristine copies auto-update, edits preserved.
+  ensureUserContentSeededSync();
+  const resetIdx = args.findIndex((a) => a === "--reset" || a === "--reset-all");
+  if (args.includes("--reset-all")) {
+    resetAllModified();
+    return;
+  }
+  if (resetIdx !== -1) {
+    const target = args[resetIdx + 1];
+    if (!target || target.startsWith("-")) {
+      if (target === "--all" || target === "all") {
+        resetAllModified();
+        return;
+      }
+      console.error("Usage: cojudge sync --reset <slug|course-id|--all>");
+      process.exitCode = 1;
+      return;
+    }
+    if (!resetOne(target)) process.exitCode = 1;
+    return;
+  }
+  printStatus();
+}

--- a/bin/lib/contentPaths.js
+++ b/bin/lib/contentPaths.js
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import fs from "fs";
 import os from "os";
 import path from "path";
@@ -69,6 +70,176 @@ export function listProblemSlugsSync() {
   return [...seen].sort();
 }
 
+/** Union of course ids from ~/cojudge and the bundled copy. */
+export function listCourseIdsSync() {
+  const seen = new Set();
+  for (const dir of [getCoursesDir(), getBundledCoursesDir()]) {
+    try {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) seen.add(entry.name);
+      }
+    } catch {}
+  }
+  return [...seen].sort();
+}
+
+function hashBuffer(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+function hashFileOrNullSync(filePath) {
+  try {
+    return hashBuffer(fs.readFileSync(filePath));
+  } catch {
+    return null;
+  }
+}
+
+const SEED_STATE_FILENAME = ".cojudge-seed.json";
+const SEED_STATE_VERSION = 1;
+
+function getSeedStatePath() {
+  return path.join(getContentRoot(), SEED_STATE_FILENAME);
+}
+
+function readSeedManifestSync() {
+  try {
+    const raw = fs.readFileSync(getSeedStatePath(), "utf8");
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && parsed.files && typeof parsed.files === "object") {
+      const files = {};
+      for (const [key, value] of Object.entries(parsed.files)) {
+        if (
+          typeof key === "string" &&
+          typeof value === "string" &&
+          /^[0-9a-f]{64}$/.test(value) &&
+          (key.startsWith("problems/") || key.startsWith("courses/")) &&
+          !key.includes("..") &&
+          !key.includes("\\")
+        ) {
+          files[key] = value;
+        }
+      }
+      return { files };
+    }
+  } catch {
+    // Missing or corrupt manifest — treated as "no baseline".
+  }
+  return { files: {} };
+}
+
+function writeSeedManifestSync(files) {
+  fs.writeFileSync(
+    getSeedStatePath(),
+    JSON.stringify({ version: SEED_STATE_VERSION, files }, null, 2),
+    "utf8",
+  );
+}
+
+function collectFilesRecursiveSync(baseDir, prefix, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(baseDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (entry.name === ".DS_Store") continue;
+    const abs = path.join(baseDir, entry.name);
+    const rel = `${prefix}/${entry.name}`;
+    if (entry.isDirectory()) {
+      collectFilesRecursiveSync(abs, rel, out);
+    } else if (entry.isFile()) {
+      const hash = hashFileOrNullSync(abs);
+      if (hash !== null) out.set(rel, { abs, hash });
+    }
+  }
+}
+
+/** All bundled files under problems/ and courses/, keyed by posix-style rel path. */
+function collectBundledFilesSync() {
+  const out = new Map();
+  collectFilesRecursiveSync(getBundledProblemsDir(), "problems", out);
+  collectFilesRecursiveSync(getBundledCoursesDir(), "courses", out);
+  return out;
+}
+
+function pruneEmptyParentsSync(startPath, root) {
+  const stop = path.resolve(root);
+  const problemsDir = path.join(stop, "problems");
+  const coursesDir = path.join(stop, "courses");
+  let dir = path.dirname(startPath);
+  while (dir.startsWith(stop) && path.resolve(dir) !== stop) {
+    if (path.resolve(dir) === problemsDir || path.resolve(dir) === coursesDir) break;
+    try {
+      if (fs.readdirSync(dir).length > 0) break;
+      fs.rmdirSync(dir);
+    } catch {
+      break;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+}
+
+/**
+ * Smart sync: seed missing files AND auto-update pristine (unedited) copies
+ * when the bundled content changed, without ever overwriting user edits.
+ * Mirrors syncUserContent() in src/lib/server/contentPaths.ts.
+ */
+function syncUserContentSync() {
+  const root = getContentRoot();
+  fs.mkdirSync(path.join(root, "problems"), { recursive: true });
+  fs.mkdirSync(path.join(root, "courses"), { recursive: true });
+  const prev = readSeedManifestSync();
+  const bundled = collectBundledFilesSync();
+  const next = {};
+  for (const [rel, { abs, hash: bundledHash }] of bundled) {
+    next[rel] = bundledHash;
+    const userPath = path.join(root, ...rel.split("/"));
+    if (!fs.existsSync(userPath)) {
+      fs.mkdirSync(path.dirname(userPath), { recursive: true });
+      fs.copyFileSync(abs, userPath);
+      continue;
+    }
+    const prevHash = prev.files[rel];
+    // No baseline (pre-manifest install, or a user file colliding with a
+    // newly shipped bundled path): preserve, never overwrite blindly.
+    if (prevHash === undefined) continue;
+    // Bundled copy unchanged since the last sync: keep the user file.
+    if (prevHash === bundledHash) continue;
+    // Bundled copy changed upstream — update only pristine copies.
+    const userHash = hashFileOrNullSync(userPath);
+    if (userHash === null) {
+      fs.mkdirSync(path.dirname(userPath), { recursive: true });
+      fs.copyFileSync(abs, userPath);
+    } else if (userHash === prevHash) {
+      fs.copyFileSync(abs, userPath);
+    }
+    // Else: user-edited (or already matching the new bundled file) — preserve.
+  }
+  for (const rel of Object.keys(prev.files)) {
+    if (bundled.has(rel)) continue;
+    if (!rel.startsWith("problems/") && !rel.startsWith("courses/")) continue;
+    const userPath = path.join(root, ...rel.split("/"));
+    const userHash = hashFileOrNullSync(userPath);
+    if (userHash === null) continue;
+    if (userHash === prev.files[rel]) {
+      try {
+        fs.rmSync(userPath, { force: true });
+      } catch {}
+      pruneEmptyParentsSync(userPath, root);
+    }
+    // Edited copies of upstream-removed files are kept (now custom).
+  }
+  writeSeedManifestSync(next);
+  const readmePath = path.join(root, "README.md");
+  if (!fs.existsSync(readmePath)) {
+    fs.writeFileSync(readmePath, USER_README, "utf8");
+  }
+}
+
 function copyMissingRecursiveSync(src, dest) {
   let entries;
   try {
@@ -114,26 +285,137 @@ cojudge submit <slug> Solution.py
 \`\`\`
 
 Missing files are seeded from the bundled CoJudge content on startup and
-are never overwritten once you have edited them. Set COJUDGE_CONTENT_DIR
+pristine (unedited) copies are auto-updated when a new CoJudge version
+ships fixes — your edits are never overwritten. If a problem shows as
+"Modified" but you never edited it, reset it with \`cojudge sync --reset
+<slug>\` (or delete its folder to re-seed). Set COJUDGE_CONTENT_DIR
 to use a different folder.
 `;
 
 /**
  * Seed ~/cojudge/problems and ~/cojudge/courses from the bundled content.
- * Only copies files that are missing — never overwrites user edits.
+ * Missing files are copied, pristine copies are auto-updated to new bundled
+ * versions, and user edits are never overwritten.
  */
 export function ensureUserContentSeededSync() {
   try {
-    const root = getContentRoot();
-    fs.mkdirSync(path.join(root, "problems"), { recursive: true });
-    fs.mkdirSync(path.join(root, "courses"), { recursive: true });
-    copyMissingRecursiveSync(getBundledProblemsDir(), getProblemsDir());
-    copyMissingRecursiveSync(getBundledCoursesDir(), getCoursesDir());
-    const readmePath = path.join(root, "README.md");
-    if (!fs.existsSync(readmePath)) {
-      fs.writeFileSync(readmePath, USER_README, "utf8");
-    }
+    syncUserContentSync();
   } catch {
-    // Seeding must never break the CLI — readers fall back to bundled content.
+    // Seeding must never break the CLI — fall back to legacy copy-missing.
+    try {
+      const root = getContentRoot();
+      fs.mkdirSync(path.join(root, "problems"), { recursive: true });
+      fs.mkdirSync(path.join(root, "courses"), { recursive: true });
+      copyMissingRecursiveSync(getBundledProblemsDir(), getProblemsDir());
+      copyMissingRecursiveSync(getBundledCoursesDir(), getCoursesDir());
+      const readmePath = path.join(root, "README.md");
+      if (!fs.existsSync(readmePath)) {
+        fs.writeFileSync(readmePath, USER_README, "utf8");
+      }
+    } catch {
+      // Readers fall back to bundled content.
+    }
   }
+}
+
+function isSafeId(id) {
+  return (
+    !!id &&
+    id !== "." &&
+    id !== ".." &&
+    !id.includes("/") &&
+    !id.includes("\\") &&
+    !id.includes("\0")
+  );
+}
+
+function refreshManifestPrefixSync(prefix) {
+  const prev = readSeedManifestSync();
+  const bundled = collectBundledFilesSync();
+  const next = { ...prev.files };
+  for (const key of Object.keys(next)) {
+    if (key === prefix.slice(0, -1) || key.startsWith(prefix)) delete next[key];
+  }
+  for (const [rel, { hash }] of bundled) {
+    if (rel.startsWith(prefix)) next[rel] = hash;
+  }
+  writeSeedManifestSync(next);
+}
+
+/** Reset a problem to its bundled copy, discarding ~/cojudge edits. */
+export function resetProblemToBundledSync(slug) {
+  if (!isSafeId(slug)) throw new Error(`Invalid slug: ${slug}`);
+  ensureUserContentSeededSync();
+  const bundledDir = path.join(getBundledProblemsDir(), slug);
+  if (!fs.existsSync(bundledDir) || !fs.statSync(bundledDir).isDirectory()) {
+    throw new Error(`No bundled problem '${slug}' to reset to`);
+  }
+  const userDir = path.join(getProblemsDir(), slug);
+  fs.rmSync(userDir, { recursive: true, force: true });
+  fs.cpSync(bundledDir, userDir, { recursive: true });
+  refreshManifestPrefixSync(`problems/${slug}/`);
+}
+
+/** Reset a course to its bundled copy, discarding ~/cojudge edits. */
+export function resetCourseToBundledSync(courseId) {
+  if (!isSafeId(courseId)) throw new Error(`Invalid course id: ${courseId}`);
+  ensureUserContentSeededSync();
+  const bundledDir = path.join(getBundledCoursesDir(), courseId);
+  if (!fs.existsSync(bundledDir) || !fs.statSync(bundledDir).isDirectory()) {
+    throw new Error(`No bundled course '${courseId}' to reset to`);
+  }
+  const userDir = path.join(getCoursesDir(), courseId);
+  fs.rmSync(userDir, { recursive: true, force: true });
+  fs.cpSync(bundledDir, userDir, { recursive: true });
+  refreshManifestPrefixSync(`courses/${courseId}/`);
+}
+
+function readIfExistsSync(filePath) {
+  try {
+    return fs.readFileSync(filePath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+function compareDirToBundledSync(userDir, bundledDir, files) {
+  const bundledExists = fs.existsSync(bundledDir);
+  const userExists = fs.existsSync(userDir);
+  if (!bundledExists) return userExists ? "custom" : "bundled";
+  if (!userExists) return "bundled";
+  return files.every(
+    (file) =>
+      readIfExistsSync(path.join(userDir, file)) ===
+      readIfExistsSync(path.join(bundledDir, file)),
+  )
+    ? "bundled"
+    : "modified";
+}
+
+const PROBLEM_COMPARE_FILES = [
+  "metadata.json",
+  "statement.md",
+  "official-tests.json",
+  "Marker.java",
+  "solution.md",
+];
+
+const COURSE_COMPARE_FILES = ["courseinfo.json"];
+
+/** Where a problem comes from: custom (user-only), modified, or bundled. */
+export function getProblemSourceSync(slug) {
+  return compareDirToBundledSync(
+    path.join(getProblemsDir(), slug),
+    path.join(getBundledProblemsDir(), slug),
+    PROBLEM_COMPARE_FILES,
+  );
+}
+
+/** Where a course comes from: custom (user-only), modified, or bundled. */
+export function getCourseSourceSync(courseId) {
+  return compareDirToBundledSync(
+    path.join(getCoursesDir(), courseId),
+    path.join(getBundledCoursesDir(), courseId),
+    COURSE_COMPARE_FILES,
+  );
 }

--- a/bin/lib/help.js
+++ b/bin/lib/help.js
@@ -25,6 +25,9 @@ Usage:
                                  (Options: --lang java|python|cpp|rust|csharp|go)
   cojudge scrape -n <number>    Scrape problem data from LeetCode by number
   cojudge scrape -s <slug>      Scrape problem data from LeetCode by slug
+  cojudge sync                  Show content status (auto-updates unedited copies)
+  cojudge sync --reset <id>     Reset a problem/course to the bundled version
+  cojudge sync --reset --all    Reset all modified content to bundled versions
   cojudge -p, --port <number>    Specify port (default: 5375)
   cojudge -v, --version          Show current version and date
   cojudge -u, --update           Update cojudge to the latest version
@@ -50,6 +53,8 @@ Examples:
 
 Content:
   Problems & courses live in ~/cojudge (auto-seeded on first start).
-  Edit/add files there to override bundled content. Override with COJUDGE_CONTENT_DIR.
+  Unedited copies auto-update when Cojudge ships fixes; your edits are
+  never overwritten. If an item shows as modified but you never edited it,
+  reset it with 'cojudge sync --reset <id>'. Override with COJUDGE_CONTENT_DIR.
 `);
 }

--- a/docs/ADD_PROBLEMS.md
+++ b/docs/ADD_PROBLEMS.md
@@ -17,7 +17,7 @@ For local use, CoJudge keeps all editable content in your home folder:
 └── courses/<course-id>/courseinfo.json
 ```
 
-On first start, CoJudge copies (seeds) the repo's bundled `problems/` and `courses/` into `~/cojudge`. Afterwards `~/cojudge` is the source of truth: view / edit / add problems, test cases, solutions, and courses by managing files there — changes take effect immediately (refresh the browser or re-run the CLI, no restart needed). Missing files are re-seeded from the bundled copy but your edits are never overwritten. Set `COJUDGE_CONTENT_DIR` (or `COJUDGE_HOME`) to use a different folder.
+On first start, CoJudge copies (seeds) the repo's bundled `problems/` and `courses/` into `~/cojudge`. Afterwards `~/cojudge` is the source of truth: view / edit / add problems, test cases, solutions, and courses by managing files there — changes take effect immediately (refresh the browser or re-run the CLI, no restart needed). Missing files are re-seeded from the bundled copy, unedited copies auto-update when a new CoJudge version ships fixes, and your edits are never overwritten. If a problem shows as "Modified" but you never edited it, reset it in Manage Problems (or `cojudge sync --reset <slug>`). Set `COJUDGE_CONTENT_DIR` (or `COJUDGE_HOME`) to use a different folder.
 
 Only `statement.md`, `metadata.json`, `official-tests.json`, and `Marker.java` are required. `solution.md` is optional — if present, a "Reference Solution" button appears in the UI.
 

--- a/src/lib/server/contentPaths.test.ts
+++ b/src/lib/server/contentPaths.test.ts
@@ -181,4 +181,147 @@ describe('contentPaths', () => {
 			cwdSpy.mockRestore();
 		}
 	});
+
+	it('auto-updates pristine copies when bundled content changes', async () => {
+		const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(bundledRoot);
+		try {
+			await fs.mkdir(path.join(bundledRoot, 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'),
+				'{"v":1}'
+			);
+
+			const mod = await import('./contentPaths');
+			await mod.ensureUserContentSeeded();
+			expect(await mod.getProblemSource('two-sum')).toBe('bundled');
+
+			// Maintainer ships a fix; the user never edited the file.
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'),
+				'{"v":2}'
+			);
+			mod.__resetEnsureMemoForTests();
+			await mod.ensureUserContentSeeded();
+
+			expect(
+				await fs.readFile(
+					path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+					'utf-8'
+				)
+			).toBe('{"v":2}');
+			expect(await mod.getProblemSource('two-sum')).toBe('bundled');
+		} finally {
+			cwdSpy.mockRestore();
+		}
+	});
+
+	it('preserves user edits when bundled content changes', async () => {
+		const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(bundledRoot);
+		try {
+			await fs.mkdir(path.join(bundledRoot, 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'),
+				'{"v":1}'
+			);
+
+			const mod = await import('./contentPaths');
+			await mod.ensureUserContentSeeded();
+
+			// User edit.
+			await fs.writeFile(
+				path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+				'{"mine":true}'
+			);
+
+			// Maintainer ships a fix — the edit must win.
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'),
+				'{"v":2}'
+			);
+			mod.__resetEnsureMemoForTests();
+			await mod.ensureUserContentSeeded();
+
+			expect(
+				await fs.readFile(
+					path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+					'utf-8'
+				)
+			).toBe('{"mine":true}');
+			expect(await mod.getProblemSource('two-sum')).toBe('modified');
+		} finally {
+			cwdSpy.mockRestore();
+		}
+	});
+
+	it('preserves pre-manifest differing copies instead of overwriting (safe migration)', async () => {
+		const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(bundledRoot);
+		try {
+			// Bundled v2, user still on stale v1, no seed manifest yet
+			// (install predates manifest tracking).
+			await fs.mkdir(path.join(bundledRoot, 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'),
+				'{"v":2}'
+			);
+			await fs.mkdir(path.join(tmpRoot, 'user', 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(
+				path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+				'{"v":1}'
+			);
+
+			const mod = await import('./contentPaths');
+			await mod.ensureUserContentSeeded();
+
+			// Must not overwrite a possible user edit.
+			expect(
+				await fs.readFile(
+					path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+					'utf-8'
+				)
+			).toBe('{"v":1}');
+			expect(await mod.getProblemSource('two-sum')).toBe('modified');
+
+			// The recovery path brings the user back to bundled.
+			await mod.resetProblemToBundled('two-sum');
+			expect(
+				await fs.readFile(
+					path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+					'utf-8'
+				)
+			).toBe('{"v":2}');
+			expect(await mod.getProblemSource('two-sum')).toBe('bundled');
+		} finally {
+			cwdSpy.mockRestore();
+		}
+	});
+
+	it('resetProblemToBundled discards edits and restores the bundled copy', async () => {
+		const cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(bundledRoot);
+		try {
+			await fs.mkdir(path.join(bundledRoot, 'problems', 'two-sum'), { recursive: true });
+			await fs.writeFile(
+				path.join(bundledRoot, 'problems', 'two-sum', 'metadata.json'),
+				'{"v":1}'
+			);
+
+			const mod = await import('./contentPaths');
+			await mod.ensureUserContentSeeded();
+			await fs.writeFile(
+				path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+				'{"edited":true}'
+			);
+			expect(await mod.getProblemSource('two-sum')).toBe('modified');
+
+			await mod.resetProblemToBundled('two-sum');
+			expect(
+				await fs.readFile(
+					path.join(tmpRoot, 'user', 'problems', 'two-sum', 'metadata.json'),
+					'utf-8'
+				)
+			).toBe('{"v":1}');
+			expect(await mod.getProblemSource('two-sum')).toBe('bundled');
+		} finally {
+			cwdSpy.mockRestore();
+		}
+	});
 });

--- a/src/lib/server/contentPaths.ts
+++ b/src/lib/server/contentPaths.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { existsSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -277,9 +278,201 @@ cojudge submit <slug> Solution.py
 \`\`\`
 
 Missing files are seeded from the bundled CoJudge content on startup and
-are never overwritten once you have edited them. Set COJUDGE_CONTENT_DIR
+pristine (unedited) copies are auto-updated when a new CoJudge version
+ships fixes — your edits are never overwritten. If a problem shows as
+"Modified" but you never edited it, reset it in Manage Problems (or delete
+its folder to re-seed). Set COJUDGE_CONTENT_DIR
 to use a different folder.
 `;
+
+function hashBuffer(buf: Buffer): string {
+	return createHash('sha256').update(buf).digest('hex');
+}
+
+async function hashFileOrNull(filePath: string): Promise<string | null> {
+	try {
+		return hashBuffer(await fs.readFile(filePath));
+	} catch {
+		return null;
+	}
+}
+
+const SEED_STATE_FILENAME = '.cojudge-seed.json';
+const SEED_STATE_VERSION = 1;
+
+function getSeedStatePath(): string {
+	return path.join(getContentRoot(), SEED_STATE_FILENAME);
+}
+
+async function readSeedManifest(): Promise<{ files: Record<string, string> }> {
+	try {
+		const raw = await fs.readFile(getSeedStatePath(), 'utf-8');
+		const parsed = JSON.parse(raw) as { files?: unknown };
+		if (parsed && typeof parsed === 'object' && parsed.files && typeof parsed.files === 'object') {
+			const files: Record<string, string> = {};
+			for (const [key, value] of Object.entries(parsed.files as Record<string, unknown>)) {
+				if (
+					typeof key === 'string' &&
+					typeof value === 'string' &&
+					/^[0-9a-f]{64}$/.test(value) &&
+					(key.startsWith('problems/') || key.startsWith('courses/')) &&
+					!key.includes('..') &&
+					!key.includes('\\')
+				) {
+					files[key] = value;
+				}
+			}
+			return { files };
+		}
+	} catch {
+		// Missing or corrupt manifest — treated as "no baseline" (see sync below).
+	}
+	return { files: {} };
+}
+
+async function writeSeedManifest(files: Record<string, string>): Promise<void> {
+	await fs.writeFile(
+		getSeedStatePath(),
+		JSON.stringify({ version: SEED_STATE_VERSION, files }, null, 2),
+		'utf-8'
+	);
+}
+
+async function collectFilesRecursive(
+	baseDir: string,
+	prefix: string,
+	out: Map<string, { abs: string; hash: string }>
+): Promise<void> {
+	let entries;
+	try {
+		entries = await fs.readdir(baseDir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		// Skip OS noise.
+		if (entry.name === '.DS_Store') continue;
+		const abs = path.join(baseDir, entry.name);
+		const rel = `${prefix}/${entry.name}`;
+		if (entry.isDirectory()) {
+			await collectFilesRecursive(abs, rel, out);
+		} else if (entry.isFile()) {
+			const hash = await hashFileOrNull(abs);
+			if (hash !== null) out.set(rel, { abs, hash });
+		}
+	}
+}
+
+/** All bundled files under problems/ and courses/, keyed by posix-style rel path. */
+async function collectBundledFiles(): Promise<Map<string, { abs: string; hash: string }>> {
+	const out = new Map<string, { abs: string; hash: string }>();
+	await collectFilesRecursive(getBundledProblemsDir(), 'problems', out);
+	await collectFilesRecursive(getBundledCoursesDir(), 'courses', out);
+	return out;
+}
+
+async function pruneEmptyParents(startPath: string, root: string): Promise<void> {
+	const stop = path.resolve(root);
+	const problemsDir = path.join(stop, 'problems');
+	const coursesDir = path.join(stop, 'courses');
+	let dir = path.dirname(startPath);
+	while (dir.startsWith(stop) && path.resolve(dir) !== stop) {
+		if (path.resolve(dir) === problemsDir || path.resolve(dir) === coursesDir) break;
+		try {
+			const entries = await fs.readdir(dir);
+			if (entries.length > 0) break;
+			await fs.rmdir(dir);
+		} catch {
+			break;
+		}
+		const parent = path.dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+}
+
+/**
+ * Smart sync: seed missing files AND auto-update pristine (unedited) copies
+ * when the bundled content changed, without ever overwriting user edits.
+ *
+ * A `.cojudge-seed.json` manifest in the content root remembers the hash of
+ * every bundled file at the last sync:
+ * - user file missing → copy from bundled (first seed, new problems, re-seed).
+ * - bundled hash unchanged since last sync → keep user file (preserves edits).
+ * - bundled changed + user file still matches the last-seeded hash (pristine)
+ *   → overwrite with the new bundled file (user receives maintainer fixes).
+ * - bundled changed + user file differs from last-seeded (user-edited or
+ *   pre-manifest stale copy) → preserve the user file (never overwrite edits).
+ * - bundled file removed + user copy pristine → remove the user copy.
+ *
+ * Installs that predate the manifest have no baseline: differing files are
+ * preserved (safe — never overwrite a possible user edit) and recorded
+ * against the current bundled hashes. Those show as `modified` until the
+ * user resets them once via Manage Problems; afterwards auto-updates work.
+ */
+async function syncUserContent(): Promise<void> {
+	const root = getContentRoot();
+	await fs.mkdir(path.join(root, 'problems'), { recursive: true });
+	await fs.mkdir(path.join(root, 'courses'), { recursive: true });
+	const prev = await readSeedManifest();
+	const bundled = await collectBundledFiles();
+	const next: Record<string, string> = {};
+	for (const [rel, { abs, hash: bundledHash }] of bundled) {
+		next[rel] = bundledHash;
+		const userPath = path.join(root, ...rel.split('/'));
+		let userExists = false;
+		try {
+			await fs.access(userPath);
+			userExists = true;
+		} catch {
+			userExists = false;
+		}
+		if (!userExists) {
+			await fs.mkdir(path.dirname(userPath), { recursive: true });
+			await fs.copyFile(abs, userPath);
+			continue;
+		}
+		const prevHash = prev.files[rel];
+		// No baseline (pre-manifest install, or a user file colliding with a
+		// newly shipped bundled path): preserve, never overwrite blindly.
+		if (prevHash === undefined) continue;
+		// Bundled copy unchanged since the last sync: keep the user file,
+		// whether pristine or edited.
+		if (prevHash === bundledHash) continue;
+		// Bundled copy changed upstream — update only pristine copies.
+		const userHash = await hashFileOrNull(userPath);
+		if (userHash === null) {
+			await fs.mkdir(path.dirname(userPath), { recursive: true });
+			await fs.copyFile(abs, userPath);
+		} else if (userHash === prevHash) {
+			await fs.copyFile(abs, userPath);
+		}
+		// Else: user-edited (or already matching the new bundled file) — preserve.
+	}
+	for (const rel of Object.keys(prev.files)) {
+		if (bundled.has(rel)) continue;
+		if (!rel.startsWith('problems/') && !rel.startsWith('courses/')) continue;
+		const userPath = path.join(root, ...rel.split('/'));
+		const userHash = await hashFileOrNull(userPath);
+		if (userHash === null) continue;
+		if (userHash === prev.files[rel]) {
+			try {
+				await fs.rm(userPath, { force: true });
+			} catch {
+				// ignore
+			}
+			await pruneEmptyParents(userPath, root);
+		}
+		// Edited copies of upstream-removed files are kept (now custom).
+	}
+	await writeSeedManifest(next);
+	const readmePath = path.join(root, 'README.md');
+	try {
+		await fs.access(readmePath);
+	} catch {
+		await fs.writeFile(readmePath, USER_README, 'utf-8');
+	}
+}
 
 async function copyMissingRecursive(src: string, dest: string): Promise<void> {
 	let entries;
@@ -319,26 +512,34 @@ let ensurePromise: Promise<void> | null = null;
 
 /**
  * Seed ~/cojudge/problems and ~/cojudge/courses from the bundled content.
- * Only copies files that are missing — never overwrites user edits.
+ * Missing files are copied, pristine (unedited) copies are auto-updated to
+ * new bundled versions, and user edits are never overwritten.
  * Safe to call on every startup / request; cheap after the first seed.
  */
 export function ensureUserContentSeeded(): Promise<void> {
 	if (!ensurePromise) {
 		ensurePromise = (async () => {
 			try {
-				const root = getContentRoot();
-				await fs.mkdir(path.join(root, 'problems'), { recursive: true });
-				await fs.mkdir(path.join(root, 'courses'), { recursive: true });
-				await copyMissingRecursive(getBundledProblemsDir(), getProblemsDir());
-				await copyMissingRecursive(getBundledCoursesDir(), getCoursesDir());
-				const readmePath = path.join(root, 'README.md');
-				try {
-					await fs.access(readmePath);
-				} catch {
-					await fs.writeFile(readmePath, USER_README, 'utf-8');
-				}
+				await syncUserContent();
 			} catch {
-				// Seeding must never break serving — readers fall back to bundled content.
+				// Seeding must never break serving — fall back to legacy
+				// copy-missing so new problems still appear, readers fall
+				// back to bundled content.
+				try {
+					const root = getContentRoot();
+					await fs.mkdir(path.join(root, 'problems'), { recursive: true });
+					await fs.mkdir(path.join(root, 'courses'), { recursive: true });
+					await copyMissingRecursive(getBundledProblemsDir(), getProblemsDir());
+					await copyMissingRecursive(getBundledCoursesDir(), getCoursesDir());
+					const readmePath = path.join(root, 'README.md');
+					try {
+						await fs.access(readmePath);
+					} catch {
+						await fs.writeFile(readmePath, USER_README, 'utf-8');
+					}
+				} catch {
+					// ignore — readers fall back to bundled content.
+				}
 			}
 		})().finally(() => {
 			// Allow a retry on the next call if this attempt ran while the
@@ -351,4 +552,84 @@ export function ensureUserContentSeeded(): Promise<void> {
 /** Reset the seeding memo (tests only). */
 export function __resetEnsureMemoForTests(): void {
 	ensurePromise = null;
+}
+
+function assertSafeContentId(id: string): void {
+	if (!isSafeSegment(id)) throw new Error(`Invalid id: ${id}`);
+}
+
+async function refreshManifestPrefix(prefix: string): Promise<void> {
+	const [prev, bundled] = await Promise.all([readSeedManifest(), collectBundledFiles()]);
+	const next = { ...prev.files };
+	for (const key of Object.keys(next)) {
+		if (key === prefix.slice(0, -1) || key.startsWith(prefix)) delete next[key];
+	}
+	for (const [rel, { hash }] of bundled) {
+		if (rel.startsWith(prefix)) next[rel] = hash;
+	}
+	await writeSeedManifest(next);
+}
+
+/**
+ * Reset a problem to its bundled copy, discarding ~/cojudge edits.
+ * Used to recover stale pre-manifest copies and to accept upstream fixes
+ * over local edits. Throws when there is no bundled problem to reset to.
+ */
+export async function resetProblemToBundled(slug: string): Promise<void> {
+	assertSafeContentId(slug);
+	await ensureUserContentSeeded();
+	const bundledDir = path.join(getBundledProblemsDir(), slug);
+	try {
+		const stat = await fs.stat(bundledDir);
+		if (!stat.isDirectory()) throw new Error('not-a-dir');
+	} catch {
+		throw new Error(`No bundled problem '${slug}' to reset to`);
+	}
+	const userDir = path.join(getProblemsDir(), slug);
+	await fs.rm(userDir, { recursive: true, force: true });
+	await fs.cp(bundledDir, userDir, { recursive: true });
+	await refreshManifestPrefix(`problems/${slug}/`);
+}
+
+/** Reset a course to its bundled copy, discarding ~/cojudge edits. */
+export async function resetCourseToBundled(courseId: string): Promise<void> {
+	assertSafeContentId(courseId);
+	await ensureUserContentSeeded();
+	const bundledDir = path.join(getBundledCoursesDir(), courseId);
+	try {
+		const stat = await fs.stat(bundledDir);
+		if (!stat.isDirectory()) throw new Error('not-a-dir');
+	} catch {
+		throw new Error(`No bundled course '${courseId}' to reset to`);
+	}
+	const userDir = path.join(getCoursesDir(), courseId);
+	await fs.rm(userDir, { recursive: true, force: true });
+	await fs.cp(bundledDir, userDir, { recursive: true });
+	await refreshManifestPrefix(`courses/${courseId}/`);
+}
+
+/** Reset every `modified` problem/course to its bundled copy. */
+export async function resetAllModifiedToBundled(): Promise<void> {
+	await ensureUserContentSeeded();
+	const [slugs, ids] = await Promise.all([listProblemSlugs(), listCourseIds()]);
+	const [problemSources, courseSources] = await Promise.all([
+		getProblemSources(slugs),
+		getCourseSources(ids)
+	]);
+	for (const slug of slugs) {
+		if (problemSources[slug] !== 'modified') continue;
+		try {
+			await resetProblemToBundled(slug);
+		} catch {
+			// Custom content has no bundled copy — nothing to reset to.
+		}
+	}
+	for (const id of ids) {
+		if (courseSources[id] !== 'modified') continue;
+		try {
+			await resetCourseToBundled(id);
+		} catch {
+			// ignore
+		}
+	}
 }

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -61,6 +61,15 @@ export const load: PageServerLoad = async ({ url }) => {
         selectedCourseId: selectedCourse?.id ?? null,
         selectedCourseInfo: selectedCourse?.info ?? null,
         problems,
+        // Every modified item (user copy differs from bundled) across all
+        // courses, so Manage Problems can offer a reset-to-bundled recovery.
+        // Needed because `problems` only covers the selected course.
+        modifiedProblems: allProblems
+            .filter((problem) => (problemSources[problem.id] ?? 'bundled') === 'modified')
+            .map((problem) => ({ id: problem.id, title: problem.title })),
+        modifiedCourses: courses
+            .filter((course) => (courseSources[course.id] ?? 'bundled') === 'modified')
+            .map((course) => ({ id: course.id, title: course.info.title })),
         // Absolute path of the user-editable content folder (~/cojudge by
         // default), shown in the "Manage Problems" popup.
         contentDir: getContentRoot()

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -78,6 +78,12 @@
     let revealingFolder = false;
     let pathCopied = false;
     let pathCopiedTimer: ReturnType<typeof setTimeout> | undefined;
+    let resettingContentKey: string | null = null;
+    let resettingAllContent = false;
+    type ModifiedItem = { id: string; title: string };
+    $: modifiedProblems = ((data?.modifiedProblems ?? []) as ModifiedItem[]);
+    $: modifiedCourses = ((data?.modifiedCourses ?? []) as ModifiedItem[]);
+    $: modifiedItemCount = modifiedProblems.length + modifiedCourses.length;
     let importNotice: { message: string; error: boolean; filePath?: string } | null = null;
     let importNoticeTimer: ReturnType<typeof setTimeout> | undefined;
     let showFirebaseSettings = false;
@@ -926,6 +932,52 @@
         }
     }
 
+    async function resetContentToBundled(type: 'problem' | 'course', id: string) {
+        manageProblemsError = '';
+        resettingContentKey = `${type}:${id}`;
+        try {
+            const response = await fetch('/api/content/reset', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ type, id })
+            });
+            const result = await response.json().catch(() => ({}));
+            if (!response.ok) {
+                throw new Error(result?.error || 'Could not reset content');
+            }
+            window.location.reload();
+        } catch (err: any) {
+            manageProblemsError = err?.message
+                ? `Could not reset ${id}: ${err.message}`
+                : `Could not reset ${id}`;
+        } finally {
+            resettingContentKey = null;
+        }
+    }
+
+    async function resetAllModifiedToBundled() {
+        manageProblemsError = '';
+        resettingAllContent = true;
+        try {
+            const response = await fetch('/api/content/reset', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ all: true })
+            });
+            const result = await response.json().catch(() => ({}));
+            if (!response.ok) {
+                throw new Error(result?.error || 'Could not reset content');
+            }
+            window.location.reload();
+        } catch (err: any) {
+            manageProblemsError = err?.message
+                ? `Could not reset all: ${err.message}`
+                : 'Could not reset all';
+        } finally {
+            resettingAllContent = false;
+        }
+    }
+
     async function closeClearProgress() {
         showClearConfirm = false;
         await tick();
@@ -1309,7 +1361,48 @@
                     </div>
                 </div>
 
-                <p class="manage-note">Duplicate a problem folder, edit it, then register the slug in a <code>courseinfo.json</code>. Missing files are re-seeded; your edits are never overwritten.</p>
+                <p class="manage-note">Duplicate a problem folder, edit it, then register the slug in a <code>courseinfo.json</code>. Unedited copies auto-update when Cojudge ships fixes; your edits are never overwritten.</p>
+
+                {#if modifiedItemCount > 0}
+                    <div class="manage-section manage-modified">
+                        <h3>Modified — differs from bundled ({modifiedItemCount})</h3>
+                        <p>If you did not edit these, they are stale copies from an older version — reset them to receive the latest fixes. Resetting discards your edits to that item.</p>
+                        <ul class="manage-modified-list">
+                            {#each modifiedProblems as item}
+                                <li>
+                                    <span class="manage-modified-id" title={item.title}>{item.id}</span>
+                                    <span class="manage-modified-kind">problem</span>
+                                    <button
+                                        class="btn manage-reset-btn"
+                                        type="button"
+                                        disabled={resettingContentKey !== null || resettingAllContent}
+                                        onclick={() => void resetContentToBundled('problem', item.id)}
+                                    >{resettingContentKey === `problem:${item.id}` ? 'Resetting…' : 'Reset'}</button>
+                                </li>
+                            {/each}
+                            {#each modifiedCourses as item}
+                                <li>
+                                    <span class="manage-modified-id" title={item.title}>{item.id}</span>
+                                    <span class="manage-modified-kind">course</span>
+                                    <button
+                                        class="btn manage-reset-btn"
+                                        type="button"
+                                        disabled={resettingContentKey !== null || resettingAllContent}
+                                        onclick={() => void resetContentToBundled('course', item.id)}
+                                    >{resettingContentKey === `course:${item.id}` ? 'Resetting…' : 'Reset'}</button>
+                                </li>
+                            {/each}
+                        </ul>
+                        {#if modifiedItemCount > 1}
+                            <button
+                                class="btn"
+                                type="button"
+                                disabled={resettingContentKey !== null || resettingAllContent}
+                                onclick={() => void resetAllModifiedToBundled()}
+                            >{resettingAllContent ? 'Resetting…' : `Reset all (${modifiedItemCount})`}</button>
+                        {/if}
+                    </div>
+                {/if}
 
                 {#if manageProblemsError}
                     <p class="modal-error" role="alert">{manageProblemsError}</p>
@@ -2130,6 +2223,45 @@
     }
     .manage-section .btn {
         margin-top: 0.55rem;
+    }
+    .manage-modified p {
+        margin-bottom: 0.55rem !important;
+    }
+    .manage-modified-list {
+        list-style: none;
+        display: grid;
+        gap: 0.35rem;
+        max-height: 12rem;
+        overflow-y: auto;
+        margin: 0 0 0.1rem;
+        padding: 0;
+    }
+    .manage-modified-list li {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        min-width: 0;
+    }
+    .manage-modified-id {
+        flex: 1 1 auto;
+        min-width: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        font-size: 0.82rem;
+        color: var(--color-text);
+    }
+    .manage-modified-kind {
+        flex: 0 0 auto;
+        font-size: 0.72rem;
+        color: var(--color-text-secondary);
+    }
+    .manage-modified-list .manage-reset-btn {
+        flex: 0 0 auto;
+        margin-top: 0;
+        padding: 0.3rem 0.7rem;
+        font-size: 0.8rem;
     }
     .manage-note {
         margin: 0 0 0.65rem !important;

--- a/src/routes/api/content/reset/+server.ts
+++ b/src/routes/api/content/reset/+server.ts
@@ -1,0 +1,39 @@
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import {
+	resetAllModifiedToBundled,
+	resetCourseToBundled,
+	resetProblemToBundled
+} from '$lib/server/contentPaths';
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const body = (await request.json().catch(() => null)) as {
+			type?: unknown;
+			id?: unknown;
+			all?: unknown;
+		} | null;
+		if (body?.all === true) {
+			await resetAllModifiedToBundled();
+			return json({ success: true });
+		}
+		if (
+			(body?.type !== 'problem' && body?.type !== 'course') ||
+			typeof body?.id !== 'string' ||
+			!body.id.trim()
+		) {
+			return json(
+				{ error: "Expected { type: 'problem' | 'course', id } or { all: true }" },
+				{ status: 400 }
+			);
+		}
+		const id = body.id.trim();
+		if (body.type === 'problem') await resetProblemToBundled(id);
+		else await resetCourseToBundled(id);
+		return json({ success: true });
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'Failed to reset content';
+		const status = /No bundled/.test(message) ? 404 : 500;
+		return json({ error: message }, { status });
+	}
+};


### PR DESCRIPTION
Seeded ~/cojudge copies used to shadow upstream problem fixes forever and falsely show as Modified in Manage Problems.

## Changes
- Track bundled file hashes in `~/cojudge/.cojudge-seed.json`; pristine (unedited) copies auto-update when a new version ships fixes, user edits are never overwritten, upstream-removed pristine files are cleaned up
- Mirrored in both server (`src/lib/server/contentPaths.ts`) and CLI (`bin/lib/contentPaths.js`)
- Recovery for pre-manifest stale copies: Manage Problems now lists modified problems/courses with per-item Reset + Reset all (`POST /api/content/reset`), and `cojudge sync` CLI shows status with `--reset <id>` / `--reset --all`
- Docs updated (README, ADD_PROBLEMS, folder README, CLI help)

## Verification
- Reproduced the bug (pristine v1 copy blocked v2), confirmed fix end-to-end via server logic and real CLI runs
- 4 new regression tests in `contentPaths.test.ts` (pristine update, edit preserved, safe pre-manifest migration, reset); full suite 132/132 green
- `svelte-check`: no new errors