### PR TITLE
fix(playground): Enter on Mac / F2 rename in explorer, OS-aware whiteboard shortcut

### DIFF
--- a/src/lib/components/Whiteboard.svelte
+++ b/src/lib/components/Whiteboard.svelte
@@ -193,6 +193,7 @@
 	let showGrid = false;
 	let isDark = false;
 	let hasInteracted = false;
+	let isMac = false;
 
 	let drawingStyle: StyleState = {
 		stroke: '#1b1b1f',
@@ -275,6 +276,7 @@
 	}
 
 	onMount(() => {
+		isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
 		const previousOverflow = document.body.style.overflow;
 		const previousOverscrollBehavior = document.documentElement.style.overscrollBehavior;
 		if (!embedded) {
@@ -2312,7 +2314,7 @@
 					</a>
 				{/if}
 				<button class="menu-item" onclick={newBoard}>
-					<WhiteboardIcon name="plus" size={18} /><span>New whiteboard</span><kbd>Ctrl N</kbd>
+					<WhiteboardIcon name="plus" size={18} /><span>New whiteboard</span><kbd>{isMac ? 'Cmd N' : 'Ctrl N'}</kbd>
 				</button>
 				<button class="menu-item" onclick={() => boardInput?.click()}>
 					<WhiteboardIcon name="upload" size={18} /><span>Open</span>

--- a/src/routes/playground/+page.svelte
+++ b/src/routes/playground/+page.svelte
@@ -6766,6 +6766,18 @@ func main() {
                         aria-expanded={t.kind === 'folder' ? isFolderExpanded(t.fileId) : undefined}
                         tabindex="0"
                         on:keydown={(e) => {
+                            if (e.key === 'F2' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                startRename(t.fileId, t.fileName, 'sidebar');
+                                return;
+                            }
+                            if (e.key === 'Enter' && isMac && !e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                startRename(t.fileId, t.fileName, 'sidebar');
+                                return;
+                            }
                             if (e.key === 'Enter' || e.key === ' ') {
                                 e.preventDefault();
                                 handleExplorerItemClick(t);


### PR DESCRIPTION
Playground explorer: focused file/folder now starts rename on Enter (macOS) and F2 (all OS, covers Win/Linux). Plain Enter/Space still opens/toggles otherwise.

Whiteboard main menu: New whiteboard shortcut label is now OS-aware (Cmd N on Mac, Ctrl N elsewhere) instead of always Ctrl N.