### PR TITLE
ci: auto-submit Windows installer to winget on release

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -313,3 +313,18 @@ jobs:
             --generate-notes \
             --notes "$RELEASE_NOTES" \
             "${release_args[@]}"
+
+  winget:
+    needs: publish
+    if: ${{ !contains(inputs.version, '-') }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Cojudge.Cojudge
+          installers-regex: 'x64-setup\.exe$'
+          release-tag: v${{ inputs.version }}
+          fork-user: anslwy
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
Adds a `winget` job to `release-desktop.yml` (via vedantmgoyal9/winget-releaser) that opens a winget-pkgs manifest PR for each stable release's `x64-setup.exe`.

Requires repo secret `WINGET_TOKEN` (classic PAT, `public_repo`) and the existing `anslwy/winget-pkgs` fork. Prereleases are skipped. Takes effect once microsoft/winget-pkgs#433815 (initial Cojudge.Cojudge package) is merged.